### PR TITLE
20.7 fb panoramapublic px updates

### DIFF
--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.003-20.004.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.003-20.004.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ALTER TABLE panoramapublic.ExperimentAnnotations ADD COLUMN PubmedId VARCHAR(10);
+
+

--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.004-20.005.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.004-20.005.sql
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+ALTER TABLE panoramapublic.JournalExperiment RENAME COLUMN journalExperimentId TO CopiedExperimentId;
+
+ALTER TABLE panoramapublic.JournalExperiment ADD COLUMN ModifiedBy USERID;
+ALTER TABLE panoramapublic.JournalExperiment ADD COLUMN Modified TIMESTAMP DEFAULT now();
+UPDATE panoramapublic.JournalExperiment SET Modified =  Created;
+UPDATE panoramapublic.JournalExperiment SET ModifiedBy = CreatedBy;
+
+-- We want to add an auto-increment PK column on table journalexperiment. Simply adding the column does not generate values
+-- in the desired order. Create a new table instead and add id values ordered by values in the created column.
+-- https://stackoverflow.com/questions/53370072/add-auto-increment-column-to-existing-table-ordered-by-date
+create sequence panoramapublic.journalexperiment_id_seq;
+create table panoramapublic.journalexperiment_new as select nextval('panoramapublic.journalexperiment_id_seq') Id, *
+       from panoramapublic.JournalExperiment order by Created;
+DROP TABLE panoramapublic.JournalExperiment;
+ALTER TABLE panoramapublic.journalexperiment_new RENAME TO JournalExperiment;
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT PK_JournalExperiment PRIMARY KEY (Id);
+ALTER SEQUENCE panoramapublic.journalexperiment_id_seq OWNED BY panoramapublic.JournalExperiment.Id;
+-- Re-create foreign keys and indexes
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_Journal FOREIGN KEY (JournalId) REFERENCES panoramapublic.Journal(Id);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_ShortUrl_Access FOREIGN KEY (ShortAccessURL) REFERENCES core.ShortUrl(EntityId);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_ShortUrl_Copy FOREIGN KEY (ShortCopyURL) REFERENCES core.ShortUrl(EntityId);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_copiedExperimentId FOREIGN KEY (CopiedExperimentId) REFERENCES panoramapublic.ExperimentAnnotations(Id);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT UQ_JournalExperiment_copiedExperimentId UNIQUE (CopiedExperimentId);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT UQ_JournalExperiment UNIQUE (JournalId, ExperimentAnnotationsId);
+CREATE INDEX IX_JournalExperiment_ShortAccessURL ON panoramapublic.JournalExperiment(ShortAccessURL);
+CREATE INDEX IX_JournalExperiment_ShortCopyURL ON panoramapublic.JournalExperiment(ShortCopyURL);
+
+
+CREATE TABLE panoramapublic.pxxml
+(
+    _ts                   TIMESTAMP,
+    Id                    SERIAL   NOT NULL,
+    CreatedBy             USERID,
+    Created               TIMESTAMP,
+    ModifiedBy            USERID,
+    Modified              TIMESTAMP,
+
+    JournalExperimentId   INT NOT NULL,
+    Xml                   TEXT NOT NULL,
+    Version               SMALLINT NOT NULL,
+    UpdateLog             TEXT,
+
+    CONSTRAINT PK_PxXml PRIMARY KEY (Id),
+    CONSTRAINT FK_PxXml_JournalExperiment FOREIGN KEY (JournalExperimentId) REFERENCES panoramapublic.JournalExperiment(Id)
+);
+CREATE INDEX IX_PxXml_JournalExperiment ON panoramapublic.pxxml(JournalExperimentId);
+

--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.004-20.005.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.004-20.005.sql
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+ALTER TABLE panoramapublic.JournalExperiment RENAME COLUMN journalExperimentId TO CopiedExperimentId;
+
+ALTER TABLE panoramapublic.JournalExperiment ADD COLUMN ModifiedBy USERID;
+ALTER TABLE panoramapublic.JournalExperiment ADD COLUMN Modified TIMESTAMP DEFAULT now();
+UPDATE panoramapublic.JournalExperiment SET Modified =  Created;
+UPDATE panoramapublic.JournalExperiment SET ModifiedBy = CreatedBy;
+
+ALTER TABLE panoramapublic.JournalExperiment ADD COLUMN IncompletePxSubmission BOOLEAN NOT NULL DEFAULT '0';
+
+-- We want to add an auto-increment PK column on table journalexperiment. Simply adding the column does not generate values
+-- in the desired order. Create a new table instead and add id values ordered by values in the created column.
+-- https://stackoverflow.com/questions/53370072/add-auto-increment-column-to-existing-table-ordered-by-date
+create sequence panoramapublic.journalexperiment_id_seq;
+create table panoramapublic.journalexperiment_new as select nextval('panoramapublic.journalexperiment_id_seq') Id, *
+       from panoramapublic.JournalExperiment order by Created;
+DROP TABLE panoramapublic.JournalExperiment;
+ALTER TABLE panoramapublic.journalexperiment_new RENAME TO JournalExperiment;
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT PK_JournalExperiment PRIMARY KEY (Id);
+ALTER SEQUENCE panoramapublic.journalexperiment_id_seq OWNED BY panoramapublic.JournalExperiment.Id;
+ALTER TABLE panoramapublic.JournalExperiment ALTER COLUMN Id set default nextval('panoramapublic.journalexperiment_id_seq');
+
+-- Re-create foreign keys and indexes
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_Journal FOREIGN KEY (JournalId) REFERENCES panoramapublic.Journal(Id);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_ShortUrl_Access FOREIGN KEY (ShortAccessURL) REFERENCES core.ShortUrl(EntityId);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_ShortUrl_Copy FOREIGN KEY (ShortCopyURL) REFERENCES core.ShortUrl(EntityId);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT FK_JournalExperiment_copiedExperimentId FOREIGN KEY (CopiedExperimentId) REFERENCES panoramapublic.ExperimentAnnotations(Id);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT UQ_JournalExperiment_copiedExperimentId UNIQUE (CopiedExperimentId);
+ALTER TABLE panoramapublic.JournalExperiment ADD CONSTRAINT UQ_JournalExperiment UNIQUE (JournalId, ExperimentAnnotationsId);
+CREATE INDEX IX_JournalExperiment_ShortAccessURL ON panoramapublic.JournalExperiment(ShortAccessURL);
+CREATE INDEX IX_JournalExperiment_ShortCopyURL ON panoramapublic.JournalExperiment(ShortCopyURL);
+
+
+CREATE TABLE panoramapublic.pxxml
+(
+    _ts                   TIMESTAMP,
+    Id                    SERIAL   NOT NULL,
+    CreatedBy             USERID,
+    Created               TIMESTAMP,
+    ModifiedBy            USERID,
+    Modified              TIMESTAMP,
+
+    JournalExperimentId   INT NOT NULL,
+    Xml                   TEXT NOT NULL,
+    Version               SMALLINT NOT NULL,
+    UpdateLog             TEXT,
+
+    CONSTRAINT PK_PxXml PRIMARY KEY (Id),
+    CONSTRAINT FK_PxXml_JournalExperiment FOREIGN KEY (JournalExperimentId) REFERENCES panoramapublic.JournalExperiment(Id)
+);
+CREATE INDEX IX_PxXml_JournalExperiment ON panoramapublic.pxxml(JournalExperimentId);
+

--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -117,6 +117,7 @@
             <column columnName="pxid">
                 <columnTitle>PX ID</columnTitle>
             </column>
+            <column columnName="PubmedId"/>
         </columns>
     </table>
 
@@ -195,6 +196,18 @@
                     <fkTable>UsersData</fkTable>
                 </fk>
             </column>
+            <column columnName="Modified"/>
+            <column columnName="ModifiedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+            </column>
+            <column columnName="Id">
+                <description>Contains a unique id for this JouralExperiment (submission).</description>
+                <isHidden>true</isHidden>
+            </column>
             <column columnName="JournalId">
                 <columnTitle>Target</columnTitle>
                 <fk>
@@ -238,7 +251,57 @@
                 <columnTitle>License</columnTitle>
             </column>
             <column columnName="AnnouncementId"/>
-            <column columnName="JournalExperimentId"/>
+            <column columnName="CopiedExperimentId"/>
+        </columns>
+    </table>
+
+    <table tableName="PxXml" tableDbType="TABLE">
+        <titleColumn>Name</titleColumn>
+        <columns>
+            <column columnName="_ts">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Created">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="CreatedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Modified">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="ModifiedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Id">
+                <description>Contains a unique id for this submitted ProteomeXchange XML.</description>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="JournalExperimentId">
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>panoramapublic</fkDbSchema>
+                    <fkTable>JournalExperiment</fkTable>
+                </fk>
+            </column>
+            <column columnName="Xml">
+                <description>Xml submitted to ProteomeXchange</description>
+                <nullable>false</nullable>
+            </column>
+            <column columnName="Version" />
+            <column columnName="UpdateLog">
+                <description>Change log added to the submitted XML</description>
+            </column>
         </columns>
     </table>
 

--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -117,6 +117,7 @@
             <column columnName="pxid">
                 <columnTitle>PX ID</columnTitle>
             </column>
+            <column columnName="PubmedId"/>
         </columns>
     </table>
 
@@ -195,6 +196,10 @@
                     <fkTable>UsersData</fkTable>
                 </fk>
             </column>
+            <column columnName="Id">
+                <description>Contains a unique id for this JouralExperiment (submission).</description>
+                <isHidden>true</isHidden>
+            </column>
             <column columnName="JournalId">
                 <columnTitle>Target</columnTitle>
                 <fk>
@@ -238,7 +243,66 @@
                 <columnTitle>License</columnTitle>
             </column>
             <column columnName="AnnouncementId"/>
-            <column columnName="JournalExperimentId"/>
+            <column columnName="CopiedExperimentId"/>
+            <column columnName="IncompletePxSubmission"/>
+            <column columnName="Modified"/>
+            <column columnName="ModifiedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+            </column>
+        </columns>
+    </table>
+
+    <table tableName="PxXml" tableDbType="TABLE">
+        <titleColumn>Name</titleColumn>
+        <columns>
+            <column columnName="_ts">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Created">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="CreatedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Modified">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="ModifiedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Id">
+                <description>Contains a unique id for this submitted ProteomeXchange XML.</description>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="JournalExperimentId">
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>panoramapublic</fkDbSchema>
+                    <fkTable>JournalExperiment</fkTable>
+                </fk>
+            </column>
+            <column columnName="Xml">
+                <description>Xml submitted to ProteomeXchange</description>
+                <nullable>false</nullable>
+            </column>
+            <column columnName="Version" />
+            <column columnName="UpdateLog">
+                <description>Change log added to the submitted XML</description>
+            </column>
         </columns>
     </table>
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -24,7 +24,6 @@ import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
-import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.action.ConfirmAction;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
@@ -72,6 +71,7 @@ import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.pipeline.PipelineStatusUrls;
 import org.labkey.api.pipeline.PipelineUrls;
 import org.labkey.api.pipeline.PipelineValidationException;
+import org.labkey.api.portal.ProjectUrls;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
@@ -111,6 +111,7 @@ import org.labkey.panoramapublic.model.DataLicense;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
 import org.labkey.panoramapublic.model.JournalExperiment;
+import org.labkey.panoramapublic.model.PxXml;
 import org.labkey.panoramapublic.pipeline.AddPanoramaPublicModuleJob;
 import org.labkey.panoramapublic.pipeline.CopyExperimentPipelineJob;
 import org.labkey.panoramapublic.proteomexchange.NcbiUtils;
@@ -124,6 +125,7 @@ import org.labkey.panoramapublic.proteomexchange.SubmissionDataStatus;
 import org.labkey.panoramapublic.proteomexchange.SubmissionDataValidator;
 import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
 import org.labkey.panoramapublic.query.JournalManager;
+import org.labkey.panoramapublic.query.PxXmlManager;
 import org.labkey.panoramapublic.view.PanoramaPublicRunListView;
 import org.labkey.panoramapublic.view.expannotations.ExperimentAnnotationsFormDataRegion;
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentWebPart;
@@ -133,11 +135,12 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -159,11 +162,9 @@ import static org.labkey.api.util.DOM.INPUT;
 import static org.labkey.api.util.DOM.LABEL;
 import static org.labkey.api.util.DOM.LK.CHECKBOX;
 import static org.labkey.api.util.DOM.LK.FORM;
-import static org.labkey.api.util.DOM.OBJECT;
 import static org.labkey.api.util.DOM.SPAN;
 import static org.labkey.api.util.DOM.at;
 import static org.labkey.api.util.DOM.cl;
