### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -154,6 +154,7 @@ public class SkylineToolsStoreController extends SpringActionController
             return new SkylineToolsStoreWebPart();
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
             root.addChild(getToolStoreNav(getContainer()));
@@ -326,6 +327,7 @@ public class SkylineToolsStoreController extends SpringActionController
 
         Collections.sort(toolList, new Comparator<SkylineTool>()
         {
+            @Override
             public int compare(SkylineTool lhs, SkylineTool rhs)
             {
                 return rhs.getCreated().compareTo(lhs.getCreated());
@@ -437,6 +439,7 @@ public class SkylineToolsStoreController extends SpringActionController
         {
         }
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             final String sender = httpServletRequest.getParameter("sender");
@@ -612,6 +615,7 @@ public class SkylineToolsStoreController extends SpringActionController
             return new JspView("/org/labkey/skylinetoolsstore/view/SkylineToolsStoreUpload.jsp", null);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
             root.addChild(getToolStoreNav(getContainer())).addChild("Upload Tool", getURL());
@@ -766,6 +770,7 @@ public class SkylineToolsStoreController extends SpringActionController
         {
         }
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             int id = NumberUtils.toInt(httpServletRequest.getParameter("id"), -1);
@@ -803,6 +808,7 @@ public class SkylineToolsStoreController extends SpringActionController
         {
         }
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             final String suppTargetString = httpServletRequest.getParameter("supptarget");
@@ -864,6 +870,7 @@ public class SkylineToolsStoreController extends SpringActionController
         {
         }
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             final String sender = httpServletRequest.getParameter("sender");
@@ -997,6 +1004,7 @@ public class SkylineToolsStoreController extends SpringActionController
     {
         private final Class REQ_PERMS = DeletePermission.class;
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             Integer id;
@@ -1062,6 +1070,7 @@ public class SkylineToolsStoreController extends SpringActionController
     {
         public static final String DOWNLOADED_COOKIE_PREFIX = "downloadtool";
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             final int id = NumberUtils.toInt(httpServletRequest.getParameter("id"), -1);
@@ -1135,6 +1144,7 @@ public class SkylineToolsStoreController extends SpringActionController
     @ActionNames("downloadFile")
     public class DownloadToolFileAction extends SimpleViewAction<DownloadFileForm> implements PermissionCheckable
     {
+        @Override
         public ModelAndView getView(DownloadFileForm form, BindException errors) throws Exception
         {
             if (StringUtils.trimToNull(form.getTool()) == null)
@@ -1170,6 +1180,7 @@ public class SkylineToolsStoreController extends SpringActionController
             return new SimpleErrorView(errors);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }
@@ -1262,6 +1273,7 @@ public class SkylineToolsStoreController extends SpringActionController
             return new SkylineToolDetails(_tool);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }
@@ -1313,6 +1325,7 @@ public class SkylineToolsStoreController extends SpringActionController
         {
         }
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             final String sender = httpServletRequest.getParameter("sender");
@@ -1384,6 +1397,7 @@ public class SkylineToolsStoreController extends SpringActionController
     {
         private final Class REQ_PERMS = InsertPermission.class;
 
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
             final Integer id = Integer.parseInt(httpServletRequest.getParameter("id"));
@@ -1492,6 +1506,7 @@ public class SkylineToolsStoreController extends SpringActionController
     @RequiresNoPermission
     public class GetToolsApiAction extends AbstractController implements PermissionCheckable
     {
+        @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException
         {
             StringBuilder sb = new StringBuilder();

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -154,9 +154,9 @@ public class SkylineToolsStoreController extends SpringActionController
             return new SkylineToolsStoreWebPart();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild(getToolStoreNav(getContainer()));
+            root.addChild(getToolStoreNav(getContainer()));
         }
     }
 
@@ -612,10 +612,9 @@ public class SkylineToolsStoreController extends SpringActionController
             return new JspView("/org/labkey/skylinetoolsstore/view/SkylineToolsStoreUpload.jsp", null);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild(getToolStoreNav(getContainer())).addChild("Upload Tool", getURL());
-            return root;
         }
 
         public ActionURL getURL()
@@ -1171,9 +1170,8 @@ public class SkylineToolsStoreController extends SpringActionController
             return new SimpleErrorView(errors);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
     public static class DownloadFileForm
@@ -1264,9 +1262,8 @@ public class SkylineToolsStoreController extends SpringActionController
             return new SkylineToolDetails(_tool);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreModule.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreModule.java
@@ -71,6 +71,7 @@ public class SkylineToolsStoreModule extends DefaultModule
                         {
                             addLegacyNames("Skyline Tools Store");
                         }
+                        @Override
                         public WebPartView getWebPartView(ViewContext portalCtx, Portal.WebPart webPart) throws WebPartConfigurationException
                         {
                             return new SkylineToolsStoreWebPart();

--- a/lincs/src/org/labkey/lincs/Gct.java
+++ b/lincs/src/org/labkey/lincs/Gct.java
@@ -424,6 +424,7 @@ public class Gct
     public static class ProbePlateKeyBuilder implements GctKeyBuilder<ProbeExpTypePlate>
     {
         // @Override
+        @Override
         public ProbeExpTypePlate build(String probe, String expTypeAndPlate)
         {
             return new ProbeExpTypePlate(probe, expTypeAndPlate);

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -185,6 +185,7 @@ public class LincsController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class RunGCTReportApiAction extends ReadOnlyApiAction<GCTReportForm>
     {
+        @Override
         public ApiResponse execute(GCTReportForm form, BindException errors) throws Exception
         {
             if(form.getRunId() == 0)
@@ -702,6 +703,7 @@ public class LincsController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class DownloadCustomGCTReportAction extends SimpleViewAction<DownloadCustomGCTReportForm>
     {
+        @Override
         public ModelAndView getView(DownloadCustomGCTReportForm form, BindException errors) throws Exception
         {
             if(form.getFileName() == null)
@@ -729,6 +731,7 @@ public class LincsController extends SpringActionController
             return null;
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }
@@ -1030,6 +1033,7 @@ public class LincsController extends SpringActionController
             return new JspView<>("/org/labkey/lincs/view/manageClueCredentials.jsp", form, errors);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }
@@ -1064,6 +1068,7 @@ public class LincsController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public class LincsPspJobDetailsAction extends SimpleViewAction<LincsPspJobForm>
     {
+        @Override
         public ModelAndView getView(LincsPspJobForm form, BindException errors)
         {
             int runId = form.getRunId();
@@ -1206,6 +1211,7 @@ public class LincsController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public class LincsPspJobStatusAction extends SimpleViewAction<LincsPspJobForm>
     {
+        @Override
         public ModelAndView getView(LincsPspJobForm form, BindException errors)
         {
             int jobId = form.getJobId();

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -128,9 +128,8 @@ public class LincsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -312,11 +311,6 @@ public class LincsController extends SpringActionController
             }
 
             return null;
-        }
-
-        public NavTree appendNavTrail(NavTree root)
-        {
-            return root;
         }
     }
 
@@ -552,9 +546,8 @@ public class LincsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -736,9 +729,8 @@ public class LincsController extends SpringActionController
             return null;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -1038,9 +1030,8 @@ public class LincsController extends SpringActionController
             return new JspView<>("/org/labkey/lincs/view/manageClueCredentials.jsp", form, errors);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -1142,13 +1133,12 @@ public class LincsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            if(root != null)
+            if (root != null)
             {
                 root.addChild("PSP Job Details");
             }
-            return root;
         }
     }
 
@@ -1274,13 +1264,12 @@ public class LincsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            if(root != null)
+            if (root != null)
             {
                 root.addChild("PSP Job Status");
             }
-            return root;
         }
     }
 

--- a/lincs/src/org/labkey/lincs/LincsSchema.java
+++ b/lincs/src/org/labkey/lincs/LincsSchema.java
@@ -67,6 +67,7 @@ public class LincsSchema extends UserSchema
     {
         DefaultSchema.registerProvider(SCHEMA_NAME, new DefaultSchema.SchemaProvider(module)
         {
+            @Override
             public QuerySchema createSchema(DefaultSchema schema, Module module)
             {
                 return new LincsSchema(schema.getUser(), schema.getContainer());

--- a/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
@@ -78,6 +78,7 @@ public class LincsPspPipelineJob extends PipelineJob implements LincsPspJobSuppo
         return _run;
     }
 
+    @Override
     public LincsPspJob getPspJob()
     {
         return _pspJob;

--- a/lincs/src/org/labkey/lincs/psp/LincsPspTask.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspTask.java
@@ -158,26 +158,31 @@ public class LincsPspTask extends PipelineJob.Task<LincsPspTask.Factory>
             super(LincsPspTask.class);
         }
 
+        @Override
         public PipelineJob.Task createTask(PipelineJob job)
         {
             return new LincsPspTask(this, job);
         }
 
+        @Override
         public List<FileType> getInputTypes()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public List<String> getProtocolActionNames()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public String getStatusName()
         {
             return "SUBMIT PSP JOB";
         }
 
+        @Override
         public boolean isJobComplete(PipelineJob job)
         {
             return false;

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -699,6 +699,7 @@ public class PanoramaPublicController extends SpringActionController
             return _destParentContainerId != null ? ContainerManager.getForRowId(_destParentContainerId) : null;
         }
 
+        @Override
         public ActionURL getReturnActionURL()
         {
             ActionURL result;
@@ -879,6 +880,7 @@ public class PanoramaPublicController extends SpringActionController
             }
         }
 
+        @Override
         public ModelAndView getConfirmView(PublishExperimentForm form, BindException errors)
         {
             if(form.isGetPxid() && (!SubmissionDataValidator.isValid(_experimentAnnotations, form.isSkipMetaDataCheck(), form.isSkipRawDataCheck(), form.isSkipModCheck())))
@@ -902,6 +904,7 @@ public class PanoramaPublicController extends SpringActionController
             }
         }
 
+        @Override
         public ModelAndView getSuccessView(PublishExperimentForm form)
         {
             setTitle("Submitted");
@@ -926,6 +929,7 @@ public class PanoramaPublicController extends SpringActionController
             return view;
         }
 
+        @Override
         public ModelAndView getFailView(PublishExperimentForm form, BindException errors)
         {
             return getPublishFormView(form, _experimentAnnotations, errors);
@@ -1283,6 +1287,7 @@ public class PanoramaPublicController extends SpringActionController
     {
         private JournalExperiment _journalExperiment;
 
+        @Override
         public void validateForm(PublishExperimentForm form, Errors errors)
         {
             _journalExperiment = JournalManager.getJournalExperiment(_experimentAnnotations.getId(), form.getJournalId());
@@ -1305,6 +1310,7 @@ public class PanoramaPublicController extends SpringActionController
             super.validateForm(form, errors);
         }
 
+        @Override
         protected void validateJournal(Errors errors, ExperimentAnnotations experiment, Journal journal)
         {
             Journal oldJournal = JournalManager.getJournal(_journalExperiment.getJournalId());
@@ -1314,6 +1320,7 @@ public class PanoramaPublicController extends SpringActionController
             }
         }
 
+        @Override
         protected void validateShortAccessUrl(PublishExperimentForm form, Errors errors)
         {
             ShortURLRecord accessUrlRecord = _journalExperiment.getShortAccessUrl();
@@ -1323,6 +1330,7 @@ public class PanoramaPublicController extends SpringActionController
             }
         }
 
+        @Override
         public ModelAndView getConfirmView(PublishExperimentForm form, BindException errors)
         {
             setTitle("Confirm Submission Update");
@@ -2519,11 +2527,13 @@ public class PanoramaPublicController extends SpringActionController
             _addSelectedRuns = addSelectedRuns;
         }
 
+        @Override
         public String getDataRegionSelectionKey()
         {
             return _dataRegionSelectionKey;
         }
 
+        @Override
         public void setDataRegionSelectionKey(String dataRegionSelectionKey)
         {
             _dataRegionSelectionKey = dataRegionSelectionKey;
@@ -2706,6 +2716,7 @@ public class PanoramaPublicController extends SpringActionController
     @RequiresPermission(UpdatePermission.class)
     public class ShowUpdateExperimentAnnotationsAction extends SimpleViewAction<ExperimentAnnotationsForm>
     {
+        @Override
         public ModelAndView getView(ExperimentAnnotationsForm form, BindException errors)
         {
             form.refreshFromDb();
@@ -2744,6 +2755,7 @@ public class PanoramaPublicController extends SpringActionController
     public class UpdateExperimentAnnotationsAction extends FormViewAction<ExperimentAnnotationsForm>
     {
         private int _experimentAnnotationsId;
+        @Override
         public void validateCommand(ExperimentAnnotationsForm target, Errors errors)
         {}
 
@@ -2755,6 +2767,7 @@ public class PanoramaPublicController extends SpringActionController
             return view;
         }
 
+        @Override
         public boolean handlePost(ExperimentAnnotationsForm form, BindException errors) throws Exception
         {
             _experimentAnnotationsId = form.getBean().getId();
@@ -2781,6 +2794,7 @@ public class PanoramaPublicController extends SpringActionController
             return true;
         }
 
+        @Override
         public ActionURL getSuccessURL(ExperimentAnnotationsForm form)
         {
             return getViewExperimentDetailsURL(_experimentAnnotationsId, getContainer());
@@ -2853,16 +2867,19 @@ public class PanoramaPublicController extends SpringActionController
     {
         private String _dataRegionSelectionKey;
 
+        @Override
         public int[] getIds()
         {
             return PageFlowUtil.toInts(DataRegionSelection.getSelected(getViewContext(), getDataRegionSelectionKey(), false));
         }
 
+        @Override
         public String getDataRegionSelectionKey()
         {
             return _dataRegionSelectionKey;
         }
 
+        @Override
         public void setDataRegionSelectionKey(String dataRegionSelectionKey)
         {
             _dataRegionSelectionKey = dataRegionSelectionKey;
@@ -2876,6 +2893,7 @@ public class PanoramaPublicController extends SpringActionController
 
     public static class DeleteExperimentAnnotationsForm extends ExperimentAnnotationsForm implements SelectedExperimentIds
     {
+        @Override
         public int[] getIds()
         {
             return new int[]{this.getBean().getId()};
@@ -2892,6 +2910,7 @@ public class PanoramaPublicController extends SpringActionController
             return FormPage.getView("/org/labkey/panoramapublic/view/expannotations/deleteExperimentAnnotations.jsp", deleteForm);
         }
 
+        @Override
         public boolean handlePost(DeleteExperimentAnnotationsForm form, BindException errors)
         {
             int _experimentAnnotationsId = form.getBean().getId();
@@ -2925,10 +2944,12 @@ public class PanoramaPublicController extends SpringActionController
     {
         private ExperimentAnnotations _expAnnot;
 
+        @Override
         public void validateCommand(ExperimentForm form, Errors errors)
         {
         }
 
+        @Override
         public boolean handlePost(ExperimentForm form, BindException errors)
         {
             _expAnnot = form.lookupExperiment();
@@ -2963,6 +2984,7 @@ public class PanoramaPublicController extends SpringActionController
             return true;
         }
 
+        @Override
         public ActionURL getSuccessURL(ExperimentForm form)
         {
             return getViewExperimentDetailsURL(_expAnnot.getId(), getContainer());
@@ -2974,10 +2996,12 @@ public class PanoramaPublicController extends SpringActionController
     {
         private ExperimentAnnotations _expAnnot;
 
+        @Override
         public void validateCommand(ExperimentForm form, Errors errors)
         {
         }
 
+        @Override
         public boolean handlePost(ExperimentForm form, BindException errors)
         {
             _expAnnot = form.lookupExperiment();
@@ -3007,6 +3031,7 @@ public class PanoramaPublicController extends SpringActionController
             return true;
         }
 
+        @Override
         public ActionURL getSuccessURL(ExperimentForm form)
         {
             return getViewExperimentDetailsURL(_expAnnot.getId(), getContainer());

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -212,10 +212,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             root.addChild("Journal Groups");
-            return root;
         }
     }
 
@@ -351,14 +350,13 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if(root != null)
             {
                 root.addChild("Journal groups", new ActionURL(JournalGroupsAdminViewAction.class, getContainer()));
                 root.addChild("Create New Journal Group");
             }
-            return root;
         }
     }
 
@@ -504,14 +502,13 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             if(root != null)
             {
                 root.addChild("Journal groups", new ActionURL(JournalGroupsAdminViewAction.class, getContainer()));
                 root.addChild("Journal group details");
             }
-            return root;
         }
     }
 
@@ -650,9 +647,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Copy Experiment");
+            root.addChild("Copy Experiment");
         }
     }
 
@@ -743,9 +740,9 @@ public class PanoramaPublicController extends SpringActionController
     public static class ViewPublishExperimentFormAction extends SimpleViewAction<PublishExperimentForm>
     {
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Experiment Submission Form");
+            root.addChild("Experiment Submission Form");
         }
 
         @Override
@@ -1776,9 +1773,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Pre-submission Check");
+            root.addChild("Pre-submission Check");
         }
     }
 
@@ -1875,9 +1872,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("ProteomeXchange Actions");
+            root.addChild("ProteomeXchange Actions");
         }
     }
 
@@ -2160,9 +2157,9 @@ public class PanoramaPublicController extends SpringActionController
             return new HtmlView(html.toString());
         }
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Validate ProteomeXchange XML");
+            root.addChild("Validate ProteomeXchange XML");
         }
     }
 
@@ -2188,9 +2185,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Submit ProteomeXchange XML");
+            root.addChild("Submit ProteomeXchange XML");
         }
     }
 
@@ -2264,9 +2261,9 @@ public class PanoramaPublicController extends SpringActionController
             return new HtmlView(html.toString());
         }
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Save ProteomeXchange ID");
+            root.addChild("Save ProteomeXchange ID");
         }
     }
 
