### PR TITLE
PanoramaPublic: Export source container to tomcat's temp directory in…

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -199,21 +199,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
                 // DataFileUrl in exp.data and FilePathRoot in exp.experimentRun point to locations in the 'export' directory.
                 // We are now copying all files from the source container to the target container file root. Update the paths
                 // to point to locations in the target container file root, and delete the 'export' directory
-                if(updateDataPaths(target, service, user, job.getLogger()))
-                {
-                    // Delete the 'export' directory
-                    // 'export' directory is written to a local temp location if the target container is cloud-based,
-                    // and gets deleted after the pipeline job finishes successfully.
-                    if(!service.isCloudRoot(target))
-                    {
-                        File exportdir = jobSupport.getExportDir();
-                        if (exportdir.exists() && !FileUtil.deleteDir(exportdir))
-                        {
-                            job.getLogger().warn("Failed to delete export directory: " + exportdir);
-                        }
-                    }
-                }
-                else
+                if(!updateDataPaths(target, service, user, job.getLogger()))
                 {
                     throw new PipelineJobException("Unable to update all data file paths.");
                 }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -71,8 +71,10 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
         if (null == targetRoot)
             throw new NotFoundException("Cannot find target pipeline root.");
 
-        LocalDirectory localDirectory = LocalDirectory.create(targetRoot, PanoramaPublicModule.NAME, baseLogFileName,
-                !targetRoot.isCloudRoot() ? targetRoot.getRootPath().getAbsolutePath() : FileUtil.getTempDirectory().getPath());
+        // CONSIDER: Add a static factory method to LocalDirectory instead of using the constructor.
+        //           create(@NotNull PipeRoot root, @NotNull String moduleName, @NotNull String baseLogFileName, @NotNull String localDirPath, boolean temporary)
+        LocalDirectory localDirectory = new LocalDirectory(targetRoot.getContainer(), PanoramaPublicModule.NAME, root, baseLogFileName);
+
         setLocalDirectory(localDirectory);
         setLogFile(localDirectory.determineLogFile());
 


### PR DESCRIPTION
…stead of the target container so that rows are not created in exp.data for the contents of the "export" directory. This is related to "Issue 39685: FileImporter does not create rows in exp.data".