-import static org.labkey.api.util.DOM.createHtml;
 import static org.labkey.api.util.DOM.createHtmlFragment;
 
 /**
@@ -176,6 +177,7 @@ public class PanoramaPublicController extends SpringActionController
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(PanoramaPublicController.class);
     public static final String NAME = "panoramapublic";
     public static final String PANORAMA_REVIEWER_PREFIX = "panorama+reviewer";
+    public static final String PUBMED_ID = "^[0-9]{1,8}$"; // https://libguides.library.arizona.edu/c.php?g=406096&p=2779570
 
     public PanoramaPublicController()
     {
@@ -823,7 +825,11 @@ public class PanoramaPublicController extends SpringActionController
         @Override
         public ModelAndView getView(CopyExperimentForm form, boolean reshow, BindException errors)
         {
-            validateAction(form);
+            if(!validateAction(form, errors))
+            {
+                return new SimpleErrorView(errors);
+            }
+
             if(!reshow)
             {
                 CopyExperimentForm.setDefaults(form, _experiment, _journalExperiment);
@@ -835,12 +841,13 @@ public class PanoramaPublicController extends SpringActionController
             return view;
         }
 
-        private void validateAction(CopyExperimentForm form)
+        private boolean validateAction(CopyExperimentForm form, BindException errors)
         {
             _experiment = form.lookupExperiment();
             if(_experiment == null)
             {
-                throw new NotFoundException("Could not find experiment with id " + form.getId());
+                errors.reject(ERROR_MSG, "Could not find experiment with id " + form.getId());
+                return false;
             }
 
             PanoramaPublicController.ensureCorrectContainer(getContainer(), _experiment.getContainer(), getViewContext());
@@ -848,30 +855,38 @@ public class PanoramaPublicController extends SpringActionController
             _journal = form.lookupJournal();
             if(_journal == null)
             {
-                throw new NotFoundException("Could not find journal with id " + form.getJournalId());
+                errors.reject(ERROR_MSG, "Could not find journal with id " + form.getJournalId());
+                return false;
             }
             // User initiating the copy must be a member of a journal that was given access
             // to the experiment.
             if(!JournalManager.userHasCopyAccess(_experiment, _journal, getUser()))
             {
-                throw new UnauthorizedException("You do not have permissions to copy this experiment.");
+                errors.reject(ERROR_MSG,"You do not have permissions to copy this experiment.");
+                return false;
             }
             _journalExperiment = JournalManager.getJournalExperiment(_experiment.getId(), _journal.getId());
             if(_journalExperiment == null)
             {
-                throw new NotFoundException("Could not find an entry in JournalExperiment table for experimentId " + _experiment.getId()
+                errors.reject(ERROR_MSG,"Could not find an entry in JournalExperiment table for experimentId " + _experiment.getId()
                 + " and journalId " + _journal.getId());
+                return false;
             }
             if(_journalExperiment.getCopied() != null)
             {
-                throw new ApiUsageException(String.format("The experiment ID %d has already been copied.  It cannot be copied again.", _experiment.getId()));
+                errors.reject(ERROR_MSG, String.format("The experiment ID %d has already been copied.  It cannot be copied again.", _experiment.getId()));
+                return false;
             }
+            return true;
         }
 
         @Override
         public boolean handlePost(CopyExperimentForm form, BindException errors)
         {
-            validateAction(form);
+            if(!validateAction(form, errors))
+            {
+                return false;
+            }
 
             if(form.isAssignPxId() && !ExperimentAnnotationsManager.hasProteomicData(_experiment, getUser()))
             {
@@ -880,9 +895,24 @@ public class PanoramaPublicController extends SpringActionController
             }
 
             // Validate the data if a ProteomeXchange ID was requested.
-            if(_journalExperiment.isPxidRequested() && !SubmissionDataValidator.isValid(_experiment))
+            if(_journalExperiment.isPxidRequested())
             {
-                errors.reject(ERROR_MSG, "Data is incomplete for a ProteomeXchange submission.");
+                SubmissionDataStatus status = SubmissionDataValidator.validateExperiment(_experiment);
+                if(_journalExperiment.isIncompletePxSubmission() && !status.canSubmitToPx())
+                {
+                    errors.reject(ERROR_MSG, "A ProteomeXchange ID was requested for an \"incomplete\" submission.  But the data is not valid for a ProteomeXchange submission");
+                    return false;
+                }
+                if(!_journalExperiment.isIncompletePxSubmission() && !status.isComplete())
+                {
+                    errors.reject(ERROR_MSG, "Data is not valid for a \"complete\" ProteomeXchange submission.");
+                    return false;
+                }
+            }
+
+            if(form.isSendEmail() && StringUtils.isBlank(form.getToEmailAddresses()))
+            {
+                errors.reject(ERROR_MSG, "Please enter at least one email address.");
                 return false;
             }
 
@@ -1096,7 +1126,7 @@ public class PanoramaPublicController extends SpringActionController
 
         public List<String> getToEmailAddressList()
         {
-            return Arrays.asList(StringUtils.split(_toEmailAddresses, "\n\r"));
+            return StringUtils.isBlank(_toEmailAddresses) ? Collections.emptyList() : Arrays.asList(StringUtils.split(_toEmailAddresses, "\n\r"));
         }
 
         public void setToEmailAddresses(String toEmailAddresses)
@@ -1131,103 +1161,179 @@ public class PanoramaPublicController extends SpringActionController
     // BEGIN Action for publishing an experiment (provide copy access to a journal)
     // ------------------------------------------------------------------------
     @RequiresPermission(AdminPermission.class)
-    public static class ViewPublishExperimentFormAction extends SimpleViewAction<PublishExperimentForm>
+    public static class PublishExperimentAction extends FormViewAction<PublishExperimentForm>
     {
-        @Override
-        public void addNavTrail(NavTree root)
-        {
-            root.addChild("Experiment Submission Form");
-        }
+        ExperimentAnnotations _experimentAnnotations;
+        Journal _journal;
+        private boolean _doConfirm = false;
 
         @Override
-        public ModelAndView getView(PublishExperimentForm form, BindException errors)
+        public ModelAndView getView(PublishExperimentForm form, boolean reshow, BindException errors)
         {
-            ExperimentAnnotations exptAnnotations = form.lookupExperiment();
-            if(exptAnnotations == null)
+            if(!reshow && !validateGetRequest(form, errors))
             {
-                throw new NotFoundException("Could not find experiment with id " + form.getId());
+                return new SimpleErrorView(errors);
             }
 
-            ensureCorrectContainer(getContainer(), exptAnnotations.getContainer(), getViewContext());
-
-            populateForm(form, exptAnnotations);
-            return getPublishFormView(form, exptAnnotations, errors);
-        }
-
-        private static void populateForm(PublishExperimentForm form, ExperimentAnnotations exptAnnotations)
-        {
-            JournalExperiment journalExperiment = JournalManager.getJournalExperiment(exptAnnotations.getId(), form.getJournalId());
-            if(journalExperiment != null)
+            if(!reshow)
             {
-                form.setShortAccessUrl(journalExperiment.getShortAccessUrl().getShortURL());
-                form.setJournalId(journalExperiment.getJournalId());
-                form.setKeepPrivate(journalExperiment.isKeepPrivate());
-                form.setGetPxid(journalExperiment.isPxidRequested());
-                form.setLabHeadName(journalExperiment.getLabHeadName());
-                form.setLabHeadEmail(journalExperiment.getLabHeadEmail());
-                form.setLabHeadAffiliation(journalExperiment.getLabHeadAffiliation());
-                DataLicense license = journalExperiment.getDataLicense();
-                form.setDataLicense(license == null ? DataLicense.defaultLicense().name() : license.name());
+                populateForm(form, _experimentAnnotations);
             }
-            else if(form.getShortAccessUrl() == null)
+
+            if (!form.isDataValidated())
             {
-                form.setShortAccessUrl(generateRandomUrl(RANDOM_URL_SIZE));
-                List<Journal> journals = JournalManager.getJournals();
-                if (journals.size() == 0)
+                // Cannot publish if this is not an "Experimental data" folder.
+                TargetedMSService.FolderType folderType = TargetedMSService.get().getFolderType(_experimentAnnotations.getContainer());
+                if (folderType != TargetedMSService.FolderType.Experiment)
                 {
-                    throw new NotFoundException("Could not find any journals.");
+                    errors.reject(ERROR_MSG, "Only Targeted MS folders of type \"Experimental data\" can be submitted to " + _journal.getName() + ".");
+                    return new SimpleErrorView(errors);
                 }
-                form.setJournalId(journals.get(0).getId()); // This is "Panorama Public" on panoramaweb.org
 
-                form.setDataLicense(DataLicense.defaultLicense().name()); // CC BY 4.0 is default license
+                // Ensure there is at least one Skyline document in submission.
+                if (!hasSkylineDocs(_experimentAnnotations))
+                {
+                    errors.reject(ERROR_MSG, "There are no Skyline documents included in this experiment.  " +
+                            "Please upload one or more Skyline documents to proceed with the submission request.");
+                    return new SimpleErrorView(errors);
+                }
+
+                if(!ExperimentAnnotationsManager.hasProteomicData(_experimentAnnotations, getUser()))
+                {
+                    // Cannot get a PX ID small molecule data
+                    form.setGetPxid(false);
+                }
+                boolean validateForPx = form.isGetPxid();
+                if (validateForPx)
+                {
+                    SubmissionDataStatus status = SubmissionDataValidator.validateExperiment(_experimentAnnotations);
+                    if (!status.isComplete() && !form.isIncompletePxSubmission())
+                    {
+                        form.setValidationStatus(status);
+                        return getMissingInformationView(form, errors);
+                    }
+                }
+                form.setDataValidated(true);
             }
-        }
-    }
 
-    private static final int RANDOM_URL_SIZE = 6;
-
-    private static JspView getPublishFormView(PublishExperimentForm form, ExperimentAnnotations exptAnnotations, BindException errors)
-    {
-        PublishExperimentFormBean bean = new PublishExperimentFormBean();
-        bean.setForm(form);
-        bean.setJournalList(JournalManager.getJournals());
-        bean.setExperimentAnnotations(exptAnnotations);
-        bean.setDataLicenseList(Arrays.asList(DataLicense.values()));
-
-        JspView view = new JspView("/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp", bean, errors);
-        view.setFrame(WebPartView.FrameType.PORTAL);
-        view.setTitle((form.isUpdate() ? "Update" : "") + " Submission Request to " + form.lookupJournal().getName());
-        return view;
-    }
-
-    private static String generateRandomUrl(int length)
-    {
-        ShortURLService shortUrlService = ShortURLService.get();
-        while(true)
-        {
-            String random = RandomStringUtils.randomAlphanumeric(length);
-            ShortURLRecord shortURLRecord = shortUrlService.resolveShortURL(random);
-            if(shortURLRecord == null)
+            if(_doConfirm)
             {
-                return random;
+                return getConfirmView(form, errors);
+            }
+            else
+            {
+                return getPublishFormView(form, _experimentAnnotations, errors);
             }
         }
-    }
 
-    @RequiresPermission(AdminPermission.class)
-    public static class PublishExperimentAction extends JournalExperimentAction
-    {
+        boolean validateGetRequest(PublishExperimentForm form, BindException errors)
+        {
+            _experimentAnnotations = ExperimentAnnotationsManager.get(form.getId());
+            if (_experimentAnnotations == null)
+            {
+                errors.reject(ERROR_MSG, "No experiment found for Id " + form.getId());
+                return false;
+            }
+
+            ensureCorrectContainer(getContainer(), _experimentAnnotations.getContainer(), getViewContext());
+
+            return true;
+        }
+
+        void populateForm(PublishExperimentForm form, ExperimentAnnotations exptAnnotations)
+        {
+            form.setShortAccessUrl(generateRandomUrl(RANDOM_URL_SIZE));
+            List<Journal> journals = JournalManager.getJournals();
+            if (journals.size() == 0)
+            {
+                throw new NotFoundException("Could not find any journals.");
+            }
+            form.setJournalId(journals.get(0).getId()); // This is "Panorama Public" on panoramaweb.org
+
+            form.setDataLicense(DataLicense.defaultLicense().name()); // CC BY 4.0 is default license
+            form.setKeepPrivate(true);
+        }
+
+        private JspView getPublishFormView(PublishExperimentForm form, ExperimentAnnotations exptAnnotations, BindException errors)
+        {
+            PublishExperimentFormBean bean = new PublishExperimentFormBean();
+            bean.setForm(form);
+            bean.setJournalList(JournalManager.getJournals());
+            bean.setExperimentAnnotations(exptAnnotations);
+            bean.setDataLicenseList(Arrays.asList(DataLicense.values()));
+
+            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp", bean, errors);
+            view.setFrame(WebPartView.FrameType.PORTAL);
+            view.setTitle(getFormViewTitle(form.lookupJournal().getName()));
+            return view;
+        }
+
+        private static String generateRandomUrl(int length)
+        {
+            ShortURLService shortUrlService = ShortURLService.get();
+            while(true)
+            {
+                String random = RandomStringUtils.randomAlphanumeric(length);
+                ShortURLRecord shortURLRecord = shortUrlService.resolveShortURL(random);
+                if(shortURLRecord == null)
+                {
+                    return random;
+                }
+            }
+        }
+
+        String getFormViewTitle(String journalName)
+        {
+            return "Submission Request to " + journalName;
+        }
+
+        ModelAndView getConfirmView(PublishExperimentForm form, BindException errors)
+        {
+            setTitle(getConfirmViewTitle());
+            PanoramaPublicRequest bean = new PanoramaPublicRequest();
+            bean.setExperimentAnnotations(_experimentAnnotations);
+            bean.setJournal(_journal);
+            bean.setForm(form);
+
+            JspView<PanoramaPublicRequest> confirmView = new JspView<PanoramaPublicRequest>("/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp", bean, errors);
+            confirmView.setTitle(getConfirmViewTitle());
+            return confirmView;
+        }
+
+        String getConfirmViewTitle()
+        {
+            return "Confirm submission request To " + _journal.getName();
+        }
+
         @Override
-        public void validateForm(PublishExperimentForm form, Errors errors)
+        public void validateCommand(PublishExperimentForm form, Errors errors)
+        {
+            _experimentAnnotations = form.lookupExperiment();
+            if(_experimentAnnotations == null)
+            {
+                errors.reject(ERROR_MSG,"Could not find experiment with Id " + form.getId());
+                return;
+            }
+
+            ensureCorrectContainer(getContainer(), _experimentAnnotations.getContainer(), getViewContext());
+
+            _journal = form.lookupJournal();
+            if(_journal == null)
+            {
+                errors.reject(ERROR_MSG, "Could not find a journal with Id " + form.getJournalId());
+            }
+
+            if(errors.getErrorCount() > 0)
+            {
+                return;
+            }
+
+            validateForm(form, errors);
+        }
+
+        void validateForm(PublishExperimentForm form, Errors errors)
         {
             validateJournal(errors, _experimentAnnotations, _journal);
-
-            // Cannot publish if this is not an "Experimental data" folder.
-            TargetedMSService.FolderType folderType = TargetedMSService.get().getFolderType(_experimentAnnotations.getContainer());
-            if(folderType != TargetedMSService.FolderType.Experiment)
-            {
-                errors.reject(ERROR_MSG,"Only Targeted MS folders of type \"Experimental data\" can be submitted to " + _journal.getName() + ".");
-            }
 
             // Validate the short access url.
             if(!StringUtils.isBlank(form.getShortAccessUrl()))
@@ -1277,33 +1383,50 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public ModelAndView getConfirmView(PublishExperimentForm form, BindException errors)
+        public boolean handlePost(PublishExperimentForm form, BindException errors) throws Exception
         {
-            if(form.isGetPxid() && (!SubmissionDataValidator.isValid(_experimentAnnotations, form.isSkipMetaDataCheck(), form.isSkipRawDataCheck(), form.isSkipModCheck())))
+            if(!form.isRequestConfirmed())
             {
-                ActionURL redirectUrl = new ActionURL(PreSubmissionCheckAction.class, _experimentAnnotations.getContainer());
-                redirectUrl.addParameter("id", _experimentAnnotations.getId());
-                throw new RedirectException(redirectUrl);
+                _doConfirm = true;
+                return false;
+            }
+            if(!form.isDataValidated())
+            {
+                return false;
+            }
+            return doUpdates(form, errors);
+        }
+
+        boolean doUpdates(PublishExperimentForm form, BindException errors) throws ValidationException
+        {
+            // Create a short copy URL.
+            assignShortCopyUrl(form);
+
+            try
+            {
+                try(DbScope.Transaction transaction = PanoramaPublicSchema.getSchema().getScope().ensureTransaction())
+                {
+                    JournalExperiment je = JournalManager.setupJournalAccess(new PanoramaPublicRequest(_experimentAnnotations, _journal, form), getUser());
+
+                    // Create notifications
+                    PanoramaPublicNotification.notifyCreated(_experimentAnnotations, _journal, je, getUser());
+
+                    transaction.commit();
+                }
+            }
+            catch(ValidationException | UnauthorizedException e)
+            {
+                errors.reject(ERROR_MSG, e.getMessage());
+                return false;
             }
 
-            else
-            {
-                setTitle("Confirm Submission Request");
-                PanoramaPublicRequest bean = new PanoramaPublicRequest();
-                bean.setExperimentAnnotations(_experimentAnnotations);
-                bean.setJournal(_journal);
-                bean.setForm(form);
-
-                JspView<PanoramaPublicRequest> view = new JspView<PanoramaPublicRequest>("/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp", bean, errors);
-                view.setTitle("Submission Request to " + _journal.getName());
-                return view;
-            }
+            return true;
         }
 
         @Override
         public ModelAndView getSuccessView(PublishExperimentForm form)
         {
-            setTitle("Submitted");
+            setTitle(getSuccessViewTitle());
             String journal = _journal.getName();
             ActionURL returnUrl = PanoramaPublicController.getViewExperimentDetailsURL(_experimentAnnotations.getId(), getContainer());
             StringBuilder html = new StringBuilder();
@@ -1321,57 +1444,19 @@ public class PanoramaPublicController extends SpringActionController
             html.append("<br><br>");
             html.append("<a href=" + returnUrl.getEncodedLocalURIString() + "><span class=\"labkey-button\">Back to Experiment Details</span></a>");
             HtmlView view = new HtmlView(html.toString());
-            view.setTitle("Request Submitted to " + journal);
+            view.setTitle(getSuccessViewTitle());
             return view;
         }
 
-        @Override
-        public ModelAndView getFailView(PublishExperimentForm form, BindException errors)
+        String getSuccessViewTitle()
         {
-            return getPublishFormView(form, _experimentAnnotations, errors);
+            return "Request submitted to " + _journal.getName();
         }
 
         @Override
-        public boolean handlePost(PublishExperimentForm form, BindException errors) throws Exception
+        public URLHelper getSuccessURL(PublishExperimentForm form)
         {
-            // Create a short copy URL.
-            assignShortCopyUrl(form);
-
-            try
-            {
-                try(DbScope.Transaction transaction = PanoramaPublicSchema.getSchema().getScope().ensureTransaction())
-                {
-                    JournalExperiment je = JournalManager.setupJournalAccess(new PanoramaPublicRequest(_experimentAnnotations, _journal, form), getUser());
-
-                    // Create notifications
-                    PanoramaPublicNotification.notifyCreated(_experimentAnnotations, _journal, je, getUser());
-
-                    transaction.commit();
-                }
-            }
-            catch(ValidationException | UnauthorizedException  e)
-            {
-                errors.reject(ERROR_MSG, e.getMessage());
-                return false;
-            }
-
-            return true;
-        }
-
-        protected void assignShortCopyUrl(PublishExperimentForm form)
-        {
-            ShortURLService shortUrlService = ShortURLService.get();
-            String baseUrl = form.getShortAccessUrl() + "_";
-            while(true)
-            {
-                String random = RandomStringUtils.randomAlphanumeric(RANDOM_URL_SIZE);
-                ShortURLRecord shortURLRecord = shortUrlService.resolveShortURL(baseUrl + random);
-                if(shortURLRecord == null)
-                {
-                    form.setShortCopyUrl(baseUrl + random);
-                    break;
-                }
-            }
+            return null;
         }
 
         void validateJournal(Errors errors, ExperimentAnnotations experiment, Journal journal)
@@ -1408,17 +1493,26 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public URLHelper getSuccessURL(PublishExperimentForm form)
+        public void addNavTrail(NavTree root)
         {
-            return PanoramaPublicController.getViewExperimentDetailsURL(form.getId(), getContainer());
+            root.addChild("Submit Experiment");
         }
+    }
 
-        @Override
-        public URLHelper getCancelUrl()
+    private static final int RANDOM_URL_SIZE = 6;
+    private static void assignShortCopyUrl(PublishExperimentForm form)
+    {
+        ShortURLService shortUrlService = ShortURLService.get();
+        String baseUrl = form.getShortAccessUrl() + "_";
+        while(true)
         {
-            ActionURL url = getViewContext().getActionURL().clone();
-            url = url.setAction(ViewPublishExperimentFormAction.class); // keep parameters same, change action class.
-            return url;
+            String random = RandomStringUtils.randomAlphanumeric(RANDOM_URL_SIZE);
+            ShortURLRecord shortURLRecord = shortUrlService.resolveShortURL(baseUrl + random);
+            if(shortURLRecord == null)
+            {
+                form.setShortCopyUrl(baseUrl + random);
+                break;
+            }
         }
     }
 
@@ -1476,7 +1570,10 @@ public class PanoramaPublicController extends SpringActionController
         private ExperimentAnnotations _experimentAnnotations;
         private Journal _journal;
 
-        public PanoramaPublicRequest(){}
+        public PanoramaPublicRequest()
+        {
+        }
+
         public PanoramaPublicRequest(ExperimentAnnotations experimentAnnotations, Journal journal, PublishExperimentForm form)
         {
             _form = form;
@@ -1529,6 +1626,11 @@ public class PanoramaPublicController extends SpringActionController
             return _form.isUpdate();
         }
 
+        public boolean isResubmit()
+        {
+            return _form.isResubmit();
+        }
+
         public boolean isKeepPrivate()
         {
             return _form.isKeepPrivate();
@@ -1537,6 +1639,11 @@ public class PanoramaPublicController extends SpringActionController
         public boolean isGetPxid()
         {
             return _form.isGetPxid();
+        }
+
+        public boolean isIncompletePxSubmission()
+        {
+            return _form.isIncompletePxSubmission();
         }
 
         public String getLabHeadName()
@@ -1568,10 +1675,14 @@ public class PanoramaPublicController extends SpringActionController
         private boolean _update;
         private boolean _keepPrivate;
         private boolean _getPxid;
+        private boolean _incompletePxSubmission;
         private String _labHeadName;
         private String _labHeadAffiliation;
         private String _labHeadEmail;
         private String _dataLicense;
+        private boolean _dataValidated;
+        private boolean _requestConfirmed;
+        private boolean _resubmit;
 
         public int getJournalId()
         {
@@ -1643,6 +1754,16 @@ public class PanoramaPublicController extends SpringActionController
             _getPxid = getPxid;
         }
 
+        public boolean isIncompletePxSubmission()
+        {
+            return _incompletePxSubmission;
+        }
+
+        public void setIncompletePxSubmission(boolean incompletePxSubmission)
+        {
+            _incompletePxSubmission = incompletePxSubmission;
+        }
+
         public String getLabHeadName()
         {
             return _labHeadName;
@@ -1682,6 +1803,36 @@ public class PanoramaPublicController extends SpringActionController
         {
             _dataLicense = dataLicense;
         }
+
+        public boolean isDataValidated()
+        {
+            return _dataValidated;
+        }
+
+        public void setDataValidated(boolean dataValidated)
+        {
+            _dataValidated = dataValidated;
+        }
+
+        public boolean isRequestConfirmed()
+        {
+            return _requestConfirmed;
+        }
+
+        public void setRequestConfirmed(boolean requestConfirmed)
+        {
+            _requestConfirmed = requestConfirmed;
+        }
+
+        public boolean isResubmit()
+        {
+            return _resubmit;
+        }
+
+        public void setResubmit(boolean resubmit)
+        {
+            _resubmit = resubmit;
+        }
     }
     // ------------------------------------------------------------------------
     // END Action for publishing an experiment (provide copy access to a journal)
@@ -1692,76 +1843,86 @@ public class PanoramaPublicController extends SpringActionController
     // BEGIN Action for updating an entry in panoramapublic.JournalExperiment table
     // ------------------------------------------------------------------------
     @RequiresPermission(AdminPermission.class)
-    public static class UpdateJournalExperimentAction extends PublishExperimentAction
+    public static class UpdateJournalExperimentAction extends ResubmitExperimentAction
     {
-        private JournalExperiment _journalExperiment;
+        @Override
+        void populateForm(PublishExperimentForm form, ExperimentAnnotations exptAnnotations)
+        {
+            super.populateForm(form, exptAnnotations);
+            form.setUpdate(true);
+        }
 
         @Override
-        public void validateForm(PublishExperimentForm form, Errors errors)
+        void validateForm(PublishExperimentForm form, Errors errors)
         {
             _journalExperiment = JournalManager.getJournalExperiment(_experimentAnnotations.getId(), form.getJournalId());
             if(_journalExperiment == null)
             {
                 errors.reject(ERROR_MSG,"Could not find an entry in JournalExperiment for experiment ID " + _experimentAnnotations.getId() + " and journal ID " + form.getJournalId());
+                return;
             }
 
             // If this experiment has already been copied by the journal, don't allow editing.
             if(_journalExperiment.getCopied() != null)
             {
-                errors.reject(ERROR_MSG, "This experiment has already been copied by " + _journal.getName() + ". You cannot change the access URL anymore." );
-            }
-
-            if(errors.getErrorCount() > 0)
-            {
+                errors.reject(ERROR_MSG, "This experiment has already been copied by " + _journal.getName() + ". You cannot edit the submission request." );
                 return;
             }
 
             super.validateForm(form, errors);
         }
 
-        @Override
-        protected void validateJournal(Errors errors, ExperimentAnnotations experiment, Journal journal)
+        String getFormViewTitle(String journalName)
         {
-            Journal oldJournal = JournalManager.getJournal(_journalExperiment.getJournalId());
-            if(oldJournal != null && (!oldJournal.getId().equals(journal.getId())))
-            {
-                super.validateJournal(errors, experiment, journal);
-            }
+            return "Update Submission Request to " + journalName;
         }
 
         @Override
-        protected void validateShortAccessUrl(PublishExperimentForm form, Errors errors)
+        String getConfirmViewTitle()
         {
-            ShortURLRecord accessUrlRecord = _journalExperiment.getShortAccessUrl();
-            if(!accessUrlRecord.getShortURL().equals(form.getShortAccessUrl()))
-            {
-                super.validateShortAccessUrl(form, errors);
-            }
+            return "Update submission request to " + _journal.getName();
         }
 
-        @Override
-        public ModelAndView getConfirmView(PublishExperimentForm form, BindException errors)
+        public ModelAndView getSuccessView(PublishExperimentForm form)
         {
-            setTitle("Confirm Submission Update");
-            PanoramaPublicRequest bean = new PanoramaPublicRequest();
-            bean.setExperimentAnnotations(_experimentAnnotations);
-            bean.setJournal(_journal);
-            bean.setForm(form);
+            setTitle(getSuccessViewTitle());
+            String journal = _journal.getName();
+            ActionURL returnUrl = PanoramaPublicController.getViewExperimentDetailsURL(_experimentAnnotations.getId(), getContainer());
 
-            JspView<PanoramaPublicRequest> view = new JspView<>("/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp", bean, errors);
-            view.setTitle("Update Submission Request to " + _journal.getName());
+            String dataPrivate = "";
+            if(form.isKeepPrivate())
+            {
+                dataPrivate = "Your data on " + journal + " will be kept private";
+                dataPrivate += form.isResubmit() ? ". The reviewer account details will be the same before." : " and reviewer account details will be included in the confirmation email.";
+            }
+
+            String pxdAssigned = "";
+            if(form.isGetPxid())
+            {
+                pxdAssigned = form.isResubmit() ? "The ProteomeXchange ID assigned to the data will remain the same as before."
+                        : "A ProteomeXchange ID will be requested for your data and included in the confirmation email.";
+            }
+
+            HtmlView view = new HtmlView(DIV("Your submission request has been upated. We will send you a confirmation email once your data has been copied.  This can take upto a week.",
+                                         DIV(dataPrivate),
+                                         DIV(pxdAssigned),
+                                         BR(), BR(),
+                                         new Link.LinkBuilder("Back to Experiment Details").href(returnUrl).build()));
+
+            view.setTitle(getSuccessViewTitle());
             return view;
         }
 
         @Override
-        public boolean handlePost(PublishExperimentForm form, BindException errors) throws Exception
+        String getSuccessViewTitle()
         {
-            _journalExperiment.setKeepPrivate(form.isKeepPrivate());
-            _journalExperiment.setPxidRequested(form.isGetPxid());
-            _journalExperiment.setDataLicense(DataLicense.resolveLicense(form.getDataLicense()));
-            _journalExperiment.setLabHeadName(form.getLabHeadName());
-            _journalExperiment.setLabHeadEmail(form.getLabHeadEmail());
-            _journalExperiment.setLabHeadAffiliation(form.getLabHeadAffiliation());
+            return "Updated submission request to " + _journal.getName();
+        }
+
+        @Override
+        boolean doUpdates(PublishExperimentForm form, BindException errors) throws ValidationException
+        {
+            setValuesInJournalExperiment(form);
 
             try(DbScope.Transaction transaction = CoreSchema.getInstance().getSchema().getScope().ensureTransaction())
             {
@@ -1782,6 +1943,75 @@ public class PanoramaPublicController extends SpringActionController
             }
             return true;
         }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            root.addChild("Update Submission Request");
+        }
+    }
+
+    @RequiresPermission(AdminPermission.class)
+    public abstract static class ResubmitExperimentAction extends PublishExperimentAction
+    {
+        protected JournalExperiment _journalExperiment;
+
+        boolean validateGetRequest(PublishExperimentForm form, BindException errors)
+        {
+            if(super.validateGetRequest(form, errors))
+            {
+                _journalExperiment = JournalManager.getJournalExperiment(_experimentAnnotations.getId(), form.getJournalId());
+                if(_journalExperiment == null)
+                {
+                    errors.reject(ERROR_MSG,"Could not find an entry in JournalExperiment for experiment ID " + _experimentAnnotations.getId() + " and journal ID " + form.getJournalId());
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void populateForm(PublishExperimentForm form, ExperimentAnnotations exptAnnotations)
+        {
+            form.setShortAccessUrl(_journalExperiment.getShortAccessUrl().getShortURL());
+            form.setJournalId(_journalExperiment.getJournalId());
+            form.setKeepPrivate(_journalExperiment.isKeepPrivate());
+            form.setLabHeadName(_journalExperiment.getLabHeadName());
+            form.setLabHeadEmail(_journalExperiment.getLabHeadEmail());
+            form.setLabHeadAffiliation(_journalExperiment.getLabHeadAffiliation());
+            DataLicense license = _journalExperiment.getDataLicense();
+            form.setDataLicense(license == null ? DataLicense.defaultLicense().name() : license.name());
+        }
+
+        @Override
+        void validateJournal(Errors errors, ExperimentAnnotations experiment, Journal journal)
+        {
+            Journal oldJournal = JournalManager.getJournal(_journalExperiment.getJournalId());
+            if(oldJournal != null && (!oldJournal.getId().equals(journal.getId())))
+            {
+                super.validateJournal(errors, experiment, journal);
+            }
+        }
+
+        @Override
+        void validateShortAccessUrl(PublishExperimentForm form, Errors errors)
+        {
+            ShortURLRecord accessUrlRecord = _journalExperiment.getShortAccessUrl();
+            if(!accessUrlRecord.getShortURL().equals(form.getShortAccessUrl()))
+            {
+                super.validateShortAccessUrl(form, errors);
+            }
+        }
+
+        void setValuesInJournalExperiment(PublishExperimentForm form)
+        {
+            _journalExperiment.setKeepPrivate(form.isKeepPrivate());
+            _journalExperiment.setPxidRequested(form.isGetPxid());
+            _journalExperiment.setIncompletePxSubmission(form.isIncompletePxSubmission());
+            _journalExperiment.setDataLicense(DataLicense.resolveLicense(form.getDataLicense()));
+            _journalExperiment.setLabHeadName(form.getLabHeadName());
+            _journalExperiment.setLabHeadEmail(form.getLabHeadEmail());
+            _journalExperiment.setLabHeadAffiliation(form.getLabHeadAffiliation());
+        }
     }
     // ------------------------------------------------------------------------
     // END Action for updating an entry in panoramapublic.JournalExperiment table
@@ -1791,20 +2021,52 @@ public class PanoramaPublicController extends SpringActionController
     // BEGIN Action for deleting an entry in panoramapublic.JournalExperiment table.
     // ------------------------------------------------------------------------
     @RequiresPermission(AdminPermission.class)
-    public static class DeleteJournalExperimentAction extends JournalExperimentAction
+    public static class DeleteJournalExperimentAction extends ConfirmAction<PublishExperimentForm>
     {
+        protected ExperimentAnnotations _experimentAnnotations;
+        protected Journal _journal;
         private JournalExperiment _journalExperiment;
+
+        @Override
+        public void validateCommand(PublishExperimentForm form, Errors errors)
+        {
+            _experimentAnnotations = form.lookupExperiment();
+            if(_experimentAnnotations == null)
+            {
+                errors.reject(ERROR_MSG,"Could not find experiment with Id " + form.getId());
+                return;
+            }
+
+            ensureCorrectContainer(getContainer(), _experimentAnnotations.getContainer(), getViewContext());
+
+            _journal = form.lookupJournal();
+            if(_journal == null)
+            {
+                errors.reject(ERROR_MSG, "Could not find a journal with Id " + form.getJournalId());
+                return;
+            }
+
+            _journalExperiment = JournalManager.getJournalExperiment(_experimentAnnotations.getId(), _journal.getId());
+            if(_journalExperiment == null)
+            {
+                errors.reject(ERROR_MSG, "Could not find an entry for experiment with Id " + form.getId() + " and journal Id " + _journal.getId());
+                return;
+            }
+
+            if(_journalExperiment.getCopiedExperimentId() != null)
+            {
+                errors.reject(ERROR_MSG, "The experiment has already been copied by the journal. Unable to delete submission request.");
+                return;
+            }
+        }
 
         @Override
         public ModelAndView getConfirmView(PublishExperimentForm form, BindException errors)
         {
             setTitle("Confirm Delete Submission");
-            StringBuilder html = new StringBuilder();
-            html.append("Are you sure you want to cancel your submission request to ").append(_journal.getName());
-            html.append("?");
-            html.append("<br><br>");
-            html.append("Experiment: ").append(_experimentAnnotations.getTitle());
-            HtmlView view = new HtmlView(html.toString());
+            HtmlView view = new HtmlView(DIV("Are you sure you want to cancel your submission request to " + _journal.getName() + "?",
+                    BR(), BR(),
+                    SPAN("Experiment " + _experimentAnnotations.getTitle())));
             view.setTitle("Cancel Submission Request to " + _journal.getName());
             return view;
         }
@@ -1823,21 +2085,6 @@ public class PanoramaPublicController extends SpringActionController
             }
 
             return true;
-        }
-
-        @Override
-        public void validateForm(PublishExperimentForm form, Errors errors)
-        {
-            _journalExperiment = JournalManager.getJournalExperiment(_experimentAnnotations.getId(), _journal.getId());
-            if(_journalExperiment == null)
-            {
-                throw new NotFoundException("Could not find an entry for experiment with Id " + form.getId() + " and journal Id " + _journal.getId());
-            }
-
-            if(_journalExperiment.getCopied() != null)
-            {
-                errors.reject(ERROR_MSG, "The experiment has already been copied by the journal. Unable to delete short access and copy URLs.");
-            }
         }
 
         @Override
@@ -1871,35 +2118,49 @@ public class PanoramaPublicController extends SpringActionController
     //       -- Reset access URL to point to the author's data
     // ------------------------------------------------------------------------
     @RequiresPermission(AdminPermission.class)
-    public static class RepublishJournalExperimentAction extends JournalExperimentAction
+    public static class RepublishJournalExperimentAction extends ResubmitExperimentAction
     {
-        private JournalExperiment _journalExperiment;
+        void populateForm(PublishExperimentForm form, ExperimentAnnotations exptAnnotations)
+        {
+            super.populateForm(form, exptAnnotations);
+            form.setResubmit(true);
+        }
+
+        String getFormViewTitle(String journalName)
+        {
+            return "Resubmit Request to " + journalName;
+        }
 
         @Override
         public ModelAndView getConfirmView(PublishExperimentForm form, BindException errors)
         {
             setTitle("Confirm Resubmit Experiment");
-            StringBuilder html = new StringBuilder();
-            html.append("Experiment: ").append(_experimentAnnotations.getTitle());
-            html.append("<br><br>");
-            html.append("This experiment has already been copied by ").append(_journal.getName());
-            html.append(". If you click OK the existing copy on ").append(_journal.getName()).append(" will be deleted and a request will be sent to make a new copy.");
-            html.append("<br>");
-            html.append("Are you sure you want to continue?");
-            HtmlView view = new HtmlView(html.toString());
-            view.setTitle("Resubmit to " + _journal.getName());
-            return view;
+            return super.getConfirmView(form, errors);
         }
 
         @Override
-        public boolean handlePost(PublishExperimentForm form, BindException errors) throws Exception
+        protected String getConfirmViewTitle()
         {
+            return "Confirm resubmission request to " + _journal.getName();
+        }
+
+        @Override
+        String getSuccessViewTitle()
+        {
+            return "Request resubmitted to " + _journal.getName();
+        }
+
+        @Override
+        boolean doUpdates(PublishExperimentForm form, BindException errors) throws ValidationException
+        {
+            setValuesInJournalExperiment(form);
+            _journalExperiment.setCopied(null);
+
             try(DbScope.Transaction transaction = PanoramaPublicManager.getSchema().getScope().ensureTransaction())
             {
                 Group journalGroup = org.labkey.api.security.SecurityManager.getGroup(_journal.getLabkeyGroupId());
                 JournalManager.addJournalPermissions(_experimentAnnotations, journalGroup, getUser());
 
-                _journalExperiment.setCopied(null);
                 JournalManager.updateJournalExperiment(_journalExperiment, getUser());
 
                 // Reset the access URL to point to the author's folder
@@ -1911,9 +2172,9 @@ public class PanoramaPublicController extends SpringActionController
 
                 // Rename the container where the old copy lives so that the same folder name can be used for the new copy.
                 // The container will be deleted after the data has been re-copied.
-                ExperimentAnnotations currentJournalExpt = ExperimentAnnotationsManager.get(_journalExperiment.getJournalExperimentId());
+                ExperimentAnnotations currentJournalExpt = ExperimentAnnotationsManager.get(_journalExperiment.getCopiedExperimentId());
                 renameOldContainer(currentJournalExpt.getContainer());
-                currentJournalExpt = ExperimentAnnotationsManager.get(_journalExperiment.getJournalExperimentId()); // query again to get the updated container name
+                currentJournalExpt = ExperimentAnnotationsManager.get(_journalExperiment.getCopiedExperimentId()); // query again to get the updated container name
                 PanoramaPublicNotification.notifyResubmitted(_experimentAnnotations, _journal, _journalExperiment, currentJournalExpt, getUser());
 
                 transaction.commit();
@@ -1936,12 +2197,13 @@ public class PanoramaPublicController extends SpringActionController
         }
 
         @Override
-        public void validateForm(PublishExperimentForm form, Errors errors)
+        void validateForm(PublishExperimentForm form, Errors errors)
         {
             _journalExperiment = JournalManager.getJournalExperiment(_experimentAnnotations.getId(), _journal.getId());
             if(_journalExperiment == null)
             {
                 errors.reject(ERROR_MSG,"Could not find an entry for experiment with Id " + form.getId() + " and journal Id " + _journal.getId());
+                return;
             }
 
             ExperimentAnnotations journalCopy = ExperimentAnnotationsManager.getJournalCopy(_experimentAnnotations);
@@ -1950,54 +2212,22 @@ public class PanoramaPublicController extends SpringActionController
                 Journal journal = JournalManager.getJournal(_journalExperiment.getJournalId());
                 errors.reject(ERROR_MSG,"The experiment cannot be resubmitted. It has been copied to " + journal.getName()
                         + ", and the copy is final. The publication link is " + PageFlowUtil.filter(journalCopy.getPublicationLink()));
+                return;
             }
+
+            super.validateForm(form, errors);
         }
 
-        @NotNull
         @Override
-        public URLHelper getSuccessURL(PublishExperimentForm publishExperimentForm)
+        public void addNavTrail(NavTree root)
         {
-            return PanoramaPublicController.getViewExperimentDetailsURL(publishExperimentForm.getId(), getContainer());
+            root.addChild("Resubmit Request");
         }
     }
 
     // ------------------------------------------------------------------------
     // END Action for resetting an entry in panoramapublic.JournalExperiment table
     // ------------------------------------------------------------------------
-
-    @RequiresPermission(AdminPermission.class)
-    public abstract static class JournalExperimentAction extends ConfirmAction<PublishExperimentForm>
-    {
-        protected ExperimentAnnotations _experimentAnnotations;
-        protected Journal _journal;
-
-        public abstract void validateForm(PublishExperimentForm form, Errors errors);
-
-        @Override
-        public void validateCommand(PublishExperimentForm form, Errors errors)
-        {
-            _experimentAnnotations = form.lookupExperiment();
-            if(_experimentAnnotations == null)
-            {
-                errors.reject(ERROR_MSG,"Could not find experiment with Id " + form.getId());
-            }
-
-            ensureCorrectContainer(getContainer(), _experimentAnnotations.getContainer(), getViewContext());
-
-            _journal = form.lookupJournal();
-            if(_journal == null)
-            {
-                errors.reject(ERROR_MSG, "Could not find a journal with Id " + form.getJournalId());
-            }
-
-            if(errors.getErrorCount() > 0)
-            {
-                return;
-            }
-
-            validateForm(form, errors);
-        }
-    }
 
     @RequiresPermission(ReadPermission.class)
     public static class CompleteInstrumentAction extends ReadOnlyApiAction<CompletionFieldForm>
@@ -2090,57 +2320,27 @@ public class PanoramaPublicController extends SpringActionController
 
             if (!hasSkylineDocs(expAnnot))
             {
-                errors.reject(ERROR_MSG, "There are no Skyline documents included in this experiment.  " +
-                        "Please upload one or more Skyline documents to proceed with the submission request.");
+                errors.reject(ERROR_MSG, "There are no Skyline documents included in this experiment.  It cannot be submitted.");
                 return new SimpleErrorView(errors);
             }
 
             boolean validateForPx = ExperimentAnnotationsManager.hasProteomicData(expAnnot, getUser()); // Can get a PX ID only for proteomic data, not small molecule data
-            JournalExperiment je = JournalManager.getLastPublishedRecord(expAnnot.getId());
-            if(je != null)
-            {
-                // If an entry exists for this experiment in the JournalExperiment table it means that the data is being re-submitted.
-                // In this case check for a valid PX submission only if a PX ID was requested in the initial submission.
-                validateForPx = validateForPx && je.isPxidRequested();
-            }
-
             if (validateForPx)
             {
-                SubmissionDataStatus status = SubmissionDataValidator.validateExperiment(expAnnot, form.isSkipMetaDataCheck(), form.isSkipRawDataCheck(), form.isSkipModCheck());
-                if(!status.isValid())
+                SubmissionDataStatus status = SubmissionDataValidator.validateExperiment(expAnnot);
+                form.setValidationStatus(status);
+                if(!status.isComplete())
                 {
-                    JspView view = new JspView("/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp", status, errors);
-                    view.setFrame(WebPartView.FrameType.PORTAL);
-                    view.setTitle("Missing Information in Submission Request");
-                    return view;
+                    return getMissingInformationView(form, errors);
                 }
             }
 
-            if(form.isNotSubmitting())
-            {
-                ActionURL returnUrl = form.getReturnActionURL();
-                if(returnUrl == null)
-                {
-                    return new HtmlView(DIV("Data is valid for a complete ProteomeXchange submission."));
-                }
-                else
-                {
-                    return new HtmlView(DIV("Data is valid for a complete ProteomeXchange submission.", BR(),
-                            new Link.LinkBuilder("Back").href(returnUrl).build()));
-                }
+            String text = validateForPx ? "Data is valid for a complete ProteomeXchange submission." :
+                    "No proteomic data was found in the experiment. It was NOT validated for a ProteomeXchange submission.";
+            ActionURL returnUrl = form.getReturnActionURL();
+            return returnUrl == null ? new HtmlView(DIV(text))
+                    : new HtmlView(DIV(text, BR(), new Link.LinkBuilder("Back").href(returnUrl).build()));
 
-            }
-
-            if(je != null)
-            {
-                // This is a resubmit request
-                return HttpView.redirect(getRePublishExperimentURL(expAnnot.getId(), je.getJournalId(), expAnnot.getContainer()));
-            }
-            else
-            {
-                // This is the first submission request for this data
-                return HttpView.redirect(getPublishExperimentURL(expAnnot.getId(), getContainer(), true, validateForPx));
-            }
         }
 
         @Override
@@ -2148,6 +2348,15 @@ public class PanoramaPublicController extends SpringActionController
         {
             root.addChild("Pre-submission Check");
         }
+    }
+
+    @NotNull
+    private static ModelAndView getMissingInformationView(PreSubmissionCheckForm form, BindException errors)
+    {
+        JspView view = new JspView("/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp", form, errors);
+        view.setFrame(WebPartView.FrameType.PORTAL);
+        view.setTitle("Missing Information in Submission Request");
+        return view;
     }
 
     private static boolean hasSkylineDocs(@NotNull ExperimentAnnotations expAnnot)
@@ -2165,10 +2374,7 @@ public class PanoramaPublicController extends SpringActionController
     public static class PreSubmissionCheckForm extends IdForm
     {
         private boolean _notSubmitting;
-        private boolean _skipRawDataCheck;
-        private boolean _skipMetaDataCheck;
-        private boolean _skipModCheck;
-        private boolean _skipAllChecks;
+        private SubmissionDataStatus _validationStatus;
 
         public boolean isNotSubmitting()
         {
@@ -2180,73 +2386,82 @@ public class PanoramaPublicController extends SpringActionController
             _notSubmitting = notSubmitting;
         }
 
-        public boolean isSkipRawDataCheck()
+        public SubmissionDataStatus getValidationStatus()
         {
-            return _skipAllChecks || _skipRawDataCheck;
+            return _validationStatus;
         }
 
-        public void setSkipRawDataCheck(boolean skipRawDataCheck)
+        public void setValidationStatus(SubmissionDataStatus validationStatus)
         {
-            _skipRawDataCheck = skipRawDataCheck;
-        }
-
-        public boolean isSkipMetaDataCheck()
-        {
-            return _skipAllChecks || _skipMetaDataCheck;
-        }
-
-        public void setSkipMetaDataCheck(boolean skipMetaDataCheck)
-        {
-            _skipMetaDataCheck = skipMetaDataCheck;
-        }
-
-        public boolean isSkipModCheck()
-        {
-            return _skipAllChecks || _skipModCheck;
-        }
-
-        public void setSkipModCheck(boolean skipModCheck)
-        {
-            _skipModCheck = skipModCheck;
-        }
-
-        public boolean isSkipAllChecks()
-        {
-            return _skipAllChecks;
-        }
-
-        public void setSkipAllChecks(boolean skipAllChecks)
-        {
-            _skipAllChecks = skipAllChecks;
+            _validationStatus = validationStatus;
         }
     }
     // ------------------------------------------------------------------------
     // BEGIN Actions for ProteomeXchange
     // ------------------------------------------------------------------------
+    public enum PX_METHOD {GET_ID, VALIDATE, SUBMIT, UPDATE}
+
     @RequiresPermission(AdminOperationsPermission.class)
-    public static class GetPxActionsAction extends SimpleViewAction<PxExportForm>
+    public static class GetPxActionsAction extends FormViewAction<PxActionsForm>
     {
+        private ExperimentAnnotations _expAnnot;
+        private JournalExperiment _journalExperiment;
+        private String _pxResponse;
+
         @Override
-        public ModelAndView getView(PxExportForm form, BindException errors) throws Exception
+        public void validateCommand(PxActionsForm form, Errors errors)
         {
-            if(form.getId() <= 0)
+            int experimentId = form.getId();
+
+            _expAnnot = ExperimentAnnotationsManager.get(experimentId);
+            if(_expAnnot == null)
             {
-                errors.reject(ERROR_MSG, "Invalid experiment annotations ID found in request " + form.getId());
+                errors.reject(ERROR_MSG, "Cannot find experiment with ID " + experimentId);
+                return;
+            }
+
+            ensureCorrectContainer(getContainer(), _expAnnot.getContainer(), getViewContext());
+
+            if(!_expAnnot.isJournalCopy())
+            {
+                errors.reject(ERROR_MSG, "ProteomeXchange actions can only be executed on a Panorama Public copy.");
+                return;
+            }
+
+            _journalExperiment = JournalManager.getRowForJournalCopy(_expAnnot);
+            if(_journalExperiment == null)
+            {
+                errors.reject(ERROR_MSG, "Cannot find a row in JournalExperiment for experiment ID: " + _expAnnot.getId());
+                return;
+            }
+        }
+
+        @Override
+        public ModelAndView getView(PxActionsForm form, boolean reshow, BindException errors)
+        {
+            if(errors.getErrorCount() > 0)
+            {
+                if(!StringUtils.isBlank(_pxResponse))
+                {
+                    errors.addError(new LabKeyError(_pxResponse));
+                }
+                return new SimpleErrorView(errors, true);
+            }
+
+            _expAnnot = ExperimentAnnotationsManager.get(form.getId());
+            if(_expAnnot == null)
+            {
+                errors.reject(ERROR_MSG, "Cannot find experiment with ID " + form.getId());
                 return new SimpleErrorView(errors);
             }
 
-            ExperimentAnnotations expAnnot = ExperimentAnnotationsManager.get(form.getId());
-            if(expAnnot == null)
+            ensureCorrectContainer(getContainer(), _expAnnot.getContainer(), getViewContext());
+
+            if(!reshow)
             {
-                errors.reject(ERROR_MSG,"Cannot find experiment with ID " + form.getId());
-                return new SimpleErrorView(errors);
-            }
-            if(!StringUtils.isBlank(expAnnot.getPublicationLink()) && !StringUtils.isBlank(expAnnot.getCitation()))
-            {
-                form.setPeerReviewed(true);
+                form.setTestDatabase(true);
             }
 
-            form.setTestDatabase(true);
             JspView view = new JspView<>("/org/labkey/panoramapublic/view/publish/pxActions.jsp", form, errors);
             view.setFrame(WebPartView.FrameType.PORTAL);
             view.setTitle("ProteomeXchange Actions");
@@ -2258,17 +2473,205 @@ public class PanoramaPublicController extends SpringActionController
         {
             root.addChild("ProteomeXchange Actions");
         }
+
+        @Override
+        public boolean handlePost(PxActionsForm form, BindException errors) throws ProteomeXchangeServiceException, PxException
+        {
+            PropertyManager.PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(ProteomeXchangeService.PX_CREDENTIALS, false);
+            String pxUser = null;
+            String pxPassword = null;
+            if(map != null)
+            {
+                pxUser = map.get(ProteomeXchangeService.PX_USER);
+                pxPassword = map.get(ProteomeXchangeService.PX_PASSWORD);
+            }
+            if(StringUtils.isBlank(pxUser))
+            {
+                errors.reject(ERROR_MSG, "Cannot find ProteomeXchange username.");
+            }
+            if(StringUtils.isBlank(pxPassword))
+            {
+                errors.reject(ERROR_MSG, "Cannot find ProteomeXchange password.");
+            }
+            if(StringUtils.isBlank(form.getMethod()))
+            {
+                errors.reject(ERROR_MSG, "Did not find a ProteomeXchange method in request.");
+            }
+            if(errors.getErrorCount() > 0)
+            {
+                return false;
+            }
+
+            PX_METHOD method = PX_METHOD.valueOf(form.getMethod());
+            switch (method)
+            {
+                case GET_ID:
+                    assignPxId(form.isTestDatabase(), form.isTestMode(), pxUser, pxPassword, errors);
+                    break;
+                case VALIDATE:
+                    validatePxXml(form.isTestDatabase(), form.getChangeLog(), pxUser, pxPassword, errors);
+                    break;
+                case SUBMIT:
+                    submitPxXml(form.isTestDatabase(), form.isTestMode(), pxUser, pxPassword, errors);
+                    break;
+                case UPDATE:
+                    updatePxXml(form.isTestDatabase(), form.isTestMode(), form.getChangeLog(), pxUser, pxPassword, errors);
+                    break;
+                default: return false;
+            }
+
+            return errors.getErrorCount() == 0;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(PxActionsForm form)
+        {
+            return null;
+        }
+
+        @Override
+        public ModelAndView getSuccessView(PxActionsForm form)
+        {
+            return new HtmlView(
+                    DIV("Sent request to " + form.getMethod(), ".  Request was successful.", BR(),
+                        SPAN("Response from PX server: "), BR(),
+                        DIV(at(style, "white-space: pre-wrap;margin:10px 0px 10px 0px;"),
+                            _pxResponse),
+                    DIV(new Link.LinkBuilder("Back to folder").href(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(_expAnnot.getContainer())))));
+        }
+
+        private PxXml createPxXml(ExperimentAnnotations expAnnot, JournalExperiment je, String pxChanageLog) throws PxException
+        {
+            // Generate the PX XML
+            int pxVersion = PxXmlManager.getNextVersion(_journalExperiment.getId());
+            PxXmlWriter annWriter;
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+            {
+                PxExperimentAnnotations pxInfo = new PxExperimentAnnotations(expAnnot, je);
+                pxInfo.setPxChangeLog(pxChanageLog);
+                pxInfo.setVersion(pxVersion);
+                annWriter = new PxXmlWriter(baos);
+                annWriter.write(pxInfo);
+
+                String xml = baos.toString(StandardCharsets.UTF_8);
+                return new PxXml(je.getId(), xml, pxVersion, pxChanageLog);
+            }
+            catch (IOException e)
+            {
+                throw new PxException("Error creating PX XML.", e);
+            }
+        }
+
+        private File writePxXmlFile(String xmlString) throws PxException
+        {
+            File xml = getLocalFile(getContainer(), "px.xml");
+
+            try (PrintWriter out = new PrintWriter(new FileWriter(xml, StandardCharsets.UTF_8)))
+            {
+                out.write(xmlString);
+            }
+            catch (IOException e)
+            {
+                throw new PxException("Error writing PX XML.", e);
+            }
+            return xml;
+        }
+
+        public void assignPxId(boolean useTestDb, boolean testMode, String pxUser, String pxPassword, BindException errors) throws ProteomeXchangeServiceException
+        {
+            _pxResponse = ProteomeXchangeService.getPxIdResponse(useTestDb, pxUser, pxPassword);
+            String pxid = ProteomeXchangeService.parsePxIdFromResponse(_pxResponse);
+            if(pxid != null)
+            {
+                // Save the PX ID with the experiment.
+                _expAnnot.setPxid(pxid);
+                ExperimentAnnotationsManager.updatePxId(_expAnnot, pxid);
+            }
+            else
+            {
+                errors.reject(ERROR_MSG, "Could not parse PXD accession from the response.");
+            }
+        }
+
+        private void validatePxXml(boolean useTestDb, String pxChangeLog, String pxUser, String pxPassword, BindException errors) throws PxException, ProteomeXchangeServiceException
+        {
+            File xmlFile = writePxXmlFile(createPxXml(_expAnnot, _journalExperiment, pxChangeLog).getXml());
+            _pxResponse = ProteomeXchangeService.validatePxXml(xmlFile, useTestDb, pxUser, pxPassword);
+            if(ProteomeXchangeService.responseHasErrors(_pxResponse))
+            {
+                errors.reject(ERROR_MSG, "PX XML is could not be validated. See response for details.");
+            }
+        }
+
+        private void submitPxXml(boolean useTestDb, boolean testMode, String pxUser, String pxPassword, BindException errors) throws ProteomeXchangeServiceException, PxException
+        {
+            submitPxXml(useTestDb, testMode,null, pxUser, pxPassword, errors);
+        }
+
+        private void submitPxXml(boolean useTestDb, boolean testMode, String pxChangeLog, String pxUser, String pxPassword, BindException errors) throws ProteomeXchangeServiceException, PxException
+        {
+            PxXml pxXml = createPxXml(_expAnnot, _journalExperiment, pxChangeLog);
+            File xmlFile = writePxXmlFile(pxXml.getXml());
+            _pxResponse = ProteomeXchangeService.submitPxXml(xmlFile, useTestDb, pxUser, pxPassword);
+            if(ProteomeXchangeService.responseHasErrors(_pxResponse))
+            {
+                errors.reject(ERROR_MSG, "PX XML could not be submitted. See response for details.");
+            }
+            else
+            {
+                PxXmlManager.save(pxXml, getUser());
+            }
+        }
+
+        private void updatePxXml(boolean useTestDb, boolean testMode, String pxChangeLog, String pxUser, String pxPassword, BindException errors) throws PxException, ProteomeXchangeServiceException
+        {
+            if(StringUtils.isBlank(pxChangeLog))
+            {
+                errors.reject(ERROR_MSG, "Change log cannot be empty.");
+                return;
+            }
+            submitPxXml(useTestDb, testMode, pxChangeLog, pxUser, pxPassword, errors);
+        }
+
+        private static File getLocalFile(Container container, String fileName) throws PxException
+        {
+            java.nio.file.Path fileRoot = FileContentService.get().getFileRootPath(container, FileContentService.ContentType.files);
+            if(fileRoot == null)
+            {
+                throw new PxException("Error writing PX XML.  Could not find file root for container " + container);
+            }
+            if (FileUtil.hasCloudScheme(fileRoot))
+            {
+                PipeRoot root = PipelineService.get().getPipelineRootSetting(container);
+                if (root != null)
+                {
+                    LocalDirectory localDirectory = LocalDirectory.create(root, PanoramaPublicModule.NAME);
+                    return new File(localDirectory.getLocalDirectoryFile(), fileName);
+                }
+                else
+                {
+                    throw new PxException("Error writing PX XML.  Pipeline root not found for container " + container);
+                }
+            }
+            else
+            {
+                return fileRoot.resolve(fileName).toFile();
+            }
+        }
     }
 
     public static class PxExperimentAnnotations
     {
         private final ExperimentAnnotations _experimentAnnotations;
-        private final PxExportForm _form;
+        private final JournalExperiment _journalExperiment;
+        private String _pxChangeLog;
+        private int _version;
+        private boolean _useTestDb;
 
-        public PxExperimentAnnotations(ExperimentAnnotations experimentAnnotations, PxExportForm form)
+        public PxExperimentAnnotations(ExperimentAnnotations experimentAnnotations, JournalExperiment je)
         {
             _experimentAnnotations = experimentAnnotations;
-            _form = form;
+            _journalExperiment = je;
         }
 
         public ExperimentAnnotations getExperimentAnnotations()
@@ -2276,17 +2679,47 @@ public class PanoramaPublicController extends SpringActionController
             return _experimentAnnotations;
         }
 
-        public PxExportForm getForm()
+        public JournalExperiment getJournalExperiment()
         {
-            return _form;
+            return _journalExperiment;
+        }
+
+        public String getPxChangeLog()
+        {
+            return _pxChangeLog;
+        }
+
+        public void setPxChangeLog(String pxChangeLog)
+        {
+            _pxChangeLog = pxChangeLog;
+        }
+
+        public int getVersion()
+        {
+            return _version;
+        }
+
+        public void setVersion(int version)
+        {
+            _version = version;
+        }
+
+        public boolean isUseTestDb()
+        {
+            return _useTestDb;
+        }
+
+        public void setUseTestDb(boolean useTestDb)
+        {
+            _useTestDb = useTestDb;
         }
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public static class ExportPxXmlAction extends SimpleStreamAction<PxExportForm>
+    public static class ExportPxXmlAction extends SimpleStreamAction<PxActionsForm>
     {
         @Override
-        public void render(PxExportForm form, BindException errors, PrintWriter out) throws Exception
+        public void render(PxActionsForm form, BindException errors, PrintWriter out) throws Exception
         {
             int experimentId = form.getId();
             if(experimentId <= 0)
@@ -2302,60 +2735,27 @@ public class PanoramaPublicController extends SpringActionController
                 return;
             }
 
-            if(!expAnnot.getContainer().equals(getContainer()))
+            JournalExperiment je = expAnnot.isJournalCopy() ? JournalManager.getRowForJournalCopy(expAnnot) : JournalManager.getLastPublishedRecord(experimentId);
+            if(je == null)
             {
-                ActionURL redirect = getViewContext().cloneActionURL();
-                redirect.setContainer(expAnnot.getContainer());
-                throw new RedirectException(redirect);
+                out.write("Cannot find a row in JournalExperiment for experiment ID " + experimentId);
             }
 
+            ensureCorrectContainer(getContainer(), expAnnot.getContainer(), getViewContext());
+
             PxXmlWriter annWriter = new PxXmlWriter(out);
-            annWriter.write(new PxExperimentAnnotations(expAnnot, form));
+            PxExperimentAnnotations pxInfo = new PxExperimentAnnotations(expAnnot, je);
+            pxInfo.setVersion(PxXmlManager.getNextVersion(je.getId()));
+            annWriter.write(pxInfo);
         }
     }
 
-    public static class PxExportForm extends ExperimentIdForm
+    public static class PxActionsForm extends ExperimentIdForm
     {
-        private boolean _peerReviewed;
-        private String _publicationId;
-        private String _publicationReference;
         private boolean _testDatabase;
-        private String _pxUserName;
-        private String _pxPassword;
+        private boolean _testMode;
         private String _changeLog;
-        private String _labHeadName;
-        private String _labHeadEmail;
-        private String _labHeadAffiliation;
-
-        public boolean getPeerReviewed()
-        {
-            return _peerReviewed;
-        }
-
-        public void setPeerReviewed(boolean peerReviewed)
-        {
-            _peerReviewed = peerReviewed;
-        }
-
-        public String getPublicationId()
-        {
-            return _publicationId;
-        }
-
-        public void setPublicationId(String publicationId)
-        {
-            _publicationId = publicationId;
-        }
-
-        public String getPublicationReference()
-        {
-            return _publicationReference;
-        }
-
-        public void setPublicationReference(String publicationReference)
-        {
-            _publicationReference = publicationReference;
-        }
+        private String _method;
 
         public boolean isTestDatabase()
         {
@@ -2367,24 +2767,14 @@ public class PanoramaPublicController extends SpringActionController
             _testDatabase = testDatabase;
         }
 
-        public String getPxUserName()
+        public boolean isTestMode()
         {
-            return _pxUserName;
+            return _testMode;
         }
 
-        public void setPxUserName(String pxUserName)
+        public void setTestMode(boolean testMode)
         {
-            _pxUserName = pxUserName;
-        }
-
-        public String getPxPassword()
-        {
-            return _pxPassword;
-        }
-
-        public void setPxPassword(String pxPassword)
-        {
-            _pxPassword = pxPassword;
+            _testMode = testMode;
         }
 
         public String getChangeLog()
@@ -2397,274 +2787,22 @@ public class PanoramaPublicController extends SpringActionController
             _changeLog = changeLog;
         }
 
-        public String getLabHeadName()
+        public String getMethod()
         {
-            return _labHeadName;
+            return _method;
         }
 
-        public void setLabHeadName(String labHeadName)
+        public void setMethod(String method)
         {
-            _labHeadName = labHeadName;
-        }
-
-        public String getLabHeadEmail()
-        {
-            return _labHeadEmail;
-        }
-
-        public void setLabHeadEmail(String labHeadEmail)
-        {
-            _labHeadEmail = labHeadEmail;
-        }
-
-        public String getLabHeadAffiliation()
-        {
-            return _labHeadAffiliation;
-        }
-
-        public void setLabHeadAffiliation(String labHeadAffiliation)
-        {
-            _labHeadAffiliation = labHeadAffiliation;
-        }
-    }
-
-    @RequiresPermission(AdminOperationsPermission.class)
-    public abstract static class PxServiceMethodAction <FormType extends PxExportForm> extends SimpleViewAction<FormType>
-    {
-        public PxServiceMethodAction(Class<FormType> formClass)
-        {
-            super(formClass);
-        }
-
-        @Override
-        public ModelAndView getView(FormType form, BindException errors) throws Exception
-        {
-            int experimentId = form.getId();
-            if(experimentId <= 0)
-            {
-                errors.reject(ERROR_MSG, "Invalid experiment Id found in request: " + experimentId);
-                return new SimpleErrorView(errors, true);
-            }
-
-            ExperimentAnnotations expAnnot = ExperimentAnnotationsManager.get(experimentId);
-            if(expAnnot == null)
-            {
-                errors.reject(ERROR_MSG, "Cannot find experiment with ID " + experimentId);
-                return new SimpleErrorView(errors, true);
-            }
-
-            String pxUser = form.getPxUserName();
-            if(StringUtils.isBlank(pxUser))
-            {
-                errors.reject(ERROR_MSG, "ProteomeXchange username cannot be blank.");
-            }
-            String pxPassword = form.getPxPassword();
-            if(StringUtils.isBlank(pxPassword))
-            {
-                errors.reject(ERROR_MSG, "ProteomeXchange password cannot be blank.");
-            }
-
-            if(errors.hasErrors())
-            {
-                return new SimpleErrorView(errors, true);
-            }
-
-            return getHtmlView(expAnnot, form, pxUser, pxPassword);
-        }
-
-        protected File writePxXmlFile(ExperimentAnnotations expAnnot, FormType form) throws PxException
-        {
-            File xml = getLocalFile(getContainer(), "px.xml");
-            // Generate the PX XML
-            PxXmlWriter annWriter;
-            try (OutputStream out = new FileOutputStream(xml))
-            {
-                annWriter = new PxXmlWriter(out);
-                annWriter.write(new PxExperimentAnnotations(expAnnot, form));
-            }
-            catch (IOException e)
-            {
-                throw new PxException("Error writing PX XML file.", e);
-            }
-            return xml;
-        }
-
-        public abstract HtmlView getHtmlView(ExperimentAnnotations expAnnot, FormType form, String pxUser, String pxPassword) throws PxException, ProteomeXchangeServiceException;
-    }
-
-    private static File getLocalFile(Container container, String fileName) throws PxException
-    {
-        java.nio.file.Path fileRoot = FileContentService.get().getFileRootPath(container, FileContentService.ContentType.files);
-        if(fileRoot == null)
-        {
-            throw new PxException("Error writing PX XML.  Could not find file root for container " + container);
-        }
-        if (FileUtil.hasCloudScheme(fileRoot))
-        {
-            PipeRoot root = PipelineService.get().getPipelineRootSetting(container);
-            if (root != null)
-            {
-                LocalDirectory localDirectory = LocalDirectory.create(root, PanoramaPublicModule.NAME);
-                return new File(localDirectory.getLocalDirectoryFile(), fileName);
-            }
-            else
-            {
-                throw new PxException("Error writing PX XML.  Pipeline root not found for container " + container);
-            }
-        }
-        else
-        {
-            return fileRoot.resolve(fileName).toFile();
-        }
-    }
-
-    @RequiresPermission(AdminOperationsPermission.class)
-    public static class ValidatePxXmlAction extends PxServiceMethodAction<PxExportForm>
-    {
-        public ValidatePxXmlAction()
-        {
-            super(PxExportForm.class);
-        }
-
-        @Override
-        public HtmlView getHtmlView(ExperimentAnnotations expAnnot, PxExportForm form, String pxUser, String pxPassword) throws PxException, ProteomeXchangeServiceException
-        {
-            File xml = writePxXmlFile(expAnnot, form);
-            String response = ProteomeXchangeService.validatePxXml(xml, form.isTestDatabase(), pxUser, pxPassword);
-            StringBuilder html = new StringBuilder();
-            html.append("<p>PX XML has been created at ").append(PageFlowUtil.filter(xml.getPath())).append(".</p>");
-            html.append("<p>Sent request to validate XML.</p>");
-            html.append("<p>Response was: </p>");
-            html.append("<p style=\"white-space: pre-wrap;\">").append(PageFlowUtil.filter(response)).append("</p>");
-            return new HtmlView(html.toString());
-        }
-        @Override
-        public void addNavTrail(NavTree root)
-        {
-            root.addChild("Validate ProteomeXchange XML");
-        }
-    }
-
-    @RequiresPermission(AdminOperationsPermission.class)
-    public static class SubmitPxXmlAction extends PxServiceMethodAction<PxExportForm>
-    {
-        public SubmitPxXmlAction()
-        {
-            super(PxExportForm.class);
-        }
-
-        @Override
-        public HtmlView getHtmlView(ExperimentAnnotations expAnnot, PxExportForm form, String pxUser, String pxPassword) throws PxException, ProteomeXchangeServiceException
-        {
-            File xml = writePxXmlFile(expAnnot, form);
-            String response = ProteomeXchangeService.submitPxXml(xml, form.isTestDatabase(), pxUser, pxPassword);
-            StringBuilder html = new StringBuilder();
-            html.append("<p>PX XML has been created at ").append(PageFlowUtil.filter(xml.getPath())).append(".</p>");
-            html.append("<p>Submitted XML to ProteomeXchange.</p>");
-            html.append("<p>Response was: </p>");
-            html.append("<p style=\"white-space: pre-wrap;\">").append(PageFlowUtil.filter(response)).append("</p>");
-            return new HtmlView(html.toString());
-        }
-
-        @Override
-        public void addNavTrail(NavTree root)
-        {
-            root.addChild("Submit ProteomeXchange XML");
-        }
-    }
-
-    @RequiresPermission(AdminOperationsPermission.class)
-    public static class UpdatePxXmlAction extends SubmitPxXmlAction
-    {
-        @Override
-        public void validate(PxExportForm form, BindException errors)
-        {
-            if(StringUtils.isBlank(form.getChangeLog()))
-            {
-                errors.reject(ERROR_MSG, "Change log cannot be empty.");
-            }
-            super.validate(form, errors);
-        }
-    }
-
-    @RequiresPermission(AdminOperationsPermission.class)
-    public static class SavePxIdAction extends PxServiceMethodAction<SavePxIdForm>
-    {
-        public SavePxIdAction()
-        {
-            super(SavePxIdForm.class);
-        }
-
-        @Override
-        public HtmlView getHtmlView(ExperimentAnnotations expAnnot, SavePxIdForm form, String pxUser, String pxPassword) throws PxException, ProteomeXchangeServiceException
-        {
-            StringBuilder html = new StringBuilder();
-            if(expAnnot.getPxid() != null && !form.isOverride())
-            {
-                html.append("Experiment ID ").append(expAnnot.getId()).append(" is associated with PX ID ").append(expAnnot.getPxid()).append(".");
-                html.append("<div style=\"margin-top:20px;\">");
-                ActionURL overrideUrl = getViewContext().getActionURL().clone();
-                overrideUrl.addParameter("id", expAnnot.getId()).addParameter("override", true).addParameter("testDatabase", form.isTestDatabase());
-                html.append(PageFlowUtil.button("Generate New PX ID").href(overrideUrl).addClass("primary"));
-                html.append("</div>");
-            }
-            else
-            {
-                String response = ProteomeXchangeService.getPxIdResponse(form.isTestDatabase(), pxUser, pxPassword);
-
-                html.append("Response from PX Server:");
-                html.append("<div style=\"white-space: pre-wrap;margin:10px 0px 10px 0px;\">").append(PageFlowUtil.filter(response)).append("</div>");
-
-                String pxid = ProteomeXchangeService.parsePxIdFromResponse(response);
-                if(pxid != null)
-                {
-                    // Save the PX ID with the experiment.
-                    expAnnot.setPxid(pxid);
-                    ExperimentAnnotationsManager.updatePxId(expAnnot, pxid);
-
-                    html.append("<p>");
-                    html.append("PX ID: ").append("<span style=\"font-weight-bold;color:red;\">").append(pxid).append("</span> saved for experiment ").append(expAnnot.getId());
-                    html.append("</p>");
-                }
-                else
-                {
-                    html.append("<p>");
-                    html.append("<span style=\"font-weight-bold;color:red;\"> ERROR getting PX ID.</span>");
-                    html.append("</p>");
-                }
-            }
-
-            html.append("<br>");
-            html.append(PageFlowUtil.link("Back to PX Actions").href(new ActionURL(GetPxActionsAction.class, getContainer()).addParameter("id", expAnnot.getId())));
-            return new HtmlView(html.toString());
-        }
-        @Override
-        public void addNavTrail(NavTree root)
-        {
-            root.addChild("Save ProteomeXchange ID");
-        }
-    }
-
-    public static class SavePxIdForm extends PxExportForm
-    {
-        private boolean _override;
-
-        public boolean isOverride()
-        {
-            return _override;
-        }
-
-        public void setOverride(boolean override)
-        {
-            _override = override;
+            _method = method;
         }
     }
 
     @RequiresPermission(AdminPermission.class)
-    public static class PxXmlSummaryAction extends SimpleViewAction<PxExportForm>
+    public static class PxXmlSummaryAction extends SimpleViewAction<PxActionsForm>
     {
         @Override
-        public ModelAndView getView(PxExportForm form, BindException errors) throws Exception
+        public ModelAndView getView(PxActionsForm form, BindException errors) throws Exception
         {
             int experimentId = form.getId();
             if(experimentId <= 0)
@@ -2682,9 +2820,20 @@ public class PanoramaPublicController extends SpringActionController
 
             ensureCorrectContainer(getContainer(), expAnnot.getContainer(), getViewContext());
 
+            JournalExperiment je = expAnnot.isJournalCopy() ? JournalManager.getRowForJournalCopy(expAnnot) : JournalManager.getLastPublishedRecord(experimentId);
+            if(je == null)
+            {
+                errors.reject(ERROR_MSG, "Cannot find a row in JournalExperiment for experiment ID: " + experimentId);
+                return new SimpleErrorView(errors, true);
+            }
+
             StringBuilder summaryHtml = new StringBuilder();
             PxHtmlWriter writer = new PxHtmlWriter(summaryHtml);
-            writer.write(new PxExperimentAnnotations(expAnnot, form));
+            PxExperimentAnnotations pxInfo = new PxExperimentAnnotations(expAnnot, je);
+            pxInfo.setUseTestDb(form.isTestDatabase());
+            pxInfo.setPxChangeLog(form.getChangeLog());
+            pxInfo.setVersion(PxXmlManager.getNextVersion(je.getId()));
+            writer.write(pxInfo);
 
             return new HtmlView(summaryHtml.toString());
         }
@@ -2779,6 +2928,11 @@ public class PanoramaPublicController extends SpringActionController
                     errors.reject(ERROR_MSG, "Publication Link does not appear to be valid. Links should begin with either http or https.");
                     return false;
                 }
+            }
+            if(!StringUtils.isBlank(_expAnnot.getPubmedId()) && !_expAnnot.getPubmedId().matches(PUBMED_ID))
+            {
+                errors.reject(ERROR_MSG, "PubMed ID should be a 1 to 8 digit number.");
+                return false;
             }
 
             // These two values are not set automatically in the form.  They have to be set explicitly.
@@ -3170,6 +3324,12 @@ public class PanoramaPublicController extends SpringActionController
                     errors.reject(ERROR_MSG, "Publication Link does not appear to be valid. Links should begin with either http or https.");
                     return false;
                 }
+            }
+
+            if(!StringUtils.isBlank(form.getBean().getPubmedId()) && !form.getBean().getPubmedId().matches(PUBMED_ID))
+            {
+                errors.reject(ERROR_MSG, "PubMed ID should be a 1 to 8 digit number");
+                return false;
             }
 
             // User is updating the experiment metadata. If this data has already been submitted, and a PX ID was requested,
@@ -3601,23 +3761,23 @@ public class PanoramaPublicController extends SpringActionController
         return result;
     }
 
-    public static ActionURL getPublishExperimentURL(int experimentAnnotationsId, Container container)
-    {
-        return getPublishExperimentURL(experimentAnnotationsId, container, true, true);
-    }
-
     public static ActionURL getPublishExperimentURL(int experimentAnnotationsId, Container container, boolean keepPrivate, boolean getPxId)
     {
-        ActionURL result = new ActionURL(ViewPublishExperimentFormAction.class, container);
+        ActionURL result = new ActionURL(PublishExperimentAction.class, container);
         result.addParameter("id", experimentAnnotationsId);
         result.addParameter("keepPrivate", keepPrivate);
         result.addParameter("getPxid", getPxId);
         return result;
     }
 
-    public static ActionURL getPrePublishExperimentCheckURL(int experimentAnnotationsId, Container container)
+    public static ActionURL getUpdateJournalExperimentURL(int experimentAnnotationsId, int journalId, Container container, boolean keepPrivate, boolean getPxId)
     {
-        return getPrePublishExperimentCheckURL(experimentAnnotationsId, container, false);
+        ActionURL result = new ActionURL(UpdateJournalExperimentAction.class, container);
+        result.addParameter("id", experimentAnnotationsId);
+        result.addParameter("journalId", journalId);
+        result.addParameter("keepPrivate", keepPrivate);
+        result.addParameter("getPxid", getPxId);
+        return result;
     }
 
     public static ActionURL getPrePublishExperimentCheckURL(int experimentAnnotationsId, Container container, boolean notSubmitting)
@@ -3628,11 +3788,13 @@ public class PanoramaPublicController extends SpringActionController
         return result;
     }
 
-    public static ActionURL getRePublishExperimentURL(int experimentAnnotationsId, int journalId, Container container)
+    public static ActionURL getRePublishExperimentURL(int experimentAnnotationsId, int journalId, Container container, boolean keepPrivate , boolean getPxId)
     {
         ActionURL result = new ActionURL(RepublishJournalExperimentAction.class, container);
         result.addParameter("id", experimentAnnotationsId);
         result.addParameter("journalId", journalId);
+        result.addParameter("keepPrivate", keepPrivate);
+        result.addParameter("getPxid", getPxId);
         return result;
     }
 
@@ -3660,11 +3822,7 @@ public class PanoramaPublicController extends SpringActionController
                 new JournalGroupDetailsAction(),
                 new DeleteJournalGroupAction(),
                 new GetPxActionsAction(),
-                new ExportPxXmlAction(),
-                new ValidatePxXmlAction(),
-                new SavePxIdAction(),
-                new SubmitPxXmlAction(),
-                new UpdatePxXmlAction()
+                new ExportPxXmlAction()
             );
 
             // @AdminConsoleAction

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
@@ -63,6 +63,11 @@ public class PanoramaPublicManager
         return getSchema().getTable(PanoramaPublicSchema.TABLE_JOURNAL_EXPERIMENT);
     }
 
+    public static TableInfo getTableInfoPxXml()
+    {
+        return getSchema().getTable(PanoramaPublicSchema.TABLE_PX_XML);
+    }
+
     public static ITargetedMSRun getRunByLsid(String lsid, Container container)
     {
         return TargetedMSService.get().getRunByLsid(lsid, container);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -65,7 +65,7 @@ public class PanoramaPublicModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.003;
+        return 20.005;
     }
 
     @Override

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -183,6 +183,10 @@ public class PanoramaPublicNotification
         text.append(NL).append("* Experiment ID: ").append(exptAnnotations.getId());
         text.append(NL).append("* Reviewer Account Requested: ").append(bold(journalExperiment.isKeepPrivate() ? "Yes" : "No"));
         text.append(NL).append("* PX ID Requested: ").append(bold(journalExperiment.isPxidRequested() ? "Yes" : "No"));
+        if(journalExperiment.isIncompletePxSubmission())
+        {
+            text.append(" (Incomplete Submission)");
+        }
         text.append(NL).append("* Access URL: ").append(journalExperiment.getShortAccessUrl().renderShortURL());
         text.append(NL).append("* User Folder: ").append(getContainerLink(exptAnnotations.getContainer()));
         text.append(NL).append("* **[[Copy Link](").append(journalExperiment.getShortCopyUrl().renderShortURL()).append(")]**");
@@ -270,77 +274,60 @@ public class PanoramaPublicNotification
     }
 
     public static String getExperimentCopiedEmailBody(ExperimentAnnotations sourceExperiment,
-                                   ExperimentAnnotations targetExperiment,
-                                   JournalExperiment jExperiment,
-                                   Journal journal,
-                                   User reviewer,
-                                   String reviewerPassword,
-                                   String toUserName,
-                                   String fromUserName)
-    {
-        return getExperimentCopiedEmailBody(sourceExperiment, targetExperiment, jExperiment, journal, reviewer, reviewerPassword, toUserName, fromUserName, false);
-    }
-
-    public static String getExperimentReCopiedEmailBody(ExperimentAnnotations sourceExperiment,
-                                                      ExperimentAnnotations targetExperiment,
-                                                      JournalExperiment jExperiment,
-                                                      Journal journal,
-                                                      String toUserName,
-                                                      String fromUserName)
-    {
-        return getExperimentCopiedEmailBody(sourceExperiment, targetExperiment, jExperiment, journal, null, null, toUserName, fromUserName, true);
-    }
-
-    public static String getExperimentCopiedEmailBody(ExperimentAnnotations sourceExperiment,
                                                       ExperimentAnnotations targetExperiment,
                                                       JournalExperiment jExperiment,
                                                       Journal journal,
                                                       User reviewer,
                                                       String reviewerPassword,
-                                                      String toUserName,
-                                                      String fromUserName,
+                                                      User toUser,
+                                                      User fromUser,
                                                       boolean recopy)
     {
         String journalName = journal.getName();
 
         StringBuilder emailMsg = new StringBuilder();
-        emailMsg.append("Dear ").append(toUserName).append(",")
+        emailMsg.append("Dear ").append(getUserName(toUser)).append(",")
                 .append(NL2);
         if(!recopy)
         {
             emailMsg.append("Thank you for your request to submit data to ").append(journalName).append(". ");
         }
         emailMsg.append(String.format("Your data has been %scopied, and the access URL (", recopy ? "re" : "")).append(targetExperiment.getShortUrl().renderShortURL()).append(")")
-                .append(" now links to the copy on ").append(journalName).append(".")
+                .append(String.format(" now links to the %scopy on ", recopy ? "new " : "")).append(journalName).append(".")
                 .append(" Please take a moment to verify that the copy is accurate.")
                 .append(" Let us know right away if you notice any discrepancies.");
 
 
-        if(jExperiment.isKeepPrivate())
+        if(reviewer != null)
         {
-            if(!recopy)
-            {
-                emailMsg.append(NL2)
-                        .append("As requested, your data on ").append(journalName).append(" is private.  Here are the reviewer account details:")
-                        .append(NL).append("Email: ").append(reviewer.getEmail())
-                        .append(NL).append("Password: ").append(reviewerPassword);
-            }
-            else
-            {
-                emailMsg.append(NL2).append("As requested, your data on ").append(journalName).append(" is private.  The reviewer account details remain unchanged.");
-            }
+            emailMsg.append(NL2)
+                    .append("As requested, your data on ").append(journalName).append(" is private.  Here are the reviewer account details:")
+                    .append(NL).append("Email: ").append(reviewer.getEmail())
+                    .append(NL).append("Password: ").append(reviewerPassword);
         }
         else
         {
-            emailMsg.append(NL2).append("As requested, your data on ").append(journalName).append(" has been made public.");
+            if(jExperiment.isKeepPrivate() && recopy)
+            {
+                emailMsg.append(NL2).append("As requested, your data on ").append(journalName).append(" is private.  The reviewer account details remain unchanged.");
+            }
+            else
+            {
+                emailMsg.append(NL2).append("As requested, your data on ").append(journalName).append(" has been made public.");
+            }
         }
 
-        if(targetExperiment.getPxid() != null && !recopy)
+        if(targetExperiment.getPxid() != null)
         {
             emailMsg.append(NL2)
                     .append("The ProteomeXchange ID reserved for your data is:")
                     .append(NL).append(targetExperiment.getPxid())
                     .append(" (http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=").append(targetExperiment.getPxid()).append(")");
+
+            if(jExperiment.isIncompletePxSubmission())
+            {
+                emailMsg.append(NL).append("The data will be submitted as \"supported by repository but incomplete data and/or metadata\" when it is made public on ProteomeXchange.");
+            }
         }
 
         emailMsg.append(NL2)
@@ -357,19 +344,20 @@ public class PanoramaPublicNotification
         }
 
         emailMsg.append(NL2).append("Best regards,");
+        String fromUserName = getUserName(fromUser);
         if(StringUtils.isBlank(fromUserName))
         {
             emailMsg.append(NL).append("The Panorama Public Team");
         }
         else
         {
-            emailMsg.append(NL).append(fromUserName).append(NL).append("(For the Panorama Public Team)");
+            emailMsg.append(NL).append(fromUserName);
         }
 
         // Add submission details
         emailMsg.append(NL2).append(NL)
                 .append("Submission Details:")
-                .append("Experiment ID: ").append(sourceExperiment.getId())
+                .append(NL).append("Experiment ID: ").append(sourceExperiment.getId())
                 .append(NL).append("Reviewer account requested: ").append(jExperiment.isKeepPrivate() ? "Yes" : "No")
                 .append(NL).append("PX ID requested: ").append(jExperiment.isPxidRequested() ? "Yes" : "No")
                 .append(NL).append("Short Access URL: ").append(targetExperiment.getShortUrl().renderShortURL())

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -369,7 +369,7 @@ public class PanoramaPublicNotification
         // Add submission details
         emailMsg.append(NL2).append(NL)
                 .append("Submission Details:")
-                .append("Experiment ID: ").append(sourceExperiment.getId())
+                .append(NL).append("Experiment ID: ").append(sourceExperiment.getId())
                 .append(NL).append("Reviewer account requested: ").append(jExperiment.isKeepPrivate() ? "Yes" : "No")
                 .append(NL).append("PX ID requested: ").append(jExperiment.isPxidRequested() ? "Yes" : "No")
                 .append(NL).append("Short Access URL: ").append(targetExperiment.getShortUrl().renderShortURL())

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -16,12 +16,14 @@
 
 package org.labkey.panoramapublic;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.module.Module;
@@ -44,6 +46,7 @@ public class PanoramaPublicSchema extends UserSchema
     public static final String TABLE_JOURNAL = "Journal";
     public static final String TABLE_JOURNAL_EXPERIMENT = "JournalExperiment";
     public static final String TABLE_EXPERIMENT_ANNOTATIONS = "ExperimentAnnotations";
+    public static final String TABLE_PX_XML = "PxXml";
 
     public PanoramaPublicSchema(User user, Container container)
     {
@@ -93,7 +96,56 @@ public class PanoramaPublicSchema extends UserSchema
             ContainerForeignKey.initColumn(supportContainerCol, this);
             return result;
         }
+
+        if(TABLE_PX_XML.equalsIgnoreCase(name))
+        {
+            return getFilteredPxXmlTable(name, cf);
+        }
         return null;
+    }
+
+    @NotNull
+    private TableInfo getFilteredPxXmlTable(String name, ContainerFilter cf)
+    {
+        FilteredTable<PanoramaPublicSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf)
+        {
+            @Override
+            protected void applyContainerFilter(ContainerFilter filter)
+            {
+                // Don't apply the container filter normally, let us apply it in our wrapper around the normally generated SQL
+            }
+
+            @Override
+            public SQLFragment getFromSQL(String alias)
+            {
+                // This table does not have a Container column so we will join it to the JournalExperiment and ExperimentAnnotations
+                // tables to filter by the Container of the copied experiment.
+                SQLFragment sql = new SQLFragment("(SELECT X.* FROM ");
+                sql.append(super.getFromSQL("X"));
+                sql.append(" ");
+
+                if (getContainerFilter() != ContainerFilter.EVERYTHING)
+                {
+                    SQLFragment joinToExpAnnotSql = new SQLFragment("INNER JOIN ");
+                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoJournalExperiment(), "je");
+                    joinToExpAnnotSql.append(" ON (je.id = JournalExperimentId) ");
+                    joinToExpAnnotSql.append(" INNER JOIN ");
+                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
+                    joinToExpAnnotSql.append(" ON (exp.id = je.CopiedExperimentId) ");
+
+                    sql.append(joinToExpAnnotSql);
+
+                    sql.append(" WHERE ");
+                    sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("exp.Container"), getContainer()));
+                }
+                sql.append(") ");
+                sql.append(alias);
+
+                return sql;
+            }
+        };
+        result.wrapAllColumns(true);
+        return result;
     }
 
     @Override
@@ -103,6 +155,7 @@ public class PanoramaPublicSchema extends UserSchema
         hs.add(TABLE_JOURNAL);
         hs.add(TABLE_JOURNAL_EXPERIMENT);
         hs.add(TABLE_EXPERIMENT_ANNOTATIONS);
+        hs.add(TABLE_PX_XML);
 
         return hs;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -16,12 +16,14 @@
 
 package org.labkey.panoramapublic;
 
+import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.module.Module;
@@ -44,6 +46,7 @@ public class PanoramaPublicSchema extends UserSchema
     public static final String TABLE_JOURNAL = "Journal";
     public static final String TABLE_JOURNAL_EXPERIMENT = "JournalExperiment";
     public static final String TABLE_EXPERIMENT_ANNOTATIONS = "ExperimentAnnotations";
+    public static final String TABLE_PX_XML = "PxXml";
 
     public PanoramaPublicSchema(User user, Container container)
     {
@@ -94,7 +97,56 @@ public class PanoramaPublicSchema extends UserSchema
             ContainerForeignKey.initColumn(supportContainerCol, this);
             return result;
         }
+
+        if(TABLE_PX_XML.equalsIgnoreCase(name))
+        {
+            return getFilteredPxXmlTable(name, cf);
+        }
         return null;
+    }
+
+    @NotNull
+    private TableInfo getFilteredPxXmlTable(String name, ContainerFilter cf)
+    {
+        FilteredTable<PanoramaPublicSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf)
+        {
+            @Override
+            protected void applyContainerFilter(ContainerFilter filter)
+            {
+                // Don't apply the container filter normally, let us apply it in our wrapper around the normally generated SQL
+            }
+
+            @Override
+            public SQLFragment getFromSQL(String alias)
+            {
+                // This table does not have a Container column so we will join it to the JournalExperiment and ExperimentAnnotations
+                // tables to filter by the Container of the copied experiment.
+                SQLFragment sql = new SQLFragment("(SELECT X.* FROM ");
+                sql.append(super.getFromSQL("X"));
+                sql.append(" ");
+
+                if (getContainerFilter() != ContainerFilter.EVERYTHING)
+                {
+                    SQLFragment joinToExpAnnotSql = new SQLFragment("INNER JOIN ");
+                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoJournalExperiment(), "je");
+                    joinToExpAnnotSql.append(" ON (je.id = JournalExperimentId) ");
+                    joinToExpAnnotSql.append(" INNER JOIN ");
+                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
+                    joinToExpAnnotSql.append(" ON (exp.id = je.CopiedExperimentId) ");
+
+                    sql.append(joinToExpAnnotSql);
+
+                    sql.append(" WHERE ");
+                    sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("exp.Container"), getContainer()));
+                }
+                sql.append(") ");
+                sql.append(alias);
+
+                return sql;
+            }
+        };
+        result.wrapAllColumns(true);
+        return result;
     }
 
     @Override
@@ -104,6 +156,7 @@ public class PanoramaPublicSchema extends UserSchema
         hs.add(TABLE_JOURNAL);
         hs.add(TABLE_JOURNAL_EXPERIMENT);
         hs.add(TABLE_EXPERIMENT_ANNOTATIONS);
+        hs.add(TABLE_PX_XML);
 
         return hs;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
@@ -75,6 +75,7 @@ public class ExperimentAnnotations
     private Integer _submitter;
     private String _submitterAffiliation;
     private String _pxid;
+    private String _pubmedId;
 
     private static Pattern taxIdPattern = Pattern.compile("(.*)\\(taxid:(\\d+)\\)");
 
@@ -98,6 +99,7 @@ public class ExperimentAnnotations
         _labHeadAffiliation = experiment.getLabHeadAffiliation();
         _submitterAffiliation = experiment.getSubmitterAffiliation();
         _pxid = experiment.getPxid();
+        _pubmedId = experiment.getPubmedId();
     }
 
     public int getId()
@@ -464,11 +466,25 @@ public class ExperimentAnnotations
 
     public boolean isPublished()
     {
-        if(!StringUtils.isBlank(_publicationLink))
-        {
-            return true;
-        }
-        return false;
+        return !StringUtils.isBlank(_publicationLink);
+    }
+
+    public boolean isPeerReviewed()
+    {
+        String publicationLink = getPublicationLink();
+        // Authors use the medRxiv and bioRxiv services to make their manuscripts available as preprintsù before peer review, allowing
+        // other scientists to see, discuss, and comment on the findings immediately.
+        return isPublished() && !(publicationLink.contains("www.biorxiv.org") || publicationLink.contains("www.medrxiv.org"));
+    }
+
+    public String getPubmedId()
+    {
+        return _pubmedId;
+    }
+
+    public void setPubmedId(String pubmedId)
+    {
+        _pubmedId = pubmedId;
     }
 
     public boolean isPublic()

--- a/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
@@ -75,6 +75,7 @@ public class ExperimentAnnotations
     private Integer _submitter;
     private String _submitterAffiliation;
     private String _pxid;
+    private String _pubmedId;
 
     private static Pattern taxIdPattern = Pattern.compile("(.*)\\(taxid:(\\d+)\\)");
 
@@ -98,6 +99,7 @@ public class ExperimentAnnotations
         _labHeadAffiliation = experiment.getLabHeadAffiliation();
         _submitterAffiliation = experiment.getSubmitterAffiliation();
         _pxid = experiment.getPxid();
+        _pubmedId = experiment.getPubmedId();
     }
 
     public int getId()
@@ -259,6 +261,11 @@ public class ExperimentAnnotations
     public String getCitation()
     {
         return _citation;
+    }
+
+    public boolean hasCitation()
+    {
+        return !StringUtils.isBlank(_citation);
     }
 
     public Boolean getSpikeIn()
@@ -464,11 +471,30 @@ public class ExperimentAnnotations
 
     public boolean isPublished()
     {
-        if(!StringUtils.isBlank(_publicationLink))
-        {
-            return true;
-        }
-        return false;
+        return !StringUtils.isBlank(_publicationLink);
+    }
+
+    public boolean isPeerReviewed()
+    {
+        String publicationLink = getPublicationLink();
+        // Authors use the medRxiv and bioRxiv services to make their manuscripts available as preprints before peer review, allowing
+        // other scientists to see, discuss, and comment on the findings immediately.
+        return isPublished() && !(publicationLink.contains("www.biorxiv.org") || publicationLink.contains("www.medrxiv.org"));
+    }
+
+    public String getPubmedId()
+    {
+        return _pubmedId;
+    }
+
+    public boolean hasPubmedId()
+    {
+        return !StringUtils.isBlank(_pubmedId);
+    }
+
+    public void setPubmedId(String pubmedId)
+    {
+        _pubmedId = pubmedId;
     }
 
     public boolean isPublic()

--- a/panoramapublic/src/org/labkey/panoramapublic/model/JournalExperiment.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/JournalExperiment.java
@@ -28,21 +28,35 @@ import java.util.Date;
  */
 public class JournalExperiment
 {
+    private int _id;
     private int _journalId;
     private int _experimentAnnotationsId;
     private ShortURLRecord _shortAccessUrl;
     private ShortURLRecord _shortCopyUrl;
     private Date _created;
     private int _createdBy;
+    private Date _modified;
+    private int _modifiedBy;
     private Date _copied;
     private boolean _keepPrivate;
-    private boolean pxidRequested;
+    private boolean _pxidRequested;
+    private boolean _incompletePxSubmission;
     private String _labHeadName;
     private String _labHeadEmail;
     private String _labHeadAffiliation;
     private DataLicense _dataLicense;
     private Integer _announcementId;
-    private Integer _journalExperimentId;
+    private Integer _copiedExperimentId;
+
+    public int getId()
+    {
+        return _id;
+    }
+
+    public void setId(int id)
+    {
+        _id = id;
+    }
 
     public int getJournalId()
     {
@@ -114,6 +128,26 @@ public class JournalExperiment
         _copied = copied;
     }
 
+    public Date getModified()
+    {
+        return _modified;
+    }
+
+    public void setModified(Date modified)
+    {
+        _modified = modified;
+    }
+
+    public int getModifiedBy()
+    {
+        return _modifiedBy;
+    }
+
+    public void setModifiedBy(int modifiedBy)
+    {
+        _modifiedBy = modifiedBy;
+    }
+
     public boolean isKeepPrivate()
     {
         return _keepPrivate;
@@ -126,12 +160,22 @@ public class JournalExperiment
 
     public boolean isPxidRequested()
     {
-        return pxidRequested;
+        return _pxidRequested;
     }
 
     public void setPxidRequested(boolean pxidRequested)
     {
-        this.pxidRequested = pxidRequested;
+        _pxidRequested = pxidRequested;
+    }
+
+    public boolean isIncompletePxSubmission()
+    {
+        return _incompletePxSubmission;
+    }
+
+    public void setIncompletePxSubmission(boolean incompletePxSubmission)
+    {
+        this._incompletePxSubmission = incompletePxSubmission;
     }
 
     public String getLabHeadName()
@@ -189,13 +233,13 @@ public class JournalExperiment
         _announcementId = announcementId;
     }
 
-    public Integer getJournalExperimentId()
+    public Integer getCopiedExperimentId()
     {
-        return _journalExperimentId;
+        return _copiedExperimentId;
     }
 
-    public void setJournalExperimentId(Integer journalExperimentId)
+    public void setCopiedExperimentId(Integer copiedExperimentId)
     {
-        _journalExperimentId = journalExperimentId;
+        _copiedExperimentId = copiedExperimentId;
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/model/JournalExperiment.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/JournalExperiment.java
@@ -28,12 +28,15 @@ import java.util.Date;
  */
 public class JournalExperiment
 {
+    private int _id;
     private int _journalId;
     private int _experimentAnnotationsId;
     private ShortURLRecord _shortAccessUrl;
     private ShortURLRecord _shortCopyUrl;
     private Date _created;
     private int _createdBy;
+    private Date _modified;
+    private int _modifiedBy;
     private Date _copied;
     private boolean _keepPrivate;
     private boolean pxidRequested;
@@ -42,7 +45,17 @@ public class JournalExperiment
     private String _labHeadAffiliation;
     private DataLicense _dataLicense;
     private Integer _announcementId;
-    private Integer _journalExperimentId;
+    private Integer _copiedExperimentId;
+
+    public int getId()
+    {
+        return _id;
+    }
+
+    public void setId(int id)
+    {
+        _id = id;
+    }
 
     public int getJournalId()
     {
@@ -112,6 +125,26 @@ public class JournalExperiment
     public void setCopied(Date copied)
     {
         _copied = copied;
+    }
+
+    public Date getModified()
+    {
+        return _modified;
+    }
+
+    public void setModified(Date modified)
+    {
+        _modified = modified;
+    }
+
+    public int getModifiedBy()
+    {
+        return _modifiedBy;
+    }
+
+    public void setModifiedBy(int modifiedBy)
+    {
+        _modifiedBy = modifiedBy;
     }
 
     public boolean isKeepPrivate()
@@ -189,13 +222,13 @@ public class JournalExperiment
         _announcementId = announcementId;
     }
 
-    public Integer getJournalExperimentId()
+    public Integer getCopiedExperimentId()
     {
-        return _journalExperimentId;
+        return _copiedExperimentId;
     }
 
-    public void setJournalExperimentId(Integer journalExperimentId)
+    public void setCopiedExperimentId(Integer copiedExperimentId)
     {
-        _journalExperimentId = journalExperimentId;
+        _copiedExperimentId = copiedExperimentId;
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/model/PxXml.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/PxXml.java
@@ -1,0 +1,94 @@
+package org.labkey.panoramapublic.model;
+
+import java.util.Date;
+
+public class PxXml
+{
+    private int _id;
+    private int _journalExperimentId;
+    private Date _created;
+    private int _createdBy;
+    private String _xml;
+    private int _version;
+    private String _updateLog;
+
+    public PxXml() {}
+
+    public PxXml(int journalExperimentId, String xml, int version, String updateLog)
+    {
+        _journalExperimentId = journalExperimentId;
+        _xml = xml;
+        _version = version;
+        _updateLog = updateLog;
+    }
+
+    public int getId()
+    {
+        return _id;
+    }
+
+    public void setId(int id)
+    {
+        _id = id;
+    }
+
+    public int getJournalExperimentId()
+    {
+        return _journalExperimentId;
+    }
+
+    public void setJournalExperimentId(int journalExperimentId)
+    {
+        _journalExperimentId = journalExperimentId;
+    }
+
+    public Date getCreated()
+    {
+        return _created;
+    }
+
+    public void setCreated(Date created)
+    {
+        _created = created;
+    }
+
+    public int getCreatedBy()
+    {
+        return _createdBy;
+    }
+
+    public void setCreatedBy(int createdBy)
+    {
+        _createdBy = createdBy;
+    }
+
+    public String getXml()
+    {
+        return _xml;
+    }
+
+    public void setXml(String xml)
+    {
+        _xml = xml;
+    }
+
+    public int getVersion()
+    {
+        return _version;
+    }
+
+    public void setVersion(int version)
+    {
+        _version = version;
+    }
+
+    public String getUpdateLog()
+    {
+        return _updateLog;
+    }
+
+    public void setUpdateLog(String updateLog)
+    {
+        _updateLog = updateLog;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -37,7 +37,6 @@ import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.MutableSecurityPolicy;
-import org.labkey.api.security.RoleAssignment;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
@@ -72,7 +71,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 
 /**
@@ -152,13 +150,13 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             targetExperiment.setShortUrl(jExperiment.getShortAccessUrl());
 
             ExperimentAnnotations previousCopy = null;
-            if(jExperiment.getJournalExperimentId() != null)
+            if(jExperiment.getCopiedExperimentId() != null)
             {
-                previousCopy = ExperimentAnnotationsManager.get(jExperiment.getJournalExperimentId());
+                previousCopy = ExperimentAnnotationsManager.get(jExperiment.getCopiedExperimentId());
                 if(previousCopy == null)
                 {
                     throw new PipelineJobException("Could not find and entry for the previous copy of the experiment.  " +
-                            "Previous experiment ID " + jExperiment.getJournalExperimentId());
+                            "Previous experiment ID " + jExperiment.getCopiedExperimentId());
                 }
             }
 
@@ -168,7 +166,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
                                        // Let the admin who is copying the data make the decision.
             )
             {
-                if(previousCopy != null)
+                if(previousCopy != null && previousCopy.getPxid() != null)
                 {
                     log.info("Copying ProteomeXchange ID from the previous copy of the data.");
                     targetExperiment.setPxid(previousCopy.getPxid());
@@ -196,7 +194,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             // Update the JournalExperiment table -- set the 'copied' timestamp and the journalExperimentId
             log.info("Setting the 'copied' timestamp and journalExperimentId on the JournalExperiment table.");
             jExperiment.setCopied(new Date());
-            jExperiment.setJournalExperimentId(targetExperiment.getId());
+            jExperiment.setCopiedExperimentId(targetExperiment.getId());
             JournalManager.updateJournalExperiment(jExperiment, user);
 
             // Remove the copy permissions given to the journal.
@@ -219,6 +217,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             {
                 // Users that had read access to the previous copy should be given read access to the new copy. This will include the reviewer
                 // account if one was created for the previous copy.
+                log.info("Adding read permissions to all users that had read access to previous copy.");
                 List<User> previousCopyReaders = getUsersWithRole(previousCopy.getContainer(), RoleManager.getRole(ReaderRole.class));
                 previousCopyReaders.forEach(u -> newPolicy.addRoleAssignment(u, ReaderRole.class));
             }
@@ -251,7 +250,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             String reviewerPassword = null;
             if(jExperiment.isKeepPrivate())
             {
-                if (previousCopy == null)
+                if (previousCopy == null || (previousCopy != null && previousCopy.isPublic()))
                 {
                     reviewerPassword = createPassword();
                     reviewer = createReviewerAccount(jobSupport.getReviewerEmailPrefix(), reviewerPassword, user, log);
@@ -265,12 +264,6 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
                 assignReader(SecurityManager.getGroup(Group.groupGuests), target);
             }
 
-            // Create notifications
-            PanoramaPublicNotification.notifyCopied(sourceExperiment, targetExperiment, jobSupport.getJournal(), jExperiment,
-                    reviewer, reviewerPassword, user, previousCopy != null /*This is a re-copy if previousCopy exists*/);
-
-            postEmailNotification(jobSupport, user, log, sourceExperiment, jExperiment, targetExperiment, reviewer, reviewerPassword, previousCopy != null);
-
             // Delete the previous copy
             if(previousCopy != null && jobSupport.deletePreviousCopy())
             {
@@ -278,6 +271,12 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
                 Container oldContainer = previousCopy.getContainer();
                 ContainerManager.delete(oldContainer, user);
             }
+
+            // Create notifications. Do this at the end after everything else is done.
+            PanoramaPublicNotification.notifyCopied(sourceExperiment, targetExperiment, jobSupport.getJournal(), jExperiment,
+                    reviewer, reviewerPassword, user, previousCopy != null /*This is a re-copy if previousCopy exists*/);
+
+            postEmailNotification(jobSupport, user, log, sourceExperiment, jExperiment, targetExperiment, reviewer, reviewerPassword, previousCopy != null);
 
             transaction.commit();
         }
@@ -367,20 +366,11 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         toAddresses.addAll(jobSupport.toEmailAddresses());
 
         String subject = String.format("Submission to %s: %s", jobSupport.getJournal().getName(), targetExperiment.getShortUrl().renderShortURL());
-        String emailBody;
-        if(recopy)
-        {
-            emailBody = PanoramaPublicNotification.getExperimentReCopiedEmailBody(sourceExperiment, targetExperiment, jExperiment, jobSupport.getJournal(),
-                    PanoramaPublicNotification.getUserName(formSubmitter),
-                    PanoramaPublicNotification.getUserName(pipelineJobUser));
-        }
-        else
-        {
-            emailBody = PanoramaPublicNotification.getExperimentCopiedEmailBody(sourceExperiment, targetExperiment, jExperiment, jobSupport.getJournal(),
+        String emailBody = PanoramaPublicNotification.getExperimentCopiedEmailBody(sourceExperiment, targetExperiment, jExperiment, jobSupport.getJournal(),
                     reviewer, reviewerPassword,
-                    PanoramaPublicNotification.getUserName(formSubmitter),
-                    PanoramaPublicNotification.getUserName(pipelineJobUser));
-        }
+                    formSubmitter,
+                    pipelineJobUser,
+                    recopy);
 
         if(jobSupport.emailSubmitter())
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
@@ -57,9 +57,14 @@ public class ProteomeXchangeService
             MultipartEntityBuilder builder = getMultipartEntityBuilder(pxxmlFile, testDatabase, method, user, pass);
             responseMessage = postRequest(builder);
         }
+        catch(ProteomeXchangeServiceException e)
+        {
+            throw e;
+        }
         catch (Exception e)
         {
-            throw new ProteomeXchangeServiceException("Error with service request " + method + " to ProteomeXchange.", e);
+            String exMsg = e.getMessage() == null ? e.toString() : e.getMessage();
+            throw new ProteomeXchangeServiceException("Error with service request " + method + " to ProteomeXchange. " + exMsg);
         }
 
         return responseMessage;
@@ -152,6 +157,16 @@ public class ProteomeXchangeService
             throw new ProteomeXchangeServiceException("Error " + statusCode + " from ProteomeXchange server: " + responseMessage);
         }
         return responseMessage;
+    }
+
+    public static boolean responseHasErrors(String response)
+    {
+        return !response.contains("result=SUCCESS")
+                || !response.contains("info=File does appear to be XML")
+                || !response.contains("info=Submitted XML is valid according to the XSD.")
+                || !response.contains("info=There were a total of 0 different CV errors or warnings.")
+                || !response.contains("info=There was a total of 0 non-CV warnings.")
+                || !response.contains("info=There was a total of 0 non-CV errors.");
     }
 }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
