### PR TITLE
Fix PanoramaPublicTest by getting editable WebParts

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -345,7 +345,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
 
     private void updateRawDataTab(Container c, FileContentService service, User user)
     {
-        List<Portal.WebPart> rawDataTabParts = Portal.getParts(c, TargetedMSService.RAW_FILES_TAB);
+        List<Portal.WebPart> rawDataTabParts = Portal.getEditableParts(c, TargetedMSService.RAW_FILES_TAB);
         if(rawDataTabParts.size() == 0)
         {
             return; // Nothing to do if there is no "Raw Data" tab.


### PR DESCRIPTION
Failure stack trace:
org.labkey.api.pipeline.PipelineJobException: Error during job execution
	at org.labkey.panoramapublic.pipeline.CopyExperimentFinalTask.run(CopyExperimentFinalTask.java:95)
	at org.labkey.api.pipeline.PipelineJob.runActiveTask(PipelineJob.java:795)
	at org.labkey.api.pipeline.PipelineJob.run(PipelineJob.java:1027)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.lang.UnsupportedOperationException
	at org.labkey.api.view.Portal$WebPart$1.setProperty(Portal.java:483)
	at org.labkey.panoramapublic.PanoramaPublicController.configureRawDataTab(PanoramaPublicController.java:3074)
	at org.labkey.panoramapublic.pipeline.CopyExperimentFinalTask.updateRawDataTab(CopyExperimentFinalTask.java:357)
	at org.labkey.panoramapublic.pipeline.CopyExperimentFinalTask.updateRawDataTabConfig(CopyExperimentFinalTask.java:342)