@@ -2313,9 +2310,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Summary of ProteomeXchange Information");
+            root.addChild("Summary of ProteomeXchange Information");
         }
     }
 
@@ -2345,9 +2342,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Create Targeted MS Experiment");
+            root.addChild("Create Targeted MS Experiment");
         }
     }
 
@@ -2484,9 +2481,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Create Targeted MS Experiment");
+            root.addChild("Create Targeted MS Experiment");
         }
     }
 
@@ -2611,11 +2608,10 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Targeted MS Experiment Details");
+            root.addChild("Targeted MS Experiment Details");
         }
-
     }
 
     public static class ExperimentAnnotationsDetails
@@ -2728,9 +2724,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Update Targeted MS Experiment Details");
+            root.addChild("Update Targeted MS Experiment Details");
         }
     }
 
@@ -2791,9 +2787,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Update Targeted MS Experiment");
+            root.addChild("Update Targeted MS Experiment");
         }
     }
 
@@ -3095,9 +3091,9 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Add Panorama Public Module");
+            root.addChild("Add Panorama Public Module");
         }
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -128,6 +128,7 @@ public class PanoramaPublicModule extends SpringModule
 
         BaseWebPartFactory containerExperimentFactory = new BaseWebPartFactory(TargetedMSExperimentWebPart.WEB_PART_NAME)
         {
+            @Override
             public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
             {
                 return new TargetedMSExperimentWebPart(portalCtx);
@@ -136,6 +137,7 @@ public class PanoramaPublicModule extends SpringModule
 
         BaseWebPartFactory proteinSearchFactory = new BaseWebPartFactory("Panorama Public Protein Search")
         {
+            @Override
             public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
             {
                 JspView view = new JspView("/org/labkey/panoramapublic/view/search/panoramaPublicProteinSearch.jsp", getDefaultProteinSearchForm());
@@ -151,6 +153,7 @@ public class PanoramaPublicModule extends SpringModule
 
         BaseWebPartFactory peptideSearchFactory = new BaseWebPartFactory("Panorama Public Peptide Search")
         {
+            @Override
             public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
             {
                 JspView view = new JspView("/org/labkey/panoramapublic/view/search/panoramaPublicPeptideSearch.jsp", getDefaultPeptideSearchForm());

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -54,6 +54,7 @@ public class PanoramaPublicSchema extends UserSchema
     {
         DefaultSchema.registerProvider(SCHEMA_NAME, new DefaultSchema.SchemaProvider(module)
         {
+            @Override
             public QuerySchema createSchema(DefaultSchema schema, Module module)
             {
                 return new PanoramaPublicSchema(schema.getUser(), schema.getContainer());

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -78,6 +78,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         super(factory, job);
     }
 
+    @Override
     @NotNull
     public RecordedActionSet run() throws PipelineJobException
     {
@@ -405,26 +406,31 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             super(CopyExperimentFinalTask.class);
         }
 
+        @Override
         public PipelineJob.Task createTask(PipelineJob job)
         {
             return new CopyExperimentFinalTask(this, job);
         }
 
+        @Override
         public List<FileType> getInputTypes()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public List<String> getProtocolActionNames()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public String getStatusName()
         {
             return "FINISH EXPERIMENT COPY";
         }
 
+        @Override
         public boolean isJobComplete(PipelineJob job)
         {
             return false;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -82,6 +82,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
                 + experiment.getContainer().getPath() + " to " + getContainer().getPath());
     }
 
+    @Override
     public ActionURL getStatusHref()
     {
         if (getContainer() != null)
@@ -91,6 +92,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
         return null;
     }
 
+    @Override
     public String getDescription()
     {
         return _description;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
@@ -51,6 +51,7 @@ public class ExperimentExportTask extends PipelineJob.Task<ExperimentExportTask.
         super(factory, job);
     }
 
+    @Override
     @NotNull
     public RecordedActionSet run() throws PipelineJobException
     {
@@ -132,26 +133,31 @@ public class ExperimentExportTask extends PipelineJob.Task<ExperimentExportTask.
             super(ExperimentExportTask.class);
         }
 
+        @Override
         public PipelineJob.Task createTask(PipelineJob job)
         {
             return new ExperimentExportTask(this, job);
         }
 
+        @Override
         public List<FileType> getInputTypes()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public List<String> getProtocolActionNames()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public String getStatusName()
         {
             return "EXPORT EXPERIMENT";
         }
 
+        @Override
         public boolean isJobComplete(PipelineJob job)
         {
             return false;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentImportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentImportTask.java
@@ -46,6 +46,7 @@ public class ExperimentImportTask extends PipelineJob.Task<ExperimentImportTask.
         super(factory, job);
     }
 
+    @Override
     @NotNull
     public RecordedActionSet run() throws PipelineJobException
     {
@@ -104,26 +105,31 @@ public class ExperimentImportTask extends PipelineJob.Task<ExperimentImportTask.
             super(ExperimentImportTask.class);
         }
 
+        @Override
         public PipelineJob.Task createTask(PipelineJob job)
         {
             return new ExperimentImportTask(this, job);
         }
 
+        @Override
         public List<FileType> getInputTypes()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public List<String> getProtocolActionNames()
         {
             return Collections.emptyList();
         }
 
+        @Override
         public String getStatusName()
         {
             return "IMPORT EXPERIMENT";
         }
 
+        @Override
         public boolean isJobComplete(PipelineJob job)
         {
             return false;

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
@@ -544,6 +544,7 @@ public class ExperimentModificationGetter
             _id = id;
         }
 
+        @Override
         public String getName()
         {
             return _name;
@@ -554,6 +555,7 @@ public class ExperimentModificationGetter
             _name = name;
         }
 
+        @Override
         public String getAminoAcid()
         {
             return _aminoAcid;
@@ -564,6 +566,7 @@ public class ExperimentModificationGetter
             _aminoAcid = aminoAcid;
         }
 
+        @Override
         public String getTerminus()
         {
             return _terminus;
@@ -574,6 +577,7 @@ public class ExperimentModificationGetter
             _terminus = terminus;
         }
 
+        @Override
         public String getFormula()
         {
             return _formula;
@@ -584,6 +588,7 @@ public class ExperimentModificationGetter
             _formula = formula;
         }
 
+        @Override
         public Double getMassDiffMono()
         {
             return _massDiffMono;
@@ -594,6 +599,7 @@ public class ExperimentModificationGetter
             _massDiffMono = massDiffMono;
         }
 
+        @Override
         public Double getMassDiffAvg()
         {
             return _massDiffAvg;
@@ -604,6 +610,7 @@ public class ExperimentModificationGetter
             _massDiffAvg = massDiffAvg;
         }
 
+        @Override
         public Integer getUnimodId()
         {
             return _unimodId;
@@ -622,6 +629,7 @@ public class ExperimentModificationGetter
         private Boolean _label18O;
         private Boolean _label2H;
 
+        @Override
         public Boolean getLabel13C()
         {
             return _label13C;
@@ -632,6 +640,7 @@ public class ExperimentModificationGetter
             _label13C = label13C;
         }
 
+        @Override
         public Boolean getLabel15N()
         {
             return _label15N;
@@ -642,6 +651,7 @@ public class ExperimentModificationGetter
             _label15N = label15N;
         }
 
+        @Override
         public Boolean getLabel18O()
         {
             return _label18O;
@@ -652,6 +662,7 @@ public class ExperimentModificationGetter
             _label18O = label18O;
         }
 
+        @Override
         public Boolean getLabel2H()
         {
             return _label2H;

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
@@ -40,6 +40,7 @@ public class PxHtmlWriter extends PxWriter
         _output = out;
     }
 
+    @Override
     public void write(PanoramaPublicController.PxExperimentAnnotations bean) throws PxException
     {
         _usePxTestDb = bean.getForm().isTestDatabase();

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
@@ -76,6 +76,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void begin(ExperimentAnnotations experimentAnnotations) throws PxException
     {
         try
@@ -96,6 +97,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void end() throws PxException
     {
         try
@@ -111,6 +113,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void close() throws PxException
     {
         if(_writer != null)
@@ -143,6 +146,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writeDatasetLinkList(ShortURLRecord accessUrl) throws PxException
     {
         /*
@@ -174,6 +178,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writeKeywordList(ExperimentAnnotations expAnnotations) throws PxException
     {
         /*
@@ -202,6 +207,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writePublicationList(ExperimentAnnotations expAnnotations, PanoramaPublicController.PxExportForm form) throws PxException
     {
         /*
@@ -260,6 +266,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writeContactList(ExperimentAnnotations expAnnotations, PanoramaPublicController.PxExportForm form) throws PxException
     {
         /*
@@ -336,6 +343,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writeModificationList(ExperimentAnnotations expAnnotations) throws PxException
     {
         /*
@@ -378,6 +386,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writeInstrumentList(ExperimentAnnotations expAnnotations) throws PxException
     {
         /*
@@ -421,6 +430,7 @@ public class PxXmlWriter extends PxWriter
         return instrument1;
     }
 
+    @Override
     void writeSpeciesList(ExperimentAnnotations expAnnotations) throws PxException
     {
         /*
@@ -477,6 +487,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writeDatasetOriginList() throws PxException
     {
         // TODO: Check for re-processed data??
@@ -495,6 +506,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
+    @Override
     void writeDatasetIdentifierList(String pxId, ShortURLRecord accessUrl) throws PxException
     {
         Element di_list = new Element("DatasetIdentifierList");
@@ -545,6 +557,7 @@ public class PxXmlWriter extends PxWriter
         return el;
     }
 
+    @Override
     void writeDatasetSummary(ExperimentAnnotations annotations, PanoramaPublicController.PxExportForm form) throws PxException
     {
         Element el = new Element("DatasetSummary");

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/TargetedMSExperimentsWebPart.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/TargetedMSExperimentsWebPart.java
@@ -67,6 +67,7 @@ public class TargetedMSExperimentsWebPart extends QueryView
         return settings;
     }
 
+    @Override
     protected void populateButtonBar(DataView view, ButtonBar bb)
     {
         super.populateButtonBar(view, bb);

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -34,6 +34,7 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%!
+    @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
         dependencies.add("Ext4");

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp
@@ -28,6 +28,7 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
 <%!
+    @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
         dependencies.add("Ext4");

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
@@ -31,6 +31,7 @@
 <labkey:errors/>
 
 <%!
+    @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
         dependencies.add("Ext4");

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
@@ -33,6 +33,7 @@
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
 <%!
+    @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
         dependencies.add("Ext4");

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
@@ -26,6 +26,7 @@
 <labkey:errors/>
 
 <%!
+    @Override
     public void addClientDependencies(ClientDependencies dependencies)
     {
         dependencies.add("Ext4");

--- a/passport/src/org/labkey/passport/PassportController.java
+++ b/passport/src/org/labkey/passport/PassportController.java
@@ -93,6 +93,7 @@ public class PassportController extends SpringActionController
             return vbox;
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }
@@ -110,6 +111,7 @@ public class PassportController extends SpringActionController
             return new JspView<>("/org/labkey/passport/view/ProteinWebPart.jsp", protein);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }

--- a/passport/src/org/labkey/passport/PassportController.java
+++ b/passport/src/org/labkey/passport/PassportController.java
@@ -93,9 +93,8 @@ public class PassportController extends SpringActionController
             return vbox;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -111,10 +110,8 @@ public class PassportController extends SpringActionController
             return new JspView<>("/org/labkey/passport/view/ProteinWebPart.jsp", protein);
         }
 
-
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 

--- a/passport/src/org/labkey/passport/PassportModule.java
+++ b/passport/src/org/labkey/passport/PassportModule.java
@@ -61,6 +61,7 @@ public class PassportModule extends SpringModule
     protected Collection<WebPartFactory> createWebPartFactories() {
         BaseWebPartFactory paretoPlotFactory = new BaseWebPartFactory("Passport")
         {
+            @Override
             public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
             {
                 QueryView v =  ProteinListView.createView(portalCtx);

--- a/passport/src/org/labkey/passport/view/ProteinListView.java
+++ b/passport/src/org/labkey/passport/view/ProteinListView.java
@@ -32,6 +32,7 @@ public class ProteinListView extends QueryView
         super.renderView(model, request, response);
     }
 
+    @Override
     protected void populateButtonBar(DataView view, ButtonBar bar)
     {
         super.populateButtonBar(view, bar);

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -83,6 +83,7 @@ public class SignUpController extends SpringActionController
     @RequiresSiteAdmin
     public class ShowSignUpAdminAction extends SimpleViewAction
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
             JspView<User> result = new JspView<>("/org/labkey/signup/SignUpAdmin.jsp", getUser());
@@ -91,6 +92,7 @@ public class SignUpController extends SpringActionController
             return result;
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
             PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Sign Up Admin", null);
@@ -313,6 +315,7 @@ public class SignUpController extends SpringActionController
     @RequiresNoPermission
     public class ConfirmAction extends SimpleViewAction<SignupConfirmForm>
     {
+        @Override
         public ModelAndView getView(SignupConfirmForm form, BindException errors) throws Exception
         {
             ValidEmail email;
@@ -447,6 +450,7 @@ public class SignUpController extends SpringActionController
             validateSignupForm(form, errors);
         }
 
+        @Override
         public ModelAndView getView(SignupForm form, boolean reshow, BindException errors) throws Exception
         {
             if(form.isNewSignUp())
@@ -524,6 +528,7 @@ public class SignUpController extends SpringActionController
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -91,10 +91,9 @@ public class SignUpController extends SpringActionController
             return result;
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            PageFlowUtil.urlProvider(AdminUrls.class).appendAdminNavTrail(root, "Sign Up Admin", null);
-            return root;
+            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Sign Up Admin", null);
         }
     }
 
@@ -405,9 +404,8 @@ public class SignUpController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -526,9 +524,8 @@ public class SignUpController extends SpringActionController
             throw new UnsupportedOperationException();
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 

--- a/signup/src/org/labkey/signup/SignUpModule.java
+++ b/signup/src/org/labkey/signup/SignUpModule.java
@@ -67,6 +67,7 @@ public class SignUpModule extends DefaultModule
     {
         BaseWebPartFactory signupWebpart = new BaseWebPartFactory("Sign Up")
         {
+            @Override
             public WebPartView getWebPartView(ViewContext portalCtx, Portal.WebPart webPart)
             {
                 JspView<SignUpController.SignupForm> view = new JspView("/org/labkey/signup/signupPage.jsp", new SignUpController.SignupForm());

--- a/signup/src/org/labkey/signup/SignUpSchema.java
+++ b/signup/src/org/labkey/signup/SignUpSchema.java
@@ -171,6 +171,7 @@ public class SignUpSchema extends UserSchema
     {
         DefaultSchema.registerProvider(SCHEMA_NAME, new DefaultSchema.SchemaProvider(module)
         {
+            @Override
             public QuerySchema createSchema(DefaultSchema schema, Module module)
             {
                 return new SignUpSchema(schema.getUser(), schema.getContainer());

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -137,12 +137,14 @@ public class TestResultsController extends SpringActionController
     public class BeginAction extends SimpleViewAction
     {
 
+        @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
             RunDownBean bean = getRunDownBean(getUser(), getContainer(), getViewContext());
             return new JspView("/org/labkey/testresults/view/rundown.jsp", bean);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }
@@ -336,6 +338,7 @@ public class TestResultsController extends SpringActionController
     @RequiresPermission(ReadPermission.class)
     public class TrainingDataViewAction extends SimpleViewAction
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
             List<Integer> foundRuns = new ArrayList<>();
@@ -356,6 +359,7 @@ public class TestResultsController extends SpringActionController
             return new JspView("/org/labkey/testresults/view/trainingdata.jsp", bean);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
         }

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -21,8 +21,8 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ApiSimpleResponse;
+import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
 import org.labkey.api.data.CompareType;
@@ -56,7 +56,6 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.testresults.model.RunDetail;
 import org.labkey.testresults.model.TestFailDetail;
 import org.labkey.testresults.model.TestHandleLeakDetail;
-import org.labkey.testresults.model.TestMemoryLeakDetail;
 import org.labkey.testresults.model.TestMemoryLeakDetail;
 import org.labkey.testresults.model.TestPassDetail;
 import org.labkey.testresults.model.User;
@@ -144,9 +143,8 @@ public class TestResultsController extends SpringActionController
             return new JspView("/org/labkey/testresults/view/rundown.jsp", bean);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -358,9 +356,8 @@ public class TestResultsController extends SpringActionController
             return new JspView("/org/labkey/testresults/view/trainingdata.jsp", bean);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -525,9 +522,8 @@ public class TestResultsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -594,9 +590,8 @@ public class TestResultsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -630,9 +625,8 @@ public class TestResultsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -689,9 +683,8 @@ public class TestResultsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -718,9 +711,8 @@ public class TestResultsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -749,9 +741,8 @@ public class TestResultsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -770,9 +761,8 @@ public class TestResultsController extends SpringActionController
             return new JspView("/org/labkey/testresults/view/flagged.jsp", new TestsDataBean(details, new User[0]));
         }
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 
@@ -881,7 +871,7 @@ public class TestResultsController extends SpringActionController
                 return new ApiSimpleResponse(res);
             }
 
-            // DEFALT TO CHECK STATUS
+            // DEFAULT TO CHECK STATUS
             res.put("Message", "Status");
             res.put("Response", "" + scheduler.checkExists(jobKeyEmail));
             return new ApiSimpleResponse(res);
@@ -943,9 +933,8 @@ public class TestResultsController extends SpringActionController
 
             res.put("Message", "Success");
 
-            // DEFALT TO CHECK STATUS
+            // DEFAULT TO CHECK STATUS
             return new ApiSimpleResponse(res);
-
         }
     }
 
@@ -1043,9 +1032,8 @@ public class TestResultsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root;
         }
     }
 

--- a/testresults/src/org/labkey/testresults/model/TestFailDetail.java
+++ b/testresults/src/org/labkey/testresults/model/TestFailDetail.java
@@ -117,6 +117,7 @@ public class TestFailDetail implements Comparable<TestFailDetail>
     }
 
     // comparable by date and then id if dates are the same
+    @Override
     public int compareTo(TestFailDetail o)
     {
         int diff = 0;

--- a/testresults/src/org/labkey/testresults/model/TestPassDetail.java
+++ b/testresults/src/org/labkey/testresults/model/TestPassDetail.java
@@ -188,6 +188,7 @@ public class TestPassDetail implements Comparable<TestPassDetail>
         this.handles = handles;
     }
 
+    @Override
     public int compareTo(TestPassDetail o2) {
         return this.getId() - o2.getId();
     }

--- a/testresults/src/org/labkey/testresults/view/RunDownBean.java
+++ b/testresults/src/org/labkey/testresults/view/RunDownBean.java
@@ -39,6 +39,7 @@ public class RunDownBean extends TestsDataBean
     public Map<User, List<RunDetail>> getUserToRunsMap(Date selectedDate) {
         // treemap sorted by usernames
         Map<User, List<RunDetail>> map = new TreeMap<>(new Comparator<User>() {
+            @Override
             public int compare(User u1, User u2) {
                 return u1.getUsername().compareTo(u2.getUsername());
             }

--- a/testresults/src/org/labkey/testresults/view/user.jsp
+++ b/testresults/src/org/labkey/testresults/view/user.jsp
@@ -2,28 +2,27 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.TableSelector" %>
 <%@ page import="org.labkey.api.data.statistics.StatsService" %>
-<%@ page import="org.labkey.api.services.ServiceRegistry" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.testresults.model.RunDetail" %>
 <%@ page import="org.labkey.testresults.TestResultsController" %>
 <%@ page import="org.labkey.testresults.TestResultsSchema" %>
-<%@ page import="org.labkey.testresults.view.TestsDataBean" %>
+<%@ page import="org.labkey.testresults.model.RunDetail" %>
 <%@ page import="org.labkey.testresults.model.User" %>
+<%@ page import="org.labkey.testresults.view.TestsDataBean" %>
 <%@ page import="java.text.DateFormat" %>
 <%@ page import="java.text.SimpleDateFormat" %>
 <%@ page import="java.util.ArrayList" %>
-<%@ page import="java.util.Collections" %>
+<%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.Comparator" %>
 <%@ page import="java.util.Date" %>
-<%@ page import="java.util.List" %>
-<%@ page import="java.util.NavigableSet" %>
-<%@ page import="java.util.TreeSet" %>
-<%@ page import="java.util.Map" %>
 <%@ page import="java.util.Iterator" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="java.util.NavigableSet" %>
 <%@ page import="java.util.TreeMap" %>
+<%@ page import="java.util.TreeSet" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
@@ -91,15 +90,8 @@
     <%}%>
       <%if(!showSingleUser) {
            User[] users = new TableSelector(TestResultsSchema.getInstance().getTableInfoUser(), null, null).getArray(User.class);
-           List<User> uniqueUsers = new ArrayList<>();
-           for(User u: users)
-               uniqueUsers.add(u);
-           Collections.sort(uniqueUsers, new Comparator<User>(){ @Override
-           public int compare(User o1, User o2)
-               {
-                   return o1.getUsername().compareTo(o2.getUsername());
-               }
-           }); %>
+           List<User> uniqueUsers = new ArrayList<>(Arrays.asList(users));
+           uniqueUsers.sort(Comparator.comparing(User::getUsername)); %>
        <p>No user selected, please select from the following list:</p>
        <select id="users">
            <option disabled selected> -- select an option -- </option>

--- a/testresults/src/org/labkey/testresults/view/user.jsp
+++ b/testresults/src/org/labkey/testresults/view/user.jsp
@@ -94,7 +94,8 @@
            List<User> uniqueUsers = new ArrayList<>();
            for(User u: users)
                uniqueUsers.add(u);
-           Collections.sort(uniqueUsers, new Comparator<User>(){ public int compare(User o1, User o2)
+           Collections.sort(uniqueUsers, new Comparator<User>(){ @Override
+           public int compare(User o1, User o2)
                {
                    return o1.getUsername().compareTo(o2.getUsername());
                }


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199