@@ -22,6 +22,7 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ShortURLRecord;
 import org.labkey.panoramapublic.PanoramaPublicController;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.panoramapublic.model.JournalExperiment;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,7 +44,7 @@ public class PxHtmlWriter extends PxWriter
     @Override
     public void write(PanoramaPublicController.PxExperimentAnnotations bean) throws PxException
     {
-        _usePxTestDb = bean.getForm().isTestDatabase();
+        _usePxTestDb = bean.isUseTestDb();
         super.write(bean);
     }
 
@@ -54,6 +55,8 @@ public class PxHtmlWriter extends PxWriter
         tr("PX Test Database", String.valueOf(_usePxTestDb));
         tr("Experiment ID", String.valueOf(experimentAnnotations.getId()));
         tr("Title", experimentAnnotations.getTitle());
+        String pxid = experimentAnnotations.getPxid();
+        tr("PX ID", pxid != null ? pxid : "NOT ASSIGNED", pxid == null);
     }
 
     @Override
@@ -69,26 +72,64 @@ public class PxHtmlWriter extends PxWriter
     }
 
     @Override
-    void writeChangeLog(PanoramaPublicController.PxExportForm form)
+    void writeChangeLog(String pxChangeLog)
     {
-        if(!StringUtils.isBlank(form.getChangeLog()))
+        if(!StringUtils.isBlank(pxChangeLog))
         {
-            tr("Change Log", form.getChangeLog());
+            tr("Change Log", pxChangeLog);
         }
     }
 
     @Override
