### PR TITLE
Fix Skyline document download links in LINCS and Passport modules.

### DIFF
--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -78,12 +78,12 @@ public class LincsDataTable extends FilteredTable
             {
                 ActionURL downloadUrl = new ActionURL("targetedms", "DownloadDocument", getContainer());
                 Integer runId = ctx.get(FieldKey.fromParts("Id"), Integer.class);
-                downloadUrl.addParameter("runId", runId);
+                downloadUrl.addParameter("id", runId);
                 out.write("<nobr>");
-                out.write(PageFlowUtil.iconLink("fa fa-download", "Download", downloadUrl.getEncodedLocalURIString(), null, null, null));
+                out.write(new Link.LinkBuilder("Download").iconCls("fa fa-download").href(downloadUrl).toString());
                 ActionURL docDetailsUrl = new ActionURL("targetedms", "ShowPrecursorList", getContainer());
                 docDetailsUrl.addParameter("id", runId);
-                out.write("&nbsp;<a href=\"" + docDetailsUrl.getEncodedLocalURIString() + "\">Skyline</a>");
+                out.write("&nbsp;" + new Link.LinkBuilder("Skyline").href(docDetailsUrl).clearClasses().toString());
                 out.write("</nobr>");
             }
 

--- a/passport/src/org/labkey/passport/view/ProteinListView.java
+++ b/passport/src/org/labkey/passport/view/ProteinListView.java
@@ -59,7 +59,7 @@ public class ProteinListView extends QueryView
         ret.getDataRegion().addDisplayColumn(0, urlColumn);
 
         ActionURL urlDownload = new ActionURL("targetedms", "downloadDocument", getContainer());
-        urlDownload.addParameter("runId", "${runid}");
+        urlDownload.addParameter("id", "${runid}");
         SimpleDisplayColumn urlColumnDownload = new UrlColumn(urlDownload.toString(), "Download");
         urlColumnDownload.setName("Skyline"); // TODO check if works
         ret.getDataRegion().addDisplayColumn(10, urlColumnDownload);

--- a/passport/src/org/labkey/passport/view/ProteinWebPart.jsp
+++ b/passport/src/org/labkey/passport/view/ProteinWebPart.jsp
@@ -49,7 +49,7 @@
 <div id="passportContainer">
     <div id="basicproteininfo">
         <h2 id="proteinName"><%=h(protein.getName())%>
-            <a href="<%=h(new ActionURL("targetedms", "downloadDocument", getContainer()))%>runId=<%=h(protein.getFile().getRunId())%>">
+            <a href="<%=h(new ActionURL("targetedms", "downloadDocument", getContainer()))%>id=<%=h(protein.getFile().getRunId())%>">
                 <img src="<%=h(contextPath)%>/passport/img/download.png" style="width:30x; height:30px; margin-left:5px;" alt="Download Skyline dataset" title="Download Skyline dataset from PanoramaWeb.org">
             </a><sub title="month/day/year" id="dataUploaded">Data Uploaded: <%=h(new SimpleDateFormat("MM-dd-yyyy").format(protein.getFile().getCreatedDate()))%></sub>
         </h2>


### PR DESCRIPTION
This broke with commit 7dc7aeb1c37c47571a13135ee89e165729521e70.  The URL parameter name changed from "runId" to "id". 