### PR TITLE
Change optionalModules to modules as checkout location

### DIFF
--- a/testresults/distributions_disabled/skyline/build.gradle
+++ b/testresults/distributions_disabled/skyline/build.gradle
@@ -7,9 +7,9 @@ apply plugin: 'org.labkey.distribution'
 
 Distribution.inheritDependencies(project, ":server:distributions:legacy")
 
-BuildUtils.addModuleDistributionDependencies(project, [":externalModules:maccoss:signup",
-                                                       ":externalModules:maccoss:SkylineToolsStore",
-                                                       ":externalModules:maccoss:testresults"])
+BuildUtils.addModuleDistributionDependencies(project, [":server:modules:maccoss:signup",
+                                                       ":server:modules:maccoss:SkylineToolsStore",
+                                                       ":server:modules:maccoss:testresults"])
 
 project.task(
         "distribution",


### PR DESCRIPTION
#### Rationale
Consolidate to server/modules as the preferred location for building module code 

#### Related Pull Requests
https://github.com/LabKey/trialServices/pull/17
https://github.com/LabKey/tnprc_billing/pull/55
https://github.com/LabKey/tnprc_ehr/pull/236
https://github.com/LabKey/premium/pull/187
https://github.com/LabKey/medImmuneFlow/pull/16
https://github.com/LabKey/MaxQuant/pull/24
https://github.com/LabKey/provenance/pull/21
https://github.com/LabKey/cds/pull/269
https://github.com/LabKey/evaluationContent/pull/29
https://github.com/LabKey/PanoramaPremiumModules/pull/29
https://github.com/LabKey/redcap/pull/24
https://github.com/LabKey/scrumtime/pull/57
https://github.com/LabKey/medImmune/pull/66
https://github.com/LabKey/gel/pull/195
https://github.com/LabKey/mobileAppStudy/pull/101
https://github.com/LabKey/harvest/pull/95
https://github.com/LabKey/nlp/pull/160
https://github.com/LabKey/sampleManagement/pull/264
https://github.com/LabKey/complianceActivities/pull/10
https://github.com/LabKey/nci/pull/62
https://github.com/LabKey/platform/pull/1155
https://github.com/LabKey/accounts/pull/110
https://github.com/LabKey/biologics/pull/584
TBD

#### Changes
Update README, build.gradle