-    void writeDatasetSummary(ExperimentAnnotations expAnnotations, PanoramaPublicController.PxExportForm form)
+    void writeDatasetSummary(ExperimentAnnotations expAnnotations)
     {
         tr("Description", expAnnotations.getAbstract());
-        tr("Review Level", (form.getPeerReviewed() || expAnnotations.isPublished()) ? "Peer Reviewed" : "Not Peer Reviewed");
+        tr("Review Level", (expAnnotations.isPeerReviewed()) ? "Peer Reviewed" : "Not Peer Reviewed");
+
+        SubmissionDataStatus status = SubmissionDataValidator.validateExperiment(expAnnotations);
+        if(status.isComplete())
+        {
+            tr("Repository Support", "Supported dataset by repository");
+        }
+        else if(status.isIncomplete())
+        {
+            HtmlList list = new HtmlList();
+            if(status.hasInvalidModifications())
+            {
+               list.addItem("Modifications without UNIMOD Ids", "Yes", true);
+            }
+            if(status.hasMissingLibrarySourceFiles())
+            {
+                list.addItem("Missing spectrum library source files", "Yes", true);
+            }
+            list.end();
+            trNoFilter("Repository Support", "supported by repository but incomplete data and/or metadata" + list.getHtml());
+        }
+        else
+        {
+            HtmlList list = new HtmlList();
+            if(status.hasMissingRawFiles())
+            {
+                list.addItem("Missing raw files", "Yes", true);
+            }
+            if(status.hasMissingMetadata())
+            {
+                list.addItem("Missing metadata", "Yes", true);
+            }
+            list.end();
+            trNoFilter("Repository Support", "Cannot be announced on ProteomeXchange" + list.getHtml(), true);
+        }
     }
 
     @Override
