### PR TITLE
Migrate from deprecated iconLink() and textLink() methods to builders.

### DIFF
--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -1298,7 +1298,7 @@ public class LincsController extends SpringActionController
             if(pspJob.getPipelineJobId() != null && getUser().isInSiteAdminGroup())
             {
                 ActionURL pipelineJobUrl = PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlDetails(getContainer(), pspJob.getPipelineJobId());
-                view.addView(new HtmlView(PageFlowUtil.textLink("View Pipeline Job. Status: " + PipelineService.get().getStatusFile(pspJob.getPipelineJobId()).getStatus(), pipelineJobUrl)));
+                view.addView(new HtmlView(PageFlowUtil.link("View Pipeline Job. Status: " + PipelineService.get().getStatusFile(pspJob.getPipelineJobId()).getStatus()).href(pipelineJobUrl).toString()));
             }
 
             view.setTitle("PSP Job Details");

--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -68,7 +68,7 @@ public class LincsDataTable extends FilteredTable
 
         var plateCol = wrapColumn(PLATE_COL, getRealTable().getColumn(FieldKey.fromParts("Token")));
         addColumn(plateCol);
-        plateCol.setDisplayColumnFactory(colInfo -> new PlateColumn(colInfo));
+        plateCol.setDisplayColumnFactory(PlateColumn::new);
 
         var level1Col =  wrapColumn("Level 1", getRealTable().getColumn(FieldKey.fromParts("FileName")));
         addColumn(level1Col);
@@ -80,7 +80,7 @@ public class LincsDataTable extends FilteredTable
                 Integer runId = ctx.get(FieldKey.fromParts("Id"), Integer.class);
                 downloadUrl.addParameter("runId", runId);
                 out.write("<nobr>");
-                out.write(PageFlowUtil.iconLink("fa fa-download", "Download", downloadUrl.getEncodedLocalURIString(), null, null, null));
+                out.write(PageFlowUtil.iconLink("fa fa-download", "Download").href(downloadUrl).toString());
                 ActionURL docDetailsUrl = new ActionURL("targetedms", "ShowPrecursorList", getContainer());
                 docDetailsUrl.addParameter("id", runId);
                 out.write("&nbsp;<a href=\"" + docDetailsUrl.getEncodedLocalURIString() + "\">Skyline</a>");
@@ -186,7 +186,7 @@ public class LincsDataTable extends FilteredTable
                     }
                     ActionURL url = new ActionURL(LincsController.LincsPspJobDetailsAction.class, getContainer());
                     url.addParameter("runId", pspJob.getRunId());
-                    out.write(PageFlowUtil.textLink(text, url));
+                    out.write(PageFlowUtil.link(text).href(url).toString());
                 }
 
                 @Override
@@ -354,7 +354,7 @@ public class LincsDataTable extends FilteredTable
         {
             out.write("<nobr>&nbsp;");
             // Do not HTML encode links given to PageFlowUtil.iconLink
-            out.write(PageFlowUtil.iconLink("fa fa-download", "Download", downloadUrl, analyticsScript, null, null));
+            out.write(PageFlowUtil.iconLink("fa fa-download", "Download").href(downloadUrl).onClick(analyticsScript).toString());
             out.write("&nbsp;");
             String onclickEvt = StringUtils.isBlank(analyticsScript) ? "" : "onclick=\"" + analyticsScript + "\"";
             out.write("<a " + onclickEvt + " href=\"" + downloadUrlEncoded + "\">" + downloadText + "</a>&nbsp;");

--- a/lincs/src/org/labkey/lincs/view/customGCTForm.jsp
+++ b/lincs/src/org/labkey/lincs/view/customGCTForm.jsp
@@ -1,19 +1,19 @@
 <%
-    /*
-     * Copyright (c) 2015-2016 LabKey Corporation
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+/*
+ * Copyright (c) 2015-2016 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
@@ -255,7 +255,7 @@
     }
 </script>
 
-<labkey:form action="<%=h(buildURL(LincsController.CreateCustomGCTAction.class))%>" method="post" id="customGCTForm">
+<labkey:form action="<%=buildURL(LincsController.CreateCustomGCTAction.class)%>" method="post" id="customGCTForm">
 
     <input type="hidden" name="selectedAnnotations"/>
 


### PR DESCRIPTION
Remove encoding from labkey:form tag action parameters.