-    void writeDatasetIdentifierList(String pxId, ShortURLRecord accessUrl)
+    void writeDatasetIdentifierList(String pxId, int version, ShortURLRecord accessUrl)
     {
         HtmlList list = new HtmlList();
         list.addItem("PX ID", pxId, StringUtils.isBlank(pxId));
+        if(!StringUtils.isBlank(pxId))
+        {
+            list.addItem("PX Version", String.valueOf(version), false);
+        }
         list.addItem("Access URL", getAccessUrlString(accessUrl), accessUrl == null);
         list.end();
         trNoFilter("Dataset identifier", list.getHtml());
@@ -192,14 +233,14 @@ public class PxHtmlWriter extends PxWriter
     }
 
     @Override
-    void writeContactList(ExperimentAnnotations experimentAnnotations, PanoramaPublicController.PxExportForm form)
+    void writeContactList(ExperimentAnnotations experimentAnnotations, JournalExperiment je)
     {
         HtmlList contactList = new HtmlList();
 
         User labHead = experimentAnnotations.getLabHeadUser();
-        String labHeadName = labHead != null ? labHead.getFullName() : form.getLabHeadName();
-        String labHeadEmail = labHead != null ? labHead.getEmail() : form.getLabHeadEmail();
-        String labHeadAffiliation = labHead != null ? experimentAnnotations.getLabHeadAffiliation() : form.getLabHeadAffiliation();
+        String labHeadName = labHead != null ? labHead.getFullName() : je.getLabHeadName();
+        String labHeadEmail = labHead != null ? labHead.getEmail() : je.getLabHeadEmail();
+        String labHeadAffiliation = labHead != null ? experimentAnnotations.getLabHeadAffiliation() : je.getLabHeadAffiliation();
 
         boolean contactErr = StringUtils.isBlank(labHeadName);
         contactList.addItem("Lab head name", StringUtils.isBlank(labHeadName) ? "NO LAB HEAD. Submitter details will be used." : labHeadName, contactErr);
@@ -210,9 +251,18 @@ public class PxHtmlWriter extends PxWriter
         }
 
         User submitter = experimentAnnotations.getSubmitterUser();
-        contactErr = submitter == null;
-        contactList.addItem("Submitter name", submitter == null ? "NO SUBMITTER" : submitter.getFullName(), contactErr);
-        contactList.addItem("Submitter email", submitter == null ? "NO EMAIL" : submitter.getEmail(), contactErr);
+        if(submitter == null)
+        {
+            contactList.addItem("Submitter name","NO SUBMITTER", true);
+            contactList.addItem("Submitter email", "NO EMAIL", true);
+        }
+        else
+        {
+            String fullName = submitter.getFullName();
+            boolean err = StringUtils.isBlank(fullName);
+            contactList.addItem("Submitter name", err ? "MISSING NAME" : fullName, err); // We need a name to submit to PX
+            contactList.addItem("Submitter email", submitter.getEmail(), false);
+        }
         if(experimentAnnotations.getSubmitterAffiliation() != null)
         {
             contactList.addItem("Submitter affiliation", experimentAnnotations.getSubmitterAffiliation(), false);
@@ -221,31 +271,49 @@ public class PxHtmlWriter extends PxWriter
     }
 
     @Override
-    void writePublicationList(ExperimentAnnotations experimentAnnotations, PanoramaPublicController.PxExportForm form)
+    void writePublicationList(ExperimentAnnotations experimentAnnotations)
     {
         HtmlList publicationList = new HtmlList();
-        boolean hasPubmedId = !StringUtils.isBlank(form.getPublicationId());
-        if(form.getPeerReviewed() || hasPubmedId)
+        if(experimentAnnotations.isPublished())
         {
-            if(hasPubmedId)
+            publicationList.addItem("Link: ", experimentAnnotations.getPublicationLink(), false);
+
+            if(experimentAnnotations.hasPubmedId())
             {
-                publicationList.addItem("PMID", form.getPublicationId(), false);
+                publicationList.addItem("PMID", experimentAnnotations.getPubmedId(), false);
             }
             else
             {
                 publicationList.addItem(null, "NO_PUBMED_ID", false);
             }
-            String reference = form.getPublicationReference();
-            if(StringUtils.isBlank(reference))
+            if(!StringUtils.isBlank(experimentAnnotations.getCitation()))
             {
-                reference = experimentAnnotations.getCitation();
+                publicationList.addItem("Reference", experimentAnnotations.getCitation(), false);
             }
-            publicationList.addItem("Reference", reference, false);
+            else
+            {
+                publicationList.addItem("Reference", "NO REFERNCE", true);
+            }
         }
         else
         {
             publicationList.addItem(null, "NONE", false);
         }
+        String announcedAs;
+        if(experimentAnnotations.isPublished() && experimentAnnotations.hasCitation())
+        {
+            announcedAs = experimentAnnotations.hasPubmedId() ? "with pubmedid id: " + experimentAnnotations.getCitation()
+                    : "pubmed_id_pending: " + experimentAnnotations.getCitation();
+        }
+        else if(experimentAnnotations.isPublished() || experimentAnnotations.hasCitation())
+        {
+            announcedAs = "Dataset with its publication pending";
+        }
+        else
+        {
+            announcedAs = "Dataset with no associated published manuscript";
+        }
+        publicationList.addItem("Announcement Type", announcedAs, false);
         publicationList.end();
         trNoFilter("Publication", publicationList.getHtml());
     }
@@ -281,6 +349,11 @@ public class PxHtmlWriter extends PxWriter
     private void trNoFilter(String cell1, String cell2)
     {
         tr(cell1, cell2, false);
+    }
+
+    private void trNoFilter(String cell1, String cell2, boolean error)
+    {
+        tr(cell1, cell2, error);
     }
 
     // Expects cell1 and cell2 to be HTML encoded.

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxWriter.java
@@ -41,15 +41,15 @@ public abstract class PxWriter
         try
         {
             begin(expAnnotations);
-            writeChangeLog(bean.getForm());
-            writeDatasetSummary(expAnnotations, bean.getForm());
-            writeDatasetIdentifierList(expAnnotations.getPxid(), accessUrl);
+            writeChangeLog(bean.getPxChangeLog());
+            writeDatasetSummary(expAnnotations);
+            writeDatasetIdentifierList(expAnnotations.getPxid(), bean.getVersion(), accessUrl);
             writeDatasetOriginList();
             writeSpeciesList(expAnnotations);
             writeInstrumentList(expAnnotations);
             writeModificationList(expAnnotations);
-            writeContactList(expAnnotations, bean.getForm());
-            writePublicationList(expAnnotations, bean.getForm());
+            writeContactList(expAnnotations, bean.getJournalExperiment());
+            writePublicationList(expAnnotations);
             writeKeywordList(expAnnotations);
             writeDatasetLinkList(accessUrl);
             end();
@@ -83,15 +83,15 @@ public abstract class PxWriter
     abstract void begin(ExperimentAnnotations experimentAnnotations) throws PxException;
     abstract void end() throws PxException;
     abstract void close() throws PxException;
-    abstract void writeChangeLog(PanoramaPublicController.PxExportForm form) throws PxException;
-    abstract void writeDatasetSummary(ExperimentAnnotations expAnnotations, PanoramaPublicController.PxExportForm form) throws PxException;
-    abstract void writeDatasetIdentifierList(String pxId, ShortURLRecord accessUrl) throws PxException;
+    abstract void writeChangeLog(String pxChangeLog) throws PxException;
+    abstract void writeDatasetSummary(ExperimentAnnotations expAnnotations) throws PxException;
+    abstract void writeDatasetIdentifierList(String pxId, int version, ShortURLRecord accessUrl) throws PxException;
     abstract void writeDatasetOriginList() throws PxException;
     abstract void writeSpeciesList(ExperimentAnnotations experimentAnnotations) throws PxException;
     abstract void writeInstrumentList(ExperimentAnnotations experimentAnnotations) throws PxException;
     abstract void writeModificationList(ExperimentAnnotations experimentAnnotations) throws PxException;
-    abstract void writeContactList(ExperimentAnnotations experimentAnnotationsn, PanoramaPublicController.PxExportForm form) throws PxException;
-    abstract void writePublicationList(ExperimentAnnotations experimentAnnotations, PanoramaPublicController.PxExportForm form) throws PxException;
+    abstract void writeContactList(ExperimentAnnotations experimentAnnotationsn, JournalExperiment je) throws PxException;
+    abstract void writePublicationList(ExperimentAnnotations experimentAnnotations) throws PxException;
     abstract void writeKeywordList(ExperimentAnnotations experimentAnnotations) throws PxException;
     abstract void writeDatasetLinkList(ShortURLRecord accessUrl) throws PxException;
 

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
@@ -19,8 +19,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.security.User;
 import org.labkey.api.view.ShortURLRecord;
-import org.labkey.panoramapublic.PanoramaPublicController;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.panoramapublic.model.JournalExperiment;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -124,13 +124,13 @@ public class PxXmlWriter extends PxWriter
     }
 
     @Override
-    void writeChangeLog(PanoramaPublicController.PxExportForm form) throws PxException
+    void writeChangeLog(String pxChangeLog) throws PxException
     {
-        if(!StringUtils.isBlank(form.getChangeLog()))
+        if(!StringUtils.isBlank(pxChangeLog))
         {
             Element changeLogEl = new Element(("ChangeLog"));
             Element clEntryEl = new Element("ChangeLogEntry");
-            clEntryEl.setText(form.getChangeLog());
+            clEntryEl.setText(pxChangeLog);
             changeLogEl.addChild(clEntryEl);
             try
             {
@@ -202,7 +202,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
-    void writePublicationList(ExperimentAnnotations expAnnotations, PanoramaPublicController.PxExportForm form) throws PxException
+    void writePublicationList(ExperimentAnnotations expAnnotations) throws PxException
     {
         /*
         <PublicationList>
@@ -222,22 +222,21 @@ public class PxXmlWriter extends PxWriter
          */
 
         Element publication_list = new Element("PublicationList");
-        boolean hasPubmedId = !StringUtils.isBlank(form.getPublicationId());
-        if(hasPubmedId || form.getPeerReviewed())
+        boolean hasPubmedId = !StringUtils.isBlank(expAnnotations.getPubmedId());
+        if(expAnnotations.isPeerReviewed())
         {
             Element publication = new Element("Publication");
-            String id = hasPubmedId ? "PMID" + form.getPublicationId() : "pubmed_id_pending";
+            String id = hasPubmedId ? "PMID" + expAnnotations.getPubmedId() : "pubmed_id_pending";
             publication.setAttributes(Collections.singletonList(new Attribute("id", id)));
             if(hasPubmedId)
             {
-                publication.addChild(new CvParamElement("MS", "MS:1000879", "PubMed identifier", form.getPublicationId()));
+                publication.addChild(new CvParamElement("MS", "MS:1000879", "PubMed identifier", expAnnotations.getPubmedId()));
             }
-            String reference = form.getPublicationReference();
-            if(StringUtils.isBlank(reference))
+            if(StringUtils.isBlank(expAnnotations.getCitation()))
             {
-                reference = expAnnotations.getCitation();
+                throw new PxException("Citation text cannot be blank.");
             }
-            publication.addChild(new CvParamElement("MS", "MS:1002866", "Reference", reference));
+            publication.addChild(new CvParamElement("MS", "MS:1002866", "Reference", expAnnotations.getCitation()));
             publication_list.addChild(publication);
         }
         else
@@ -260,7 +259,7 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
-    void writeContactList(ExperimentAnnotations expAnnotations, PanoramaPublicController.PxExportForm form) throws PxException
+    void writeContactList(ExperimentAnnotations expAnnotations, JournalExperiment je) throws PxException
     {
         /*
         <ContactList>
@@ -290,11 +289,11 @@ public class PxXmlWriter extends PxWriter
         String labHeadName = labHead != null ? labHead.getFullName() : null;
         String labHeadEmail = labHead != null ? labHead.getEmail() : null;
         // Check if there is a form override
-        if(!StringUtils.isBlank(form.getLabHeadName()))
+        if(je.hasLabHeadDetails())
         {
-            labHeadName = form.getLabHeadName();
-            labHeadEmail = form.getLabHeadEmail();
-            labHeadAffiliation = form.getLabHeadAffiliation();
+            labHeadName = je.getLabHeadName();
+            labHeadEmail = je.getLabHeadEmail();
+            labHeadAffiliation = je.getLabHeadAffiliation();
         }
 
         Element labHeadEl = new Element("Contact");
@@ -495,12 +494,12 @@ public class PxXmlWriter extends PxWriter
         }
     }
 
-    void writeDatasetIdentifierList(String pxId, ShortURLRecord accessUrl) throws PxException
+    void writeDatasetIdentifierList(String pxId, int version, ShortURLRecord accessUrl) throws PxException
     {
         Element di_list = new Element("DatasetIdentifierList");
         Element di1 = new Element("DatasetIdentifier");
         di1.addChild(new CvParamElement("MS", "MS:1001919", "ProteomeXchange accession number", StringUtils.isBlank(pxId) ? "PXD000000" : pxId));
-//        di2.addChild(new CvParamElement("MS", "MS:1001921", "ProteomeXchange accession number version number", "1"));
+        di1.addChild(new CvParamElement("MS", "MS:1001921", "ProteomeXchange accession number version number", String.valueOf(version)));
         di_list.addChild(di1);
         Element di2 = new Element("DatasetIdentifier");
         di2.addChild(new CvParamElement("MS", "MS:1002872", "Panorama Public dataset identifier", getAccessUrlString(accessUrl)));
@@ -545,7 +544,7 @@ public class PxXmlWriter extends PxWriter
         return el;
     }
 
-    void writeDatasetSummary(ExperimentAnnotations annotations, PanoramaPublicController.PxExportForm form) throws PxException
+    void writeDatasetSummary(ExperimentAnnotations annotations) throws PxException
     {
         Element el = new Element("DatasetSummary");
         List<Attribute> attributes = new ArrayList<>(3);
@@ -561,11 +560,23 @@ public class PxXmlWriter extends PxWriter
 
 
         Element reviewLevel = new Element("ReviewLevel");
-        reviewLevel.addChild((form.getPeerReviewed() || annotations.isPublished()) ? peerReviewedEl : nonPeerReviewedEl);
+        reviewLevel.addChild((annotations.isPeerReviewed()) ? peerReviewedEl : nonPeerReviewedEl);
         el.addChild(reviewLevel);
 
         Element repoSupport = new Element("RepositorySupport");
-        repoSupport.addChild(new CvParamElement("MS", "MS:1002856", "Supported dataset by repository"));
+        SubmissionDataStatus status = SubmissionDataValidator.validateExperiment(annotations);
+        if(status.isValid())
+        {
+            repoSupport.addChild(new CvParamElement("MS", "MS:1002856", "Supported dataset by repository"));
+        }
+        else if(status.isPartial())
+        {
+            repoSupport.addChild(new CvParamElement("MS", "MS:1003087", "supported by repository but incomplete data and/or metadata"));
+        }
+        else
+        {
+            throw new PxException("Data is missing raw files and / or required metadata. It cannot be announced on ProteomeXchange.");
+        }
         el.addChild(repoSupport);
 
         try

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataStatus.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataStatus.java
@@ -156,7 +156,17 @@ public class SubmissionDataStatus
 
     public boolean isValid()
     {
-        return !hasMissingMetadata() && !hasMissingRawFiles() && !hasMissingLibrarySourceFiles() && !hasInvalidModifications();
+        return canSubmitToPx() && !hasMissingLibrarySourceFiles() && !hasInvalidModifications();
+    }
+
+    public boolean isPartial()
+    {
+        return canSubmitToPx() && (hasMissingRawFiles() || hasInvalidModifications());
+    }
+
+    public boolean canSubmitToPx()
+    {
+        return !hasMissingMetadata() && !hasMissingRawFiles();
     }
 
     public boolean hasMissingMetadata()

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataStatus.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataStatus.java
@@ -161,7 +161,7 @@ public class SubmissionDataStatus
 
     public boolean isIncomplete()
     {
-        return canSubmitToPx() && (hasMissingRawFiles() || hasInvalidModifications());
+        return canSubmitToPx() && (hasMissingLibrarySourceFiles() || hasInvalidModifications());
     }
 
     public boolean canSubmitToPx()

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataStatus.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataStatus.java
@@ -154,9 +154,19 @@ public class SubmissionDataStatus
         _noUnimodMods.add(modName);
     }
 
-    public boolean isValid()
+    public boolean isComplete()
     {
-        return !hasMissingMetadata() && !hasMissingRawFiles() && !hasMissingLibrarySourceFiles() && !hasInvalidModifications();
+        return canSubmitToPx() && !hasMissingLibrarySourceFiles() && !hasInvalidModifications();
+    }
+
+    public boolean isIncomplete()
+    {
+        return canSubmitToPx() && (hasMissingRawFiles() || hasInvalidModifications());
+    }
+
+    public boolean canSubmitToPx()
+    {
+        return !hasMissingMetadata() && !hasMissingRawFiles();
     }
 
     public boolean hasMissingMetadata()

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataValidator.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataValidator.java
@@ -94,6 +94,11 @@ public class SubmissionDataValidator
         return true;
     }
 
+    public static SubmissionDataStatus validateExperiment(ExperimentAnnotations expAnnot)
+    {
+        return validateExperiment(expAnnot, false, false, false);
+    }
+
     public static SubmissionDataStatus validateExperiment(ExperimentAnnotations expAnnot, boolean skipMetaDataCheck, boolean skipRawDataCheck, boolean skipModificationCheck)
     {
         SubmissionDataStatus status = new SubmissionDataStatus(expAnnot);

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataValidator.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataValidator.java
@@ -56,14 +56,9 @@ public class SubmissionDataValidator
 
     public static boolean isValid(ExperimentAnnotations expAnnot)
     {
-        return isValid(expAnnot, false, false, false);
-    }
-
-    public static boolean isValid(ExperimentAnnotations expAnnot, boolean skipMetaDataCheck, boolean skipRawDataCheck, boolean skipModificationCheck)
-    {
-        boolean metadataValid = skipMetaDataCheck || metadataComplete(expAnnot);
-        boolean hasRawFiles = skipRawDataCheck || rawDataUploaded(expAnnot);
-        boolean hasValidMods = skipModificationCheck || hasUnimodModifications(expAnnot);
+        boolean metadataValid = metadataComplete(expAnnot);
+        boolean hasRawFiles = rawDataUploaded(expAnnot);
+        boolean hasValidMods = hasUnimodModifications(expAnnot);
         return metadataValid && hasRawFiles && hasValidMods;
     }
 
@@ -94,27 +89,17 @@ public class SubmissionDataValidator
         return true;
     }
 
-    public static SubmissionDataStatus validateExperiment(ExperimentAnnotations expAnnot, boolean skipMetaDataCheck, boolean skipRawDataCheck, boolean skipModificationCheck)
+    public static SubmissionDataStatus validateExperiment(ExperimentAnnotations expAnnot)
     {
         SubmissionDataStatus status = new SubmissionDataStatus(expAnnot);
-        if(!skipMetaDataCheck)
-        {
-            status.setMissingMetadata(getMissingExperimentMetadataFields(expAnnot));
-        }
-        if(!skipRawDataCheck)
-        {
-            getMissingRawFiles(expAnnot, status);
-        }
+        status.setMissingMetadata(getMissingExperimentMetadataFields(expAnnot));
+        getMissingRawFiles(expAnnot, status);
 
-        if(!skipModificationCheck)
+        List<ExperimentModificationGetter.PxModification> invalidMods = getInvalidModifications(expAnnot);
+        for (ExperimentModificationGetter.PxModification invalidMod : invalidMods)
         {
-            List<ExperimentModificationGetter.PxModification> invalidMods = getInvalidModifications(expAnnot);
-            for (ExperimentModificationGetter.PxModification invalidMod : invalidMods)
-            {
-                status.addInvalidMod(invalidMod);
-            }
+            status.addInvalidMod(invalidMod);
         }
-
         return status;
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
@@ -446,7 +446,7 @@ public class ExperimentAnnotationsManager
         {
             // If this experiment has already been copied and the journal copy is final (paper published and data public)
             // then the user should not be able to re-submit this data.
-            ExperimentAnnotations journalCopy = ExperimentAnnotationsManager.get(journalExperiment.getJournalExperimentId());
+            ExperimentAnnotations journalCopy = ExperimentAnnotationsManager.get(journalExperiment.getCopiedExperimentId());
             return journalCopy == null || !journalCopy.isFinal();
         }
         return true;
@@ -458,7 +458,7 @@ public class ExperimentAnnotationsManager
         if(expAnnotations != null)
         {
             JournalExperiment journalExperiment = JournalManager.getLastPublishedRecord(expAnnotations.getId());
-            return journalExperiment != null ? ExperimentAnnotationsManager.get(journalExperiment.getJournalExperimentId()): null;
+            return journalExperiment != null ? ExperimentAnnotationsManager.get(journalExperiment.getCopiedExperimentId()): null;
         }
         return null;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalExperimentTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalExperimentTableInfo.java
@@ -231,10 +231,6 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
                             out.write(PageFlowUtil.link("Edit").href(ediUrl).toString());
                         }
                     }
-                    else
-                    {
-                        out.write("");
-                    }
                 }
 
                 @Override

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
@@ -19,8 +19,6 @@ import org.apache.log4j.Logger;
 import org.labkey.api.admin.FolderExportPermission;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.CoreSchema;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -245,10 +243,7 @@ public class JournalManager
 
     public static void updateJournalExperiment(JournalExperiment journalExperiment, User user)
     {
-        Map<String, Object> pkVals = new HashMap<>();
-        pkVals.put("experimentAnnotationsId", journalExperiment.getExperimentAnnotationsId());
-        pkVals.put("journalId", journalExperiment.getJournalId());
-        Table.update(user, PanoramaPublicManager.getTableInfoJournalExperiment(), journalExperiment, pkVals);
+        Table.update(user, PanoramaPublicManager.getTableInfoJournalExperiment(), journalExperiment, journalExperiment.getId());
     }
 
     public static boolean journalHasAccess(Journal journal, ExperimentAnnotations experiment)
@@ -274,10 +269,7 @@ public class JournalManager
 
         sourceJournalExp.setShortAccessUrl(shortAccessUrlRecord);
 
-        Map<String, Integer> pkVals = new HashMap<>();
-        pkVals.put("JournalId", sourceJournalExp.getJournalId());
-        pkVals.put("ExperimentAnnotationsId", sourceJournalExp.getExperimentAnnotationsId());
-        Table.update(user, PanoramaPublicManager.getTableInfoJournalExperiment(), sourceJournalExp, pkVals);
+        updateJournalExperiment(sourceJournalExp, user);
     }
 
     public static JournalExperiment getJournalExperiment(ExperimentAnnotations experiment, Journal journal)
@@ -429,7 +421,7 @@ public class JournalManager
     {
         JournalExperiment je = getJournalExperiment(expAnnotations, journal);
 
-        if(je.getJournalExperimentId() == null)
+        if(je.getCopiedExperimentId() == null)
         {
             // This experiment has not yet been copied to Panorama Public so we can delete the row in JournalExperiment
             SimpleFilter filter = new SimpleFilter();
@@ -476,13 +468,13 @@ public class JournalManager
     public static void deleteRowForJournalCopy(ExperimentAnnotations journalCopy)
     {
         Table.delete(PanoramaPublicManager.getTableInfoJournalExperiment(),
-                new SimpleFilter().addCondition(FieldKey.fromParts("JournalExperimentId"), journalCopy.getId()));
+                new SimpleFilter().addCondition(FieldKey.fromParts("CopiedExperimentId"), journalCopy.getId()));
     }
 
     public static JournalExperiment getRowForJournalCopy(ExperimentAnnotations journalCopy)
     {
         return new TableSelector(PanoramaPublicManager.getTableInfoJournalExperiment()
-                , new SimpleFilter().addCondition(FieldKey.fromParts("JournalExperimentId"), journalCopy.getId())
+                , new SimpleFilter().addCondition(FieldKey.fromParts("CopiedExperimentId"), journalCopy.getId())
                 , null).getObject(JournalExperiment.class);
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/PxXmlManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/PxXmlManager.java
@@ -17,12 +17,12 @@ public class PxXmlManager
 
     public static int getNextVersion(int journalExperimentId)
     {
-        List<Integer> versions =  new TableSelector(PanoramaPublicManager.getTableInfoPxXml(),
+        Integer version = new TableSelector(PanoramaPublicManager.getTableInfoPxXml(),
                 Collections.singleton("Version"),
                 new SimpleFilter(FieldKey.fromParts("JournalExperimentId"), journalExperimentId),
-                new Sort("-Version")).getArrayList(Integer.class);
+                new Sort("-Version")).setMaxRows(1).getObject(Integer.class);
 
-        return versions.size() == 0 ? 1 : versions.get(0) + 1;
+        return version == null ? 1 : version + 1;
     }
 
     public static PxXml save(PxXml pxXml, User user)

--- a/panoramapublic/src/org/labkey/panoramapublic/query/PxXmlManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/PxXmlManager.java
@@ -1,0 +1,32 @@
+package org.labkey.panoramapublic.query;
+
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.Sort;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.User;
+import org.labkey.panoramapublic.PanoramaPublicManager;
+import org.labkey.panoramapublic.model.PxXml;
+
+import java.util.Collections;
+import java.util.List;
+
+public class PxXmlManager
+{
+
+    public static int getNextVersion(int journalExperimentId)
+    {
+        List<Integer> versions =  new TableSelector(PanoramaPublicManager.getTableInfoPxXml(),
+                Collections.singleton("Version"),
+                new SimpleFilter(FieldKey.fromParts("JournalExperimentId"), journalExperimentId),
+                new Sort("-Version")).getArrayList(Integer.class);
+
+        return versions.size() == 0 ? 1 : versions.get(0) + 1;
+    }
+
+    public static PxXml save(PxXml pxXml, User user)
+    {
+        return Table.insert(user, PanoramaPublicManager.getTableInfoPxXml(), pxXml);
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/ExperimentAnnotationsFormDataRegion.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/ExperimentAnnotationsFormDataRegion.java
@@ -39,7 +39,7 @@ public class ExperimentAnnotationsFormDataRegion extends DataRegion
         super();
 
         addColumns(new ExperimentAnnotationsTableInfo(new PanoramaPublicSchema(viewContext.getUser(), viewContext.getContainer()), null),
-                "Id,Title,Organism,Instrument,SpikeIn,Abstract,ExperimentDescription,SampleDescription, Keywords, LabHead, LabHeadAffiliation, Submitter, SubmitterAffiliation, Citation,PublicationLink,");
+                "Id,Title,Organism,Instrument,SpikeIn,Abstract,ExperimentDescription,SampleDescription, Keywords, LabHead, LabHeadAffiliation, Submitter, SubmitterAffiliation, Citation,PublicationLink,PubmedId");
 
         DisplayColumn idCol = getDisplayColumn("Id");
         idCol.setVisible(false);

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -29,7 +29,6 @@
 <%@ page import="org.labkey.panoramapublic.model.Journal" %>
 <%@ page import="org.labkey.panoramapublic.model.JournalExperiment" %>
 <%@ page import="org.labkey.panoramapublic.query.JournalManager" %>
-<%@ page import="org.labkey.api.util.Link" %>
 <%@ page import="org.labkey.panoramapublic.model.DataLicense" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
@@ -55,7 +54,7 @@
             PanoramaPublicController.getViewExperimentDetailsURL(annot.getId(), getContainer()));
     ActionURL deleteUrl = PanoramaPublicController.getDeleteExperimentURL(getContainer(), annot.getId(), getContainer().getStartURL(getUser()));
 
-    ActionURL publishUrl = PanoramaPublicController.getPrePublishExperimentCheckURL(annot.getId(), getContainer());
+    ActionURL publishUrl = PanoramaPublicController.getPublishExperimentURL(annot.getId(), getContainer(), true, true);
     Container experimentContainer = annot.getContainer();
     final boolean canEdit = (!annot.isJournalCopy() || getUser().hasSiteAdminPermission()) && experimentContainer.hasPermission(getUser(), InsertPermission.class);
     // User needs to be the folder admin to publish an experiment.
@@ -79,6 +78,7 @@
         if(!journalCopyPending)
         {
             publishButtonText = "Resubmit";
+            publishUrl = PanoramaPublicController.getRePublishExperimentURL(annot.getId(), je.getJournalId(), getContainer(), je.isKeepPrivate(), true); // Has been copied; User is re-submitting
         }
     }
     String accessUrl = accessUrlRecord == null ? null : accessUrlRecord.renderShortURL();

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp
@@ -24,6 +24,8 @@
 <%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
 <%@ page import="org.labkey.api.view.ShortURLRecord" %>
 <%@ page import="org.labkey.panoramapublic.model.DataLicense" %>
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
@@ -62,24 +64,36 @@
 %>
 
 <div>
-    <%if(!form.isUpdate()) { %>
-    You are giving access to <%=h(journal)%> to make a copy of your data.
+    <%if(form.isResubmit()) { %>
+    This experiment has already been copied by <%=h(journal)%>. If you click OK the existing copy on <%=h(journal)%> will be deleted and a request will be sent to make a new copy.
     <br>
-    <% } else { %>
+    <% } else if(form.isUpdate()) { %>
     You are updating your submission request to <%=h(journal)%>.
     <br>
+    <% } else { %>
+    You are giving access to <%=h(journal)%> to make a copy of your data.
     <% } %>
     The access link is: <%=h(ShortURLRecord.renderShortURL(form.getShortAccessUrl()))%>.
     <br>
     <%if(form.isKeepPrivate()) {%>
-    Your data on <%=h(journal)%> will be kept private and a reviewer account will be provided to you.
+    Your data on <%=h(journal)%> will be kept private
+    <%if(!form.isResubmit()) { %> and a reviewer account will be provided to you.<% } else {%>
+    . The reviewer account details will be the same as before.<% } %>
     <%} else { %>
     Your data on <%=h(journal)%> will be made public.
     <% } %>
     <%if(form.isGetPxid()) { %>
         <br><br>
-        A ProteomeXchange ID will be requested for your data.
-        The following user information will be submitted to ProteomeXchange:
+        <%if(!form.isResubmit()) { %>
+            A ProteomeXchange ID will be requested for your data.
+        <% } else { %>
+            The ProteomeXchange ID assigned to your data will remain the same as before.
+        <% } %>
+        <%if(form.isIncompletePxSubmission()) { %>
+        <br> The data will be submitted as "supported by repository but incomplete data and/or metadata" when it is made public on ProteomeXchange.
+        <%}%>
+        <br>
+        The following user information will be submitted to ProteomeXchange<%if(form.isKeepPrivate()) { %> when this data is made public<%}%>:
         <br>
         <span style="font-weight:bold;">Submitter:</span>
         <ul>
@@ -100,6 +114,7 @@
             <% } %>
         </ul>
         <br>
+
     <% } %>
     <div style="font-weight:bold;font-style:italic;margin-top:10px;">
         <%if(form.isKeepPrivate()) { %>
@@ -111,4 +126,24 @@
     </div>
 <br>
     Are you sure you want to continue?
+</div>
+<div>
+<labkey:form action="<%=getActionURL().clone().deleteParameters()%>" method="POST">
+    <%= button("Cancel").href(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(expAnnotations.getContainer())) %>
+    <%= button("OK").submit(true) %>
+    <input type="hidden" name="update" value="<%=form.isUpdate()%>"/>
+    <input type="hidden" name="dataValidated" value="<%=form.isDataValidated()%>"/>
+    <input type="hidden" name="resubmit" value="<%=form.isResubmit()%>"/>
+    <input type="hidden" name="requestConfirmed" value="true"/>
+    <input type="hidden" name="id" value="<%=form.getId()%>"/>
+    <input type="hidden" name="journalId" value="<%=form.getJournalId()%>"/>
+    <input type="hidden" name="shortAccessUrl" value="<%=h(form.getShortAccessUrl())%>"/>
+    <input type="hidden" name="keepPrivate" value="<%=form.isKeepPrivate()%>"/>
+    <input type="hidden" name="getPxid" value="<%=form.isGetPxid()%>"/>
+    <input type="hidden" name="incompletePxSubmission" value="<%=form.isIncompletePxSubmission()%>"/>
+    <input type="hidden" name="labHeadName" value="<%=h(form.getLabHeadName())%>"/>
+    <input type="hidden" name="labHeadEmail" value="<%=h(form.getLabHeadEmail())%>"/>
+    <input type="hidden" name="labHeadAffiliation" value="<%=h(form.getLabHeadAffiliation())%>"/>
+    <input type="hidden" name="dataLicense" value="<%=h(form.getDataLicense())%>"/>
+</labkey:form>
 </div>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
@@ -48,7 +48,7 @@
     ExperimentAnnotations expAnnot = bean.lookupExperiment();
     Journal journal = bean.lookupJournal();
     JournalExperiment je = JournalManager.getJournalExperiment(expAnnot.getId(), journal.getId());
-    ExperimentAnnotations previousCopy = je.getJournalExperimentId() != null ? ExperimentAnnotationsManager.get(je.getJournalExperimentId()) : null;
+    ExperimentAnnotations previousCopy = je.getCopiedExperimentId() != null ? ExperimentAnnotationsManager.get(je.getCopiedExperimentId()) : null;
     boolean isRecopy = previousCopy != null;
 
     String selectedFolder = "Please select a destination folder...";

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
@@ -49,7 +49,7 @@
     ExperimentAnnotations expAnnot = bean.lookupExperiment();
     Journal journal = bean.lookupJournal();
     JournalExperiment je = JournalManager.getJournalExperiment(expAnnot.getId(), journal.getId());
-    ExperimentAnnotations previousCopy = je.getJournalExperimentId() != null ? ExperimentAnnotationsManager.get(je.getJournalExperimentId()) : null;
+    ExperimentAnnotations previousCopy = je.getCopiedExperimentId() != null ? ExperimentAnnotationsManager.get(je.getCopiedExperimentId()) : null;
     boolean isRecopy = previousCopy != null;
 
     String selectedFolder = "Please select a destination folder...";
@@ -177,14 +177,13 @@
                 },
                 {
                     xtype: 'checkbox',
-                    hidden: <%=isRecopy%>,
                     fieldLabel: "Assign ProteomeXchange ID",
                     checked: <%=bean.isAssignPxId()%>,
-                    name: 'assignPxId'
+                    name: 'assignPxId',
+                    boxLabel: 'This box will be checked if the user requested a ProteomeXchange ID. Admin doing the copy can override if needed.'
                 },
                 {
                     xtype: 'checkbox',
-                    hidden: <%=isRecopy%>,
                     fieldLabel: "Use ProteomeXchange Test Database",
                     checked: <%=bean.isUsePxTestDb()%>,
                     name: 'usePxTestDb',

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
@@ -63,9 +63,10 @@
             PanoramaPublicController.getViewExperimentDetailsURL(expAnnotations.getId(), getContainer()));
 
     String continueSubmissionText;
+    String continueIncomplete = "Continue with an incomplete ProteomeXchange submission";
     if(status.canSubmitToPx())
     {
-        continueSubmissionText = bean.isNotSubmitting() ? "Data is valid for an \"incomplete\" ProteomeXchange submission." : "Continue with an incomplete ProteomeXchange submission";
+        continueSubmissionText = bean.isNotSubmitting() ? "Data is valid for an \"incomplete\" ProteomeXchange submission." : continueIncomplete;
     }
     else
     {
@@ -160,7 +161,7 @@
         <div style="color:steelblue;margin-bottom: 10px;">
             Raw data and search results used to build spectrum libraries associated with Skyline documents are required
             for a "complete" ProteomeXchange submission.
-            You can click the <span style="font-weight:bold;">"<%=h(continueSubmissionText)%>"</span> link
+            You can click the <span style="font-weight:bold;">"<%=h(continueIncomplete)%>"</span> link
             at the top of the page to proceed with an "incomplete" ProteomeXchange submission.
             You will see the link only if all the raw files imported into the Skyline documents have been uploaded and all
             the required experiment metadata (e.g. abstract, organism, instrument etc.) has been provided.

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
@@ -25,7 +25,6 @@
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicManager" %>
 <%@ page import="org.labkey.panoramapublic.proteomexchange.ExperimentModificationGetter" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.labkey.api.util.Link" %>
 <%@ page import="org.labkey.panoramapublic.model.JournalExperiment" %>
 <%@ page import="org.labkey.panoramapublic.query.JournalManager" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -41,31 +40,51 @@
 
 <labkey:errors/>
 <%
-    JspView<SubmissionDataStatus> me = (JspView<SubmissionDataStatus>) HttpView.currentView();
-    SubmissionDataStatus bean = me.getModelBean();
+    JspView<PanoramaPublicController.PreSubmissionCheckForm> me = (JspView<PanoramaPublicController.PreSubmissionCheckForm>) HttpView.currentView();
+    PanoramaPublicController.PreSubmissionCheckForm bean = me.getModelBean();
+    SubmissionDataStatus status = bean.getValidationStatus();
 
-    ExperimentAnnotations expAnnotations = bean.getExperimentAnnotations();
+    ExperimentAnnotations expAnnotations = status.getExperimentAnnotations();
     JournalExperiment je = JournalManager.getLastPublishedRecord(expAnnotations.getId());
-    boolean resubmit = je != null;
+    boolean requestPxId = status.canSubmitToPx(); // Request a PX ID if the data validates for a PX submission.
+    boolean doIncompletePxSubmission = status.isIncomplete();
 
     ActionURL rawFilesUrl = PanoramaPublicManager.getRawDataTabUrl(getContainer());
-    ActionURL formUrl = PanoramaPublicController.getPublishExperimentURL(expAnnotations.getId(), getContainer(),
-            true,  // keep private.
-            false); // don't request a PX ID.
+    boolean keepPrivate = je == null ? true : je.isKeepPrivate();
+    int journalId = je == null ? 0 : je.getJournalId();
+
+    ActionURL submitUrl = je == null ? new ActionURL(PanoramaPublicController.PublishExperimentAction.class, getContainer()) // Data has not yet been submitted.
+            : (je.getCopied()) == null ?
+            new ActionURL(PanoramaPublicController.UpdateJournalExperimentAction.class, getContainer()) // Data submitted but not copied yet.
+            :
+            new ActionURL(PanoramaPublicController.RepublishJournalExperimentAction.class, getContainer()); // Data has been copied to Panorama Public.  This is a re-submit.
+
     ActionURL editUrl = PanoramaPublicController.getEditExperimentDetailsURL(getContainer(), expAnnotations.getId(),
             PanoramaPublicController.getViewExperimentDetailsURL(expAnnotations.getId(), getContainer()));
 
+    String continueSubmissionText;
+    if(status.canSubmitToPx())
+    {
+        continueSubmissionText = bean.isNotSubmitting() ? "Data is valid for an \"incomplete\" ProteomeXchange submission." : "Continue with an incomplete ProteomeXchange submission";
+    }
+    else
+    {
+        continueSubmissionText = bean.isNotSubmitting() ? "Data cannot be submitted to ProteomeXchange.": "Continue without a ProteomeXchange ID";
+    }
 %>
 
 <div style="margin: 30px 20px 20px 20px">
-    The following information is required for getting a ProteomeXchange ID for your submission.
-    <% if(!resubmit) {%> <span style="margin-left:10px;"><%=link("Continue Without ProteomeXchange ID", formUrl)%></span> <%}%>
+    <% if(bean.isNotSubmitting()) {%>
+        <%=h(continueSubmissionText)%> <br><br>
+    <% } %>
+    The following information is required for a "complete" ProteomeXchange submission. <span style="margin-left:10px;">
+    <% if(!bean.isNotSubmitting()) {%> <%=link(continueSubmissionText).onClick("submitForm();")%></span> <% } %>
 
-    <% if(bean.hasMissingMetadata()) { %>
+    <% if(status.hasMissingMetadata()) { %>
     <div style="margin-top:10px;margin-bottom:20px;">
         <span style="font-weight:bold;">Missing experiment metadata:</span>
         <ul>
-            <%for(String missing: bean.getMissingMetadata()) {%>
+            <%for(String missing: status.getMissingMetadata()) {%>
             <li><%=h(missing)%></li>
             <%}%>
         </ul>
@@ -73,7 +92,7 @@
     </div>
     <%}%>
 
-    <% if(bean.hasInvalidModifications()) { %>
+    <% if(status.hasInvalidModifications()) { %>
     <div style="margin-top:10px;margin-bottom:20px;">
         <span style="font-weight:bold;">The following modifications do not have a Unimod ID:</span>
         <table class="table-condensed table-striped table-bordered" style="margin-top:1px; margin-bottom:2px;">
@@ -84,7 +103,7 @@
             </tr>
             </thead>
             <tbody>
-            <%for(ExperimentModificationGetter.PxModification mod: bean.getInvalidMods()) {%>
+            <%for(ExperimentModificationGetter.PxModification mod: status.getInvalidMods()) {%>
             <tr>
                 <td>
                     <%for(String run: mod.getSkylineDocs()){%>
@@ -102,7 +121,7 @@
     </div>
     <%}%>
 
-    <% if(bean.hasMissingRawFiles()) { %>
+    <% if(status.hasMissingRawFiles()) { %>
     <div style="margin-top:10px;">
         <span style="font-weight:bold;">Missing raw data:</span>
         <table class="table-condensed table-striped table-bordered" style="margin-top:1px; margin-bottom:5px;">
@@ -113,7 +132,7 @@
             </tr>
             </thead>
             <tbody>
-            <%for(SubmissionDataStatus.MissingRawData missingData: bean.getMissingRawData()) {%>
+            <%for(SubmissionDataStatus.MissingRawData missingData: status.getMissingRawData()) {%>
             <tr>
                 <td>
                     <%for(String run: missingData.getSkyDocs()){%>
@@ -133,9 +152,34 @@
     </div>
     <%}%>
 
-    <% if(bean.hasMissingLibrarySourceFiles()) { %>
+    <% if(status.hasMissingLibrarySourceFiles()) { %>
     <div style="margin-top:10px;">
         <span style="font-weight:bold;">Missing files for spectrum libraries:</span>
+
+        <br>
+        <div style="color:steelblue;margin-bottom: 10px;">
+            Raw data and search results used to build spectrum libraries associated with Skyline documents are required
+            for a "complete" ProteomeXchange submission.
+            You can click the <span style="font-weight:bold;">"<%=h(continueSubmissionText)%>"</span> link
+            at the top of the page to proceed with an "incomplete" ProteomeXchange submission.
+            You will see the link only if all the raw files imported into the Skyline documents have been uploaded and all
+            the required experiment metadata (e.g. abstract, organism, instrument etc.) has been provided.
+
+            <br><br>
+            You do not have to upload the files used to build a spectrum library if one of the following conditions applies:
+            <ul>
+                <li>Raw data and search results have been uploaded to another ProteomeXchange repository</li>
+                <li>The library was downloaded from a public resource</li>
+                <li>The library is irrelevant to results OR was used only as supporting information</li>
+            </ul>
+            If one of the above applies, you can respond to the confirmation email from Panorama Public after your data has been
+            copied.  In your email, please include the reason for not uploading files for a spectrum library.
+            If the files are in another ProteomeXchange repository such as PRIDE or MassIVE then let us know the PXD accession of
+            the data and the reviewer account details if the data in the repository is private.  For a library that was downloaded
+            from a public resource please provide the URL of the resource.
+            We will upgrade your submission to a "complete" ProteomeXchange submission if we are able to verify the details.
+        </div>
+
         <table class="table-condensed table-striped table-bordered" style="margin-top:1px; margin-bottom:5px;">
             <thead>
             <tr>
@@ -146,7 +190,7 @@
             </tr>
             </thead>
             <tbody>
-            <%for(Map.Entry<String, SubmissionDataStatus.MissingLibrarySourceFiles> missingFiles: bean.getMissingLibFiles().entrySet()) {%>
+            <%for(Map.Entry<String, SubmissionDataStatus.MissingLibrarySourceFiles> missingFiles: status.getMissingLibFiles().entrySet()) {%>
             <tr>
                 <td>
                     <%=h(missingFiles.getKey())%>
@@ -170,9 +214,64 @@
             <%}%>
             </tbody>
         </table>
-        <%=button("Upload Raw Data").href(rawFilesUrl).build()%> <span>(Drag and drop to the files browser in the Raw Data tab to upload files)</span>
+        <%=button("Upload Library Source Data").href(rawFilesUrl).build()%> <span>(Drag and drop to the files browser in the Raw Data tab to upload files)</span>
     </div>
     <%}%>
 
 </div>
+<div id="publishExperimentForm"></div>
+<script type="text/javascript">
+    var publishForm;
+    Ext4.onReady(function()
+    {
+        publishForm = Ext4.create('Ext.form.Panel', {
+            renderTo: "publishExperimentForm",
+            standardSubmit: true,
+            border: false,
+            frame: false,
+            items: [
+                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
+                {
+                    xtype: 'hidden',
+                    name: 'id',
+                    value: <%=expAnnotations.getId()%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'journalId',
+                    value: <%=journalId%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'keepPrivate',
+                    value: <%=keepPrivate%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'getPxid',
+                    value: <%=requestPxId%>,
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'incompletePxSubmission',
+                    value: <%=doIncompletePxSubmission%>,
+                }
+            ]
+        });
+    });
+
+    function submitForm()
+    {
+        if(publishForm)
+        {
+            var values = publishForm.getForm().getValues();
+            // console.log(values);
+            publishForm.submit({url: <%=q(submitUrl.getLocalURIString())%>, method: 'GET', params: values});
+        }
+        else
+        {
+            alert("Could not continue with the request. Please contact the server administrator.");
+        }
+    }
+</script>
 

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
@@ -51,15 +51,19 @@
     ActionURL rawFilesUrl = PanoramaPublicManager.getRawDataTabUrl(getContainer());
     ActionURL formUrl = PanoramaPublicController.getPublishExperimentURL(expAnnotations.getId(), getContainer(),
             true,  // keep private.
-            false); // don't request a PX ID.
+            bean.canSubmitToPx()); // don't request a PX ID.
     ActionURL editUrl = PanoramaPublicController.getEditExperimentDetailsURL(getContainer(), expAnnotations.getId(),
             PanoramaPublicController.getViewExperimentDetailsURL(expAnnotations.getId(), getContainer()));
 
+    String incompleteSubmissionTxt = "Continue with an incomplete ProteomeXchange submission";
+    String continueSubmissionText = bean.canSubmitToPx() ? incompleteSubmissionTxt : "Continue without ProteomeXchange ID";
 %>
 
 <div style="margin: 30px 20px 20px 20px">
-    The following information is required for getting a ProteomeXchange ID for your submission.
-    <% if(!resubmit) {%> <span style="margin-left:10px;"><%=link("Continue Without ProteomeXchange ID", formUrl)%></span> <%}%>
+    The following information is required for a "complete" ProteomeXchange submission.
+    <% if(!resubmit || resubmit && bean.canSubmitToPx()) {%>
+        <span style="margin-left:10px;"><%=link(continueSubmissionText, formUrl)%></span>
+    <%}%>
 
     <% if(bean.hasMissingMetadata()) { %>
     <div style="margin-top:10px;margin-bottom:20px;">
@@ -136,6 +140,31 @@
     <% if(bean.hasMissingLibrarySourceFiles()) { %>
     <div style="margin-top:10px;">
         <span style="font-weight:bold;">Missing files for spectrum libraries:</span>
+
+        <br>
+        <div style="color:steelblue;margin-bottom: 10px;">
+            Raw data and search results used to build spectrum libraries associated with Skyline documents are required
+            for a "complete" ProteomeXchange submission.
+            You can click the <span style="font-weight:bold;">"<%=h(incompleteSubmissionTxt)%>"</span> link
+            at the top of the page to proceed with an "incomplete" ProteomeXchange submission.
+            You will see the link only if all the raw files imported into the Skyline documents have been uploaded and all
+            the required experiment metadata (e.g. abstract, organism, instrument etc.) has been provided.
+
+            <br><br>
+            You do not have to upload the files used to build a spectrum library if one of the following conditions applies:
+            <ul>
+                <li>Raw data and search results have been uploaded to another ProteomeXchange repository</li>
+                <li>The library was downloaded from a public resource</li>
+                <li>The library is irrelevant to results OR was used only as supporting information</li>
+            </ul>
+            If one of the above applies, you can respond to the confirmation email from Panorama Public after your data has been
+            copied.  In your email, please include the reason for not uploading files for a spectrum library.
+            If the files are in another ProteomeXchange repository such as PRIDE or MassIVE then let us know the PXD accession of
+            the data and the reviewer account details if the data in the repository is private.  For a library that was downloaded
+            from a public resource please provide the URL of the resource.
+            We will upgrade your submission to a "complete" ProteomeXchange submission if we are able to verify the details.
+        </div>
+
         <table class="table-condensed table-striped table-bordered" style="margin-top:1px; margin-bottom:5px;">
             <thead>
             <tr>
@@ -170,7 +199,7 @@
             <%}%>
             </tbody>
         </table>
-        <%=button("Upload Raw Data").href(rawFilesUrl).build()%> <span>(Drag and drop to the files browser in the Raw Data tab to upload files)</span>
+        <%=button("Upload Library Source Data").href(rawFilesUrl).build()%> <span>(Drag and drop to the files browser in the Raw Data tab to upload files)</span>
     </div>
     <%}%>
 

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
@@ -60,9 +60,13 @@
     Set<Container> experimentFolders = ExperimentAnnotationsManager.getExperimentFolders(expAnnotations, getUser());
 
     boolean isUpdate = bean.getForm().isUpdate();
-    String publishButtonText = isUpdate ? "Update" : "Submit";
-    String submitUrl = isUpdate ? new ActionURL(PanoramaPublicController.UpdateJournalExperimentAction.class, getContainer()).getLocalURIString() :
-            new ActionURL(PanoramaPublicController.PublishExperimentAction.class, getContainer()).getLocalURIString();
+    boolean isResubmit = bean.getForm().isResubmit();
+    String publishButtonText = isUpdate ? "Update" : (isResubmit ? "Resubmit" : "Submit");
+    String submitUrl = isUpdate ? new ActionURL(PanoramaPublicController.UpdateJournalExperimentAction.class, getContainer()).getLocalURIString()
+            : (isResubmit ?
+              new ActionURL(PanoramaPublicController.RepublishJournalExperimentAction.class, getContainer()).getLocalURIString()
+            : new ActionURL(PanoramaPublicController.PublishExperimentAction.class, getContainer()).getLocalURIString());
+
     String cancelUrl = PanoramaPublicController.getViewExperimentDetailsURL(bean.getForm().getId(), getContainer()).getLocalURIString();
 
     boolean siteAdmin = getUser().hasSiteAdminPermission();
@@ -156,6 +160,16 @@
                 },
                 {
                     xtype: 'hidden',
+                    name: 'resubmit',
+                    value: <%=isResubmit%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'dataValidated',
+                    value: <%=bean.getForm().isDataValidated()%>
+                },
+                {
+                    xtype: 'hidden',
                     name: 'id',
                     value: <%=bean.getExperimentAnnotations().getId()%>
                 },
@@ -166,7 +180,7 @@
                 },
 
                 // If the user is updating an existing entry, don't allow them to choose a journal
-                <%if(bean.getForm().isUpdate()) { %>
+                <%if(isUpdate || isResubmit) { %>
                     {
                         xtype: 'displayfield',
                         fieldLabel: "Submit To",
@@ -194,6 +208,19 @@
                         value: <%=journalId%>
                     },
                 <%}%>
+                // If the user is resubmitting the experiment we will not change the short access url
+                <%if(isResubmit) { %>
+                {
+                    xtype: 'displayfield',
+                    fieldLabel: "Short Access URL",
+                    value: <%=q(shortAccessUrl)%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'shortAccessUrl',
+                    value: <%=q(shortAccessUrl)%>
+                },
+                <%} else { %>
                 {
                     xtype: 'textfield',
                     name: 'shortAccessUrl',
@@ -218,6 +245,7 @@
                         }
                     }
                 },
+                <%}%>
                 {
                     xtype: 'checkbox',
                     fieldLabel: "Keep Private",
@@ -229,10 +257,15 @@
                 {
                     xtype: 'checkbox',
                     fieldLabel: "Get ProteomeXchange ID",
-                    hidden: <%=!siteAdmin%>,
+                    hidden: <%=!form.isGetPxid()%>, // This field will be set to true if this is data is valid for PX.  Hide the field otherwise.
                     checked: <%=form.isGetPxid()%>,
                     name: 'getPxid',
                     boxLabel: 'Check this box to get a ProteomeXchange ID for your data.'
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'incompletePxSubmission',
+                    value: <%=form.isIncompletePxSubmission()%>,
                 },
                 {
                     xtype: 'textfield',
@@ -305,27 +338,6 @@
                             }
                         }
                     }
-                },
-                {
-                    xtype: 'checkbox',
-                    fieldLabel: "Skip Raw Data Check",
-                    hidden: <%=!siteAdmin%>,
-                    checked: false,
-                    name: 'skipRawDataCheck'
-                },
-                {
-                    xtype: 'checkbox',
-                    fieldLabel: "Skip Meta Data Check",
-                    hidden: <%=!siteAdmin%>,
-                    checked: false,
-                    name: 'skipMetaDataCheck'
-                },
-                {
-                    xtype: 'checkbox',
-                    fieldLabel: "Skip Modifications Check",
-                    hidden: <%=!siteAdmin%>,
-                    checked: false,
-                    name: 'skipModCheck'
                 }
             ],
             buttonAlign: 'left',
@@ -337,7 +349,7 @@
                     console.log(values);
                     form.submit({
                         url: <%=q(submitUrl)%>,
-                        method: 'GET',
+                        method: 'POST',
                         params: values
                         });
                     }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
@@ -33,26 +33,20 @@
 %>
 
 <%
-    JspView<PanoramaPublicController.PxExportForm> me = (JspView<PanoramaPublicController.PxExportForm>) HttpView.currentView();
-    PanoramaPublicController.PxExportForm bean = me.getModelBean();
+    JspView<PanoramaPublicController.PxActionsForm> me = (JspView<PanoramaPublicController.PxActionsForm>) HttpView.currentView();
+    PanoramaPublicController.PxActionsForm bean = me.getModelBean();
     ExperimentAnnotations expAnnot = bean.lookupExperiment();
-
-    ActionURL generateXmlUrl = new ActionURL(PanoramaPublicController.ExportPxXmlAction.class, getContainer());
-    generateXmlUrl.addParameter("id", expAnnot.getId());
-
-    ActionURL validateXmlUrl = new ActionURL(PanoramaPublicController.ValidatePxXmlAction.class, getContainer());
-    validateXmlUrl.addParameter("id", expAnnot.getId());
 %>
 
 
-<div id="pxExportForm"></div>
+<div id="pxMethodsForm"></div>
 
 <script type="text/javascript">
 
     Ext4.onReady(function(){
 
         var form = Ext4.create('Ext.form.Panel', {
-            renderTo: "pxExportForm",
+            renderTo: "pxMethodsForm",
             standardSubmit: true,
             border: false,
             frame: false,
@@ -71,7 +65,6 @@
                 {
                     xtype:'displayfield',
                     fieldLabel: "Experiment ID",
-                    name: 'id',
                     value: <%=expAnnot.getId()%>
                 },
                 {
@@ -80,54 +73,15 @@
                     value: <%=expAnnot.getId()%>
                 },
                 {
-                    xtype: 'checkbox',
-                    fieldLabel: 'Peer Reviewed',
-                    name: 'peerReviewed',
-                    value: <%=bean.getPeerReviewed()%>,
-                    afterBodyEl: '<span style="font-size: 0.75em;margin-left:5px;">Check if data has been peer reviewed and published.</span>',
-                    msgTarget : 'side'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'PubMed ID',
-                    value: <%=q(bean.getPublicationId())%>,
-                    name: 'publicationId'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Reference',
-                    value: <%=q(bean.getPublicationReference())%>,
-                    name: 'publicationReference'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Lab Head',
-                    name: 'labHeadName'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Lab Head Email',
-                    name: 'labHeadEmail'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Lab Head Affiliation',
-                    name: 'labHeadAffiliation'
+                    xtype:'hiddenfield',
+                    name: 'method',
+                    value: <%=q(bean.getMethod())%>
                 },
                 {
                     xtype: 'textfield',
                     fieldLabel: 'PX Change Log',
-                    name: 'changeLog'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'PX User Name',
-                    name: 'pxUserName'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'PX Password',
-                    name: 'pxPassword'
+                    name: 'changeLog',
+                    value: <%=q(bean.getChangeLog())%>
                 },
                 {
                     xtype: 'checkbox',
@@ -165,31 +119,23 @@
                                 params: values
                             });
                         },
+                        margin: '20 30 0 0'
+                    },
+                    {
+                        text: 'Get PX ID',
+                        cls: 'labkey-button primary',
+                        handler: function() {
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.GET_ID.toString())%>);
+                            submitPxForm();
+                        },
                         margin: '20 10 0 0'
                     },
                     {
                         text: 'Validate PX XML',
                         cls: 'labkey-button',
                         handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.ValidatePxXmlAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
-                        },
-                        margin: '20 10 0 0'
-                    },
-                    {
-                        text: 'Get PX ID',
-                        cls: 'labkey-button primary',
-                        handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.SavePxIdAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.VALIDATE.toString())%>);
+                            submitPxForm();
                         },
                         margin: '20 10 0 0'
                     },
@@ -197,12 +143,8 @@
                         text: 'Submit PX XML',
                         cls: 'labkey-button primary',
                         handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.SubmitPxXmlAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.SUBMIT.toString())%>);
+                            submitPxForm();
                         },
                         margin: '20 10 0 0'
                     },
@@ -210,16 +152,21 @@
                         text: 'Update PX XML',
                         cls: 'labkey-button primary',
                         handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.UpdatePxXmlAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.UPDATE.toString())%>);
+                            submitPxForm();
                         },
                         margin: '20 10 0 0'
                     }
             ]
         });
+
+        function submitPxForm() {
+            var values = form.getForm().getValues();
+            form.submit({
+                url: <%=q(new ActionURL(PanoramaPublicController.GetPxActionsAction.class, getContainer()).getLocalURIString())%>,
+                method: 'POST',
+                params: values
+            });
+        }
     });
 </script>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
@@ -34,26 +34,21 @@
 %>
 
 <%
-    JspView<PanoramaPublicController.PxExportForm> me = (JspView<PanoramaPublicController.PxExportForm>) HttpView.currentView();
-    PanoramaPublicController.PxExportForm bean = me.getModelBean();
+    JspView<PanoramaPublicController.PxActionsForm> me = (JspView<PanoramaPublicController.PxActionsForm>) HttpView.currentView();
+    PanoramaPublicController.PxActionsForm bean = me.getModelBean();
     ExperimentAnnotations expAnnot = bean.lookupExperiment();
-
-    ActionURL generateXmlUrl = new ActionURL(PanoramaPublicController.ExportPxXmlAction.class, getContainer());
-    generateXmlUrl.addParameter("id", expAnnot.getId());
-
-    ActionURL validateXmlUrl = new ActionURL(PanoramaPublicController.ValidatePxXmlAction.class, getContainer());
-    validateXmlUrl.addParameter("id", expAnnot.getId());
 %>
 
 
-<div id="pxExportForm"></div>
+<div id="pxMethodsForm"></div>
+<div id="pxLinks"></div>
 
 <script type="text/javascript">
 
     Ext4.onReady(function(){
 
         var form = Ext4.create('Ext.form.Panel', {
-            renderTo: "pxExportForm",
+            renderTo: "pxMethodsForm",
             standardSubmit: true,
             border: false,
             frame: false,
@@ -72,7 +67,6 @@
                 {
                     xtype:'displayfield',
                     fieldLabel: "Experiment ID",
-                    name: 'id',
                     value: <%=expAnnot.getId()%>
                 },
                 {
@@ -81,54 +75,15 @@
                     value: <%=expAnnot.getId()%>
                 },
                 {
-                    xtype: 'checkbox',
-                    fieldLabel: 'Peer Reviewed',
-                    name: 'peerReviewed',
-                    value: <%=bean.getPeerReviewed()%>,
-                    afterBodyEl: '<span style="font-size: 0.75em;margin-left:5px;">Check if data has been peer reviewed and published.</span>',
-                    msgTarget : 'side'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'PubMed ID',
-                    value: <%=q(bean.getPublicationId())%>,
-                    name: 'publicationId'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Reference',
-                    value: <%=q(bean.getPublicationReference())%>,
-                    name: 'publicationReference'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Lab Head',
-                    name: 'labHeadName'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Lab Head Email',
-                    name: 'labHeadEmail'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'Lab Head Affiliation',
-                    name: 'labHeadAffiliation'
+                    xtype:'hiddenfield',
+                    name: 'method',
+                    value: <%=q(bean.getMethod())%>
                 },
                 {
                     xtype: 'textfield',
                     fieldLabel: 'PX Change Log',
-                    name: 'changeLog'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'PX User Name',
-                    name: 'pxUserName'
-                },
-                {
-                    xtype: 'textfield',
-                    fieldLabel: 'PX Password',
-                    name: 'pxPassword'
+                    name: 'changeLog',
+                    value: <%=q(bean.getChangeLog())%>
                 },
                 {
                     xtype: 'checkbox',
@@ -143,83 +98,79 @@
             buttonAlign: 'left',
             buttons: [
                     {
-                        text: 'PX XML Summary',
-                        cls: 'labkey-button',
+                        text: 'Get PX ID',
                         handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.PxXmlSummaryAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
-                        },
-                        margin: '20 10 0 0'
-                    },
-                    {
-                        text: 'Export PX XML',
-                        cls: 'labkey-button',
-                        handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.ExportPxXmlAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.GET_ID.toString())%>);
+                            submitPxForm();
                         },
                         margin: '20 10 0 0'
                     },
                     {
                         text: 'Validate PX XML',
-                        cls: 'labkey-button',
                         handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.ValidatePxXmlAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
-                        },
-                        margin: '20 10 0 0'
-                    },
-                    {
-                        text: 'Get PX ID',
-                        cls: 'labkey-button primary',
-                        handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.SavePxIdAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.VALIDATE.toString())%>);
+                            submitPxForm();
                         },
                         margin: '20 10 0 0'
                     },
                     {
                         text: 'Submit PX XML',
-                        cls: 'labkey-button primary',
+                        style: 'background-color:red;',
                         handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.SubmitPxXmlAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.SUBMIT.toString())%>);
+                            submitPxForm();
                         },
                         margin: '20 10 0 0'
                     },
                     {
                         text: 'Update PX XML',
-                        cls: 'labkey-button primary',
+                        style: 'background-color:red;',
                         handler: function() {
-                            var values = form.getForm().getValues();
-                            form.submit({
-                                url: <%=q(new ActionURL(PanoramaPublicController.UpdatePxXmlAction.class, getContainer()).getLocalURIString())%>,
-                                method: 'POST',
-                                params: values
-                            });
+                            form.getForm().findField('method').setValue(<%=q(PanoramaPublicController.PX_METHOD.UPDATE.toString())%>);
+                            submitPxForm();
                         },
                         margin: '20 10 0 0'
                     }
+            ]
+        });
+
+        function submitPxForm() {
+            var values = form.getForm().getValues();
+            form.submit({
+                url: <%=q(new ActionURL(PanoramaPublicController.GetPxActionsAction.class, getContainer()).getLocalURIString())%>,
+                method: 'POST',
+                params: values
+            });
+        }
+
+        var linksPanel = Ext4.create('Ext.panel.Panel', {
+            renderTo: "pxLinks",
+            bodyPadding: 5,
+            // width: 300,
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 150,
+                width: 500,
+                labelStyle: 'background-color: #E0E6EA; padding: 5px;'
+            },
+            items: [
+                {
+                    xtype: 'component',
+                    fieldLabel: "PX XML Summary",
+                    autoEl: {tag: 'a',
+                        href: <%=q(new ActionURL(PanoramaPublicController.PxXmlSummaryAction.class, getContainer()).addParameter("id", expAnnot.getId()).getLocalURIString())%>,
+                        html: 'Get PX XML Summary',
+                        style: 'font-weight: bold; margin-right: 10px'}
+                },
+                {
+                    xtype: 'component',
+                    fieldLabel: "Export PX XML",
+                    autoEl: {tag: 'a',
+                        href: <%=q(new ActionURL(PanoramaPublicController.ExportPxXmlAction.class, getContainer()).addParameter("id", expAnnot.getId()).getLocalURIString())%>,
+                        html: 'Export PX XML file',
+                        style: 'font-weight: bold'}
+                }
             ]
         });
     });

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -110,7 +110,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         // Click Submit.  Expect to see the missing information page
         testSubmitWithMissingRawFiles(portalHelper, expWebPart);
 
-        // Submit the experiment by clicking the "Continue Without ProteomeXchange ID" link
+        // Submit the experiment by clicking the "Continue without ProteomeXchange ID" link
         portalHelper.click(Locator.folderTab("Panorama Dashboard"));
         expWebPart.submitWithoutPXId();
         assertTextPresent("Copy Pending!");
@@ -271,7 +271,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         public void submitWithoutPXId()
         {
             findElement(Locator.linkContainingText("Submit")).click();
-            waitAndClick(Locator.linkContainingText("Continue Without ProteomeXchange ID"));
+            waitAndClick(Locator.linkContainingText("Continue without ProteomeXchange ID"));
             getWrapper()._ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PANORAMA_PUBLIC);
             waitAndClick(Locator.linkContainingText("Submit"));
             waitAndClick(Locator.lkButton("OK")); // Confirm to proceed with the submission.

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -110,7 +110,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         // Click Submit.  Expect to see the missing information page
         testSubmitWithMissingRawFiles(portalHelper, expWebPart);
 
-        // Submit the experiment by clicking the "Continue Without ProteomeXchange ID" link
+        // Submit the experiment by clicking the "Continue without a ProteomeXchange ID" link
         portalHelper.click(Locator.folderTab("Panorama Dashboard"));
         expWebPart.submitWithoutPXId();
         assertTextPresent("Copy Pending!");
@@ -169,7 +169,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         goToProjectHome(getProjectName());
         impersonate(SUBMITTER);
         portalHelper.click(Locator.folderTab("Panorama Dashboard"));
-        expWebPart.resubmit();
+        expWebPart.resubmitWithoutPxd();
 
         stopImpersonating();
         goToProjectHome(PANORAMA_PUBLIC);
@@ -271,9 +271,9 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         public void submitWithoutPXId()
         {
             findElement(Locator.linkContainingText("Submit")).click();
-            waitAndClick(Locator.linkContainingText("Continue Without ProteomeXchange ID"));
+            waitAndClick(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
             getWrapper()._ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PANORAMA_PUBLIC);
-            waitAndClick(Locator.linkContainingText("Submit"));
+            waitAndClick(Ext4Helper.Locators.ext4Button("Submit"));
             waitAndClick(Locator.lkButton("OK")); // Confirm to proceed with the submission.
             waitAndClick(Locator.linkWithSpan("Back to Experiment Details")); // Navigate to the experiment details page.
         }
@@ -283,12 +283,18 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
             clickAndWait(Locator.linkContainingText("Submit"));
         }
 
-        public void resubmit()
+        public void resubmitWithoutPxd()
         {
             Locator.XPathLocator resubmitLink = Locator.linkContainingText("Resubmit");
             assertNotNull("Expected to see a \"Resubmit\" button", resubmitLink);
             clickAndWait(resubmitLink);
-            waitAndClick(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+            waitAndClick(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
+            waitForText("Resubmit Request to ");
+            click(Ext4Helper.Locators.ext4Button(("Resubmit")));
+            waitForText("Confirm resubmission request to");
+            click(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+            waitForText("Request resubmitted to");
+            click(Locator.linkWithSpan("Back to Experiment Details")); // Navigate to the experiment details page.
         }
     }
 


### PR DESCRIPTION
#### Rationale
- Issue 40097: Add version information to PX XML
- Issue 40572: Incomplete data and/or metadata submission to ProteomeXchange

#### Changes
- Added table to store submitted xml, version number and any change log
- Added auto increment PK column to the JournalExperiment table
- Updated SubmissionDataValidator to check for incomplete / partial submission (i.e. has raw files imported into Skyline documents + required metadata but could have non-Unimod modifications and / or spectrum library source files)
- Updated notifications to include information about incomplete submissions
- Updated PX HTML summary and PX XML to include include incomplete submission tag where required. Other updates to HTML summary to display publication related info that will be submitted
- Cleaned up submission action classes. Consolidated work in PublishExperimentAction and two subclasses for update and resubmit. Removed unused fields in form.
- Cleaned up PX actions. Single action class handles getting a PX ID, XML validation, submission and update.
