### PR TITLE
PanoramaPublic: Fix issues noted while testing on panoramweb-dr

### DIFF
--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -215,7 +215,7 @@
                     <fkDbSchema>panoramapublic</fkDbSchema>
                     <fkTable>ExperimentAnnotations</fkTable>
                 </fk>
-                <url>/panoramapublic/showExperimentAnnotations.view?id=${ExperimentAnnotationsId}</url>
+                <url>/panoramapublic-showExperimentAnnotations.view?id=${ExperimentAnnotationsId}</url>
             </column>
             <column columnName="ShortAccessURL">
                 <columnTitle>Access Link</columnTitle>
@@ -243,7 +243,15 @@
                 <columnTitle>License</columnTitle>
             </column>
             <column columnName="AnnouncementId"/>
-            <column columnName="CopiedExperimentId"/>
+            <column columnName="CopiedExperimentId">
+                <columnTitle>Data Copy</columnTitle>
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>panoramapublic</fkDbSchema>
+                    <fkTable>ExperimentAnnotations</fkTable>
+                </fk>
+                <url>/panoramapublic-showExperimentAnnotations.view?id=${CopiedExperimentId}</url>
+            </column>
             <column columnName="IncompletePxSubmission"/>
             <column columnName="Modified"/>
             <column columnName="ModifiedBy">

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -2917,7 +2917,7 @@ public class PanoramaPublicController extends SpringActionController
 
             if(!_experimentAnnotations.isJournalCopy())
             {
-                errors.reject(ERROR_MSG, "Experiment is not a jounal copy. Cannot update PX ID and other details.");
+                errors.reject(ERROR_MSG, "Experiment is not a journal copy. Cannot update PX ID and other details.");
                 return;
             }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -89,6 +89,7 @@ import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.permissions.AbstractActionPermissionTest;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
 import org.labkey.api.security.permissions.AdminPermission;
@@ -910,10 +911,37 @@ public class PanoramaPublicController extends SpringActionController
                 }
             }
 
-            if(form.isSendEmail() && StringUtils.isBlank(form.getToEmailAddresses()))
+            List<String> recipientEmails = new ArrayList<>();
+            String replyToEmail = null;
+            if(form.isSendEmail())
             {
-                errors.reject(ERROR_MSG, "Please enter at least one email address.");
-                return false;
+                if(StringUtils.isBlank(form.getToEmailAddresses()))
+                {
+                    errors.reject(ERROR_MSG, "Please enter at least one email address.");
+                    return false;
+                }
+
+                for(String email: form.getToEmailAddressList())
+                {
+                    ValidEmail vEmail = getValidEmail(email, "Invalid email address in \"To\" field: " + email, errors);
+                    if(vEmail != null)
+                    {
+                        recipientEmails.add(vEmail.getEmailAddress());
+                    }
+                }
+
+                if(!StringUtils.isBlank(form.getReplyToAddress()))
+                {
+                    ValidEmail vEmail = getValidEmail(form.getReplyToAddress(), "Invalid email address in \"Reply-To\" field: " + form.getReplyToAddress(), errors);
+                    if(vEmail != null)
+                    {
+                        replyToEmail = vEmail.getEmailAddress();
+                    }
+                }
+                if(errors.getErrorCount() > 0)
+                {
+                    return false;
+                }
             }
 
             Container parentContainer = form.lookupDestParentContainer();
@@ -958,7 +986,8 @@ public class PanoramaPublicController extends SpringActionController
                 job.setUsePxTestDb(form.isUsePxTestDb());
                 job.setReviewerEmailPrefix(form.getReviewerEmailPrefix());
                 job.setEmailSubmitter(form.isSendEmail());
-                job.setToEmailAddresses(form.getToEmailAddressList());
+                job.setToEmailAddresses(recipientEmails);
+                job.setReplyToAddress(replyToEmail);
                 job.setDeletePreviousCopy(form.isDeleteOldCopy());
                 PipelineService.get().queueJob(job);
 
@@ -969,6 +998,19 @@ public class PanoramaPublicController extends SpringActionController
             catch (PipelineValidationException e){
                 return false;
             }
+        }
+
+        private ValidEmail getValidEmail(String email, String errMsg, BindException errors)
+        {
+            try
+            {
+                return new ValidEmail(email);
+            }
+            catch (ValidEmail.InvalidEmailException e)
+            {
+                errors.reject(ERROR_MSG, errMsg + ". " + e.getMessage());
+            }
+            return null;
         }
 
         @Override
@@ -994,6 +1036,7 @@ public class PanoramaPublicController extends SpringActionController
         private boolean _usePxTestDb; // Use the test database for getting a PX ID if true
         private boolean _sendEmail;
         private String _toEmailAddresses;
+        private String _replyToAddress;
         private boolean _deleteOldCopy;
 
         static void setDefaults(CopyExperimentForm form, ExperimentAnnotations sourceExperiment, JournalExperiment je)
@@ -1132,6 +1175,16 @@ public class PanoramaPublicController extends SpringActionController
         public void setToEmailAddresses(String toEmailAddresses)
         {
             _toEmailAddresses = toEmailAddresses;
+        }
+
+        public String getReplyToAddress()
+        {
+            return _replyToAddress;
+        }
+
+        public void setReplyToAddress(String replyToAddress)
+        {
+            _replyToAddress = replyToAddress;
         }
 
         public boolean isDeleteOldCopy()
@@ -1429,21 +1482,27 @@ public class PanoramaPublicController extends SpringActionController
             setTitle(getSuccessViewTitle());
             String journal = _journal.getName();
             ActionURL returnUrl = PanoramaPublicController.getViewExperimentDetailsURL(_experimentAnnotations.getId(), getContainer());
-            StringBuilder html = new StringBuilder();
-            html.append("Thank you for submitting your data to ").append(PageFlowUtil.filter(journal)).append("!");
-            html.append(" We will send you a confirmation email once your data has been copied. This can take up to a week.");
+
+            String dataPrivate = "";
             if(form.isKeepPrivate())
             {
-                html.append("<br>Your data on ").append(PageFlowUtil.filter(journal)).append(" will be kept private and reviewer account details will be included in the confirmation email. ");
-            }
-            if(form.isGetPxid())
-            {
-                html.append("<br>A ProteomeXchange ID will be requested for your data and included in the confirmation email.");
+                dataPrivate = "Your data on " + journal + " will be kept private";
+                dataPrivate += form.isResubmit() ? ". The reviewer account details will be the same before." : " and reviewer account details will be included in the confirmation email.";
             }
 
-            html.append("<br><br>");
-            html.append("<a href=" + returnUrl.getEncodedLocalURIString() + "><span class=\"labkey-button\">Back to Experiment Details</span></a>");
-            HtmlView view = new HtmlView(html.toString());
+            String pxdAssigned = "";
+            if(form.isGetPxid())
+            {
+                pxdAssigned = form.isResubmit() ? "The ProteomeXchange ID assigned to the data will remain the same as before."
+                        : "A ProteomeXchange ID will be requested for your data and included in the confirmation email.";
+            }
+
+            HtmlView view = new HtmlView(DIV(getSuccessViewText() + " We will send you a confirmation email once your data has been copied.  This can take upto a week.",
+                    DIV(dataPrivate),
+                    DIV(pxdAssigned),
+                    BR(), BR(),
+                    new Link.LinkBuilder("Back to Experiment Details").href(returnUrl).build()));
+
             view.setTitle(getSuccessViewTitle());
             return view;
         }
@@ -1451,6 +1510,11 @@ public class PanoramaPublicController extends SpringActionController
         String getSuccessViewTitle()
         {
             return "Request submitted to " + _journal.getName();
+        }
+
+        String getSuccessViewText()
+        {
+            return "Thank you for submitting your data to " + _journal.getName() + "!";
         }
 
         @Override
@@ -1883,40 +1947,16 @@ public class PanoramaPublicController extends SpringActionController
             return "Update submission request to " + _journal.getName();
         }
 
-        public ModelAndView getSuccessView(PublishExperimentForm form)
-        {
-            setTitle(getSuccessViewTitle());
-            String journal = _journal.getName();
-            ActionURL returnUrl = PanoramaPublicController.getViewExperimentDetailsURL(_experimentAnnotations.getId(), getContainer());
-
-            String dataPrivate = "";
-            if(form.isKeepPrivate())
-            {
-                dataPrivate = "Your data on " + journal + " will be kept private";
-                dataPrivate += form.isResubmit() ? ". The reviewer account details will be the same before." : " and reviewer account details will be included in the confirmation email.";
-            }
-
-            String pxdAssigned = "";
-            if(form.isGetPxid())
-            {
-                pxdAssigned = form.isResubmit() ? "The ProteomeXchange ID assigned to the data will remain the same as before."
-                        : "A ProteomeXchange ID will be requested for your data and included in the confirmation email.";
-            }
-
-            HtmlView view = new HtmlView(DIV("Your submission request has been upated. We will send you a confirmation email once your data has been copied.  This can take upto a week.",
-                                         DIV(dataPrivate),
-                                         DIV(pxdAssigned),
-                                         BR(), BR(),
-                                         new Link.LinkBuilder("Back to Experiment Details").href(returnUrl).build()));
-
-            view.setTitle(getSuccessViewTitle());
-            return view;
-        }
-
         @Override
         String getSuccessViewTitle()
         {
             return "Updated submission request to " + _journal.getName();
+        }
+
+        @Override
+        String getSuccessViewText()
+        {
+            return "Your submission request to " + _journal.getName() + " has been updated.";
         }
 
         @Override
@@ -2066,7 +2106,7 @@ public class PanoramaPublicController extends SpringActionController
             setTitle("Confirm Delete Submission");
             HtmlView view = new HtmlView(DIV("Are you sure you want to cancel your submission request to " + _journal.getName() + "?",
                     BR(), BR(),
-                    SPAN("Experiment " + _experimentAnnotations.getTitle())));
+                    SPAN("Experiment: " + _experimentAnnotations.getTitle())));
             view.setTitle("Cancel Submission Request to " + _journal.getName());
             return view;
         }
@@ -2148,6 +2188,12 @@ public class PanoramaPublicController extends SpringActionController
         String getSuccessViewTitle()
         {
             return "Request resubmitted to " + _journal.getName();
+        }
+
+        @Override
+        String getSuccessViewText()
+        {
+            return "Your request to " + _journal.getName() + " has been resubmitted.";
         }
 
         @Override
@@ -2579,6 +2625,12 @@ public class PanoramaPublicController extends SpringActionController
 
         public void assignPxId(boolean useTestDb, boolean testMode, String pxUser, String pxPassword, BindException errors) throws ProteomeXchangeServiceException
         {
+            if(!StringUtils.isBlank(_expAnnot.getPxid()))
+            {
+                errors.reject(ERROR_MSG, "A PX ID is already assigned to the experiment.");
+                return;
+            }
+
             _pxResponse = ProteomeXchangeService.getPxIdResponse(useTestDb, pxUser, pxPassword);
             String pxid = ProteomeXchangeService.parsePxIdFromResponse(_pxResponse);
             if(pxid != null)
@@ -2845,6 +2897,118 @@ public class PanoramaPublicController extends SpringActionController
         }
     }
 
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class UpdatePxDetailsAction extends FormViewAction<PxDetailsForm>
+    {
+        private ExperimentAnnotations _experimentAnnotations;
+        private JournalExperiment _journalExperiment;
+
+        @Override
+        public void validateCommand(PxDetailsForm form, Errors errors)
+        {
+            _experimentAnnotations = form.lookupExperiment();
+            if(_experimentAnnotations == null)
+            {
+                errors.reject(ERROR_MSG, "Cannot find experiment with ID " + form.getId());
+                return;
+            }
+
+            ensureCorrectContainer(getContainer(), _experimentAnnotations.getContainer(), getViewContext());
+
+            if(!_experimentAnnotations.isJournalCopy())
+            {
+                errors.reject(ERROR_MSG, "Experiment is not a jounal copy. Cannot update PX ID and other details.");
+                return;
+            }
+
+            _journalExperiment = JournalManager.getRowForJournalCopy(_experimentAnnotations);
+            if(_journalExperiment == null)
+            {
+                errors.reject(ERROR_MSG, "Could not find a row in JournalExperiment for copied experiment " + _experimentAnnotations.getId());
+            }
+        }
+
+        @Override
+        public ModelAndView getView(PxDetailsForm form, boolean reshow, BindException errors)
+        {
+            if(!reshow)
+            {
+               validateCommand(form, errors);
+               if(errors.getErrorCount() > 0)
+               {
+                   return new SimpleErrorView(errors);
+               }
+               form.setPxId(_experimentAnnotations.getPxid());
+               form.setIncompletePxSubmission(_journalExperiment.isIncompletePxSubmission());
+            }
+
+            JspView view = new JspView<>("/org/labkey/panoramapublic/view/publish/updatePxDetails.jsp", form, errors);
+            view.setFrame(WebPartView.FrameType.PORTAL);
+            view.setTitle("Update ProteomeXchange Details");
+            return view;
+        }
+
+        @Override
+        public boolean handlePost(PxDetailsForm form, BindException errors)
+        {
+            String pxid = form.getPxId();
+            if(!StringUtils.isBlank(pxid) && !pxid.matches(ProteomeXchangeService.PXID))
+            {
+                errors.reject(ERROR_MSG, "Invalid ProteomeXchange ID");
+                return false;
+            }
+
+            try(DbScope.Transaction transaction = PanoramaPublicManager.getSchema().getScope().ensureTransaction())
+            {
+                _experimentAnnotations.setPxid(pxid);
+                ExperimentAnnotationsManager.updatePxId(_experimentAnnotations, pxid);
+
+                _journalExperiment.setIncompletePxSubmission(form.isIncompletePxSubmission());
+                JournalManager.updateJournalExperiment(_journalExperiment, getUser());
+
+                transaction.commit();
+            }
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(PxDetailsForm pxDetailsForm)
+        {
+            return PanoramaPublicController.getViewExperimentDetailsURL(_experimentAnnotations.getId(), _experimentAnnotations.getContainer());
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            root.addChild("Update ProteomeXchange Details");
+        }
+    }
+
+    public static class PxDetailsForm extends ExperimentIdForm
+    {
+        private String _pxId;
+        private boolean _incompletePxSubmission;
+
+        public String getPxId()
+        {
+            return _pxId;
+        }
+
+        public void setPxId(String pxId)
+        {
+            _pxId = pxId;
+        }
+
+        public boolean isIncompletePxSubmission()
+        {
+            return _incompletePxSubmission;
+        }
+
+        public void setIncompletePxSubmission(boolean incompletePxSubmission)
+        {
+            _incompletePxSubmission = incompletePxSubmission;
+        }
+    }
     // ------------------------------------------------------------------------
     // END Actions for ProteomeXchange
     // ------------------------------------------------------------------------
@@ -3822,7 +3986,8 @@ public class PanoramaPublicController extends SpringActionController
                 new JournalGroupDetailsAction(),
                 new DeleteJournalGroupAction(),
                 new GetPxActionsAction(),
-                new ExportPxXmlAction()
+                new ExportPxXmlAction(),
+                new UpdatePxDetailsAction()
             );
 
             // @AdminConsoleAction

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentJobSupport.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentJobSupport.java
@@ -41,6 +41,7 @@ public interface CopyExperimentJobSupport
 
     boolean emailSubmitter();
     List<String> toEmailAddresses();
+    String replyToAddress();
 
     boolean deletePreviousCopy();
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -56,6 +56,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
 
     private boolean _emailSubmitter;
     private List<String> _toEmailAddresses;
+    private String _replyToAddress;
 
     private boolean _deletePreviousCopy;
 
@@ -188,6 +189,12 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     }
 
     @Override
+    public String replyToAddress()
+    {
+        return _replyToAddress;
+    }
+
+    @Override
     public boolean deletePreviousCopy()
     {
         return _deletePreviousCopy;
@@ -216,6 +223,11 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     public void setToEmailAddresses(List<String> toEmailAddresses)
     {
         _toEmailAddresses = toEmailAddresses;
+    }
+
+    public void setReplyToAddress(String replyToAddress)
+    {
+        _replyToAddress = replyToAddress;
     }
 
     public void setDeletePreviousCopy(boolean deletePreviousCopy)

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
@@ -36,7 +36,8 @@ public class ProteomeXchangeService
     public static final String PX_USER = "ProteomeXchange User";
     public static final String PX_PASSWORD = "ProteomeXchange Password";
 
-    private static final Pattern PXID = Pattern.compile("identifier=(PX[DT]\\d{6})");
+    public static final String PXID = "PX[DT]\\d{6}";
+    private static final Pattern PXID_IN_RESPONSE = Pattern.compile("identifier=(" + PXID + ")");
 
     private enum METHOD {submitDataset, validateXML, requestID}
 
@@ -89,7 +90,7 @@ public class ProteomeXchangeService
 
     public static String parsePxIdFromResponse(String response)
     {
-        Matcher match = PXID.matcher(response);
+        Matcher match = PXID_IN_RESPONSE.matcher(response);
         if(match.find())
         {
             return match.group(1);

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
@@ -32,7 +32,6 @@ import java.util.Map;
 public class PxHtmlWriter extends PxWriter
 {
     private final StringBuilder _output;
-    private boolean _usePxTestDb;
 
     private static final Logger LOG = Logger.getLogger(PxHtmlWriter.class);
 
@@ -44,7 +43,6 @@ public class PxHtmlWriter extends PxWriter
     @Override
     public void write(PanoramaPublicController.PxExperimentAnnotations bean) throws PxException
     {
-        _usePxTestDb = bean.isUseTestDb();
         super.write(bean);
     }
 
@@ -52,7 +50,6 @@ public class PxHtmlWriter extends PxWriter
     void begin(ExperimentAnnotations experimentAnnotations)
     {
         _output.append("<div><table class=\"table-condensed table-striped table-bordered\">");
-        tr("PX Test Database", String.valueOf(_usePxTestDb));
         tr("Experiment ID", String.valueOf(experimentAnnotations.getId()));
         tr("Title", experimentAnnotations.getTitle());
         String pxid = experimentAnnotations.getPxid();

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalExperimentTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalExperimentTableInfo.java
@@ -110,6 +110,7 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
         columns.add(FieldKey.fromParts("Delete"));
         columns.add(FieldKey.fromParts("DataLicense"));
         columns.add(FieldKey.fromParts("PxidRequested"));
+        columns.add(FieldKey.fromParts("CopiedExperimentId"));
         setDefaultVisibleColumns(columns);
     }
 
@@ -132,9 +133,13 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
             SQLFragment joinToExpAnnotSql = new SQLFragment("INNER JOIN ");
             joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
             joinToExpAnnotSql.append(" ON ( ");
-            joinToExpAnnotSql.append("exp.id");
-            joinToExpAnnotSql.append(" = ");
-            joinToExpAnnotSql.append("ExperimentAnnotationsId");
+            // JournalExperiment table contains two experiment id (table ExperimentAnnotations) columns. One for the source experiment and another for the
+            // experiment copied to Panorama Public. We want to see the JournalExperiment row in the containers of both the source experiment and the
+            // Panorama Public copy so we are filtering on the Container columns of both experiments.
+            // This means, however, that when the container filter is changed to "All Folders", the user will see duplicate rows for a row in JournalExperiment
+            // if they have read permissions in both containers.
+            joinToExpAnnotSql.append("exp.id = ").append("ExperimentAnnotationsId");
+            joinToExpAnnotSql.append(" OR exp.id = ").append("CopiedExperimentId");
             joinToExpAnnotSql.append(" ) ");
 
             sql.append(joinToExpAnnotSql);
@@ -151,12 +156,10 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
     public static class DeleteUrlDisplayColumnFactory implements DisplayColumnFactory
     {
         private final ActionURL _url;
-        private final String _linkText;
 
         DeleteUrlDisplayColumnFactory(Container container)
         {
             _url = new ActionURL(PanoramaPublicController.DeleteJournalExperimentAction.class, container);
-            _linkText = "Delete";
         }
 
         @Override
@@ -167,18 +170,15 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
                 @Override
                 public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
                 {
-                    String experimentAnnotationsId = String.valueOf(ctx.get("ExperimentAnnotationsId"));
-                    String journalId = String.valueOf(ctx.get("JournalId"));
-                    if(ctx.get("Copied") != null)
+                    Integer experimentAnnotationsId = ctx.get(colInfo.getFieldKey(), Integer.class);
+                    Integer journalId = ctx.get(FieldKey.fromParts("JournalId"), Integer.class);
+                    Integer copiedExperimentId = ctx.get(FieldKey.fromParts("CopiedExperimentId"), Integer.class);
+                    if(copiedExperimentId == null)
                     {
-                        // Do not show the delete link if the experiment has already been copied by a journal
-                        out.write("");
-                    }
-                    else
-                    {
-                        _url.replaceParameter("id", experimentAnnotationsId);
-                        _url.replaceParameter("journalId", journalId);
-                        out.write(PageFlowUtil.link(_linkText).href(_url).toString());
+                        // Show the delete link only if the experiment has not yet been copied
+                        _url.replaceParameter("id", String.valueOf(experimentAnnotationsId));
+                        _url.replaceParameter("journalId", String.valueOf(journalId));
+                        out.write(PageFlowUtil.link("Delete").href(_url).toString());
                     }
                 }
 
@@ -186,7 +186,8 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
                 public void addQueryFieldKeys(Set<FieldKey> keys)
                 {
                     super.addQueryFieldKeys(keys);
-                    keys.add(FieldKey.fromParts("Copied"));
+                    keys.add(FieldKey.fromParts("JournalId"));
+                    keys.add(FieldKey.fromParts("CopiedExperimentId"));
                 }
             };
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
@@ -216,6 +216,13 @@
                     afterBodyEl: '<span style="font-size: 0.9em;">Enter one email address per line</span>'
                 },
                 {
+                    xtype: 'textfield',
+                    fieldLabel: "Email address (Reply-To:)",
+                    value: <%=q(bean.getReplyToAddress())%>,
+                    name: 'replyToAddress',
+                    width: 450
+                },
+                {
                     xtype: 'checkbox',
                     hidden: <%=!isRecopy%>,
                     fieldLabel: "Delete Previous Copy",

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
@@ -346,7 +346,6 @@
                 cls: 'labkey-button primary',
                 handler: function() {
                     var values = form.getForm().getValues();
-                    console.log(values);
                     form.submit({
                         url: <%=q(submitUrl)%>,
                         method: 'POST',

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
@@ -21,6 +21,8 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
 <%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <labkey:errors/>
@@ -39,9 +41,8 @@
     ExperimentAnnotations expAnnot = bean.lookupExperiment();
 %>
 
-
-<div id="pxMethodsForm"></div>
 <div id="pxLinks"></div>
+<div id="pxMethodsForm"></div>
 
 <script type="text/javascript">
 
@@ -146,7 +147,7 @@
         var linksPanel = Ext4.create('Ext.panel.Panel', {
             renderTo: "pxLinks",
             bodyPadding: 5,
-            // width: 300,
+            layout: {type: 'vbox', align: 'left'},
             border: false,
             frame: false,
             defaults: {
@@ -161,7 +162,7 @@
                     autoEl: {tag: 'a',
                         href: <%=q(new ActionURL(PanoramaPublicController.PxXmlSummaryAction.class, getContainer()).addParameter("id", expAnnot.getId()).getLocalURIString())%>,
                         html: 'Get PX XML Summary',
-                        style: 'font-weight: bold; margin-right: 10px'}
+                        style: 'font-weight: bold;'}
                 },
                 {
                     xtype: 'component',
@@ -169,6 +170,15 @@
                     autoEl: {tag: 'a',
                         href: <%=q(new ActionURL(PanoramaPublicController.ExportPxXmlAction.class, getContainer()).addParameter("id", expAnnot.getId()).getLocalURIString())%>,
                         html: 'Export PX XML file',
+                        style: 'font-weight: bold'}
+                },
+                {
+                    xtype: 'component',
+                    fieldLabel: "Update PX ID And Submission Type",
+                    autoEl: {tag: 'a',
+                        href: <%=q(new ActionURL(PanoramaPublicController.UpdatePxDetailsAction.class, getContainer()).addParameter("id", expAnnot.getId())
+                                 .addReturnURL(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(expAnnot.getContainer())).getLocalURIString())%>,
+                        html: 'Update PX ID And Submission Type',
                         style: 'font-weight: bold'}
                 }
             ]

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/updatePxDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/updatePxDetails.jsp
@@ -1,0 +1,96 @@
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
+<%@ page extends="org.labkey.api.jsp.FormPage" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<labkey:errors/>
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("Ext4");
+    }
+%>
+
+<%
+    PanoramaPublicController.PxDetailsForm form = ((JspView<PanoramaPublicController.PxDetailsForm>) HttpView.currentView()).getModelBean();
+    ExperimentAnnotations expAnnot = form.lookupExperiment();
+    ActionURL cancelUrl = form.getReturnActionURL(PanoramaPublicController.getViewExperimentDetailsURL(expAnnot.getId(), expAnnot.getContainer()));
+%>
+<div style="margin-top:15px;margin-bottom:15px;color:red;bont-weight:bold" id="updateDetailsForm">
+    This form should be used only if:
+    <ul>
+        <li>A ProteomeXchange ID from the test database was accidentally assigned to the experiment and has to be changed</li>
+        <li>User submitted an "incomplete" submission before we were setup to handle spectrum library data and we now need to upgrade the submission to a "complete" submission</li>
+    </ul>
+</div>
+<div style="margin-top:15px;" id="updateDetailsForm"></div>
+<script type="text/javascript">
+
+    Ext4.onReady(function(){
+
+        var form = Ext4.create('Ext.form.Panel', {
+            renderTo: "updateDetailsForm",
+            standardSubmit: true,
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 250,
+                width: 800,
+                labelStyle: 'background-color: #E0E6EA; padding: 5px;'
+            },
+            items: [
+                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
+                {
+                    xtype: 'displayfield',
+                    fieldLabel: "Experiment",
+                    value: <%=q(expAnnot.getTitle())%>
+                },
+                {
+                    xtype:'hidden',
+                    name: 'id',
+                    value: <%=expAnnot.getId()%>
+                },
+                {
+                    xtype: 'textfield',
+                    fieldLabel: 'ProteomeXchange ID',
+                    name: 'pxId',
+                    width: 650,
+                    value: <%=q(form.getPxId())%>
+                },
+                {
+                    xtype: 'checkbox',
+                    fieldLabel: "Incomplete ProteomeXchange Submission",
+                    checked: <%=form.isIncompletePxSubmission()%>,
+                    name: 'incompletePxSubmission',
+                    boxLabel: 'This box will be checked if the user requested an "incomplete" ProteomeXchange submission. Admin can override if needed.'
+                },
+            ],
+            buttonAlign: 'left',
+            buttons: [
+                {
+                    text: 'Update',
+                    cls: 'labkey-button primary',
+                    handler: function() {
+                        var values = form.getForm().getValues();
+                        form.submit({
+                            url: <%=q(new ActionURL(PanoramaPublicController.UpdatePxDetailsAction.class, getContainer()).getLocalURIString())%>,
+                            method: 'POST',
+                            params: values
+                        });
+                    },
+                    margin: '20 10 0 10'
+                },
+                {
+                    text: 'Cancel',
+                    cls: 'labkey-button',
+                    hrefTarget: '_self',
+                    href: <%=q(cancelUrl.getLocalURIString())%>
+                }
+            ]
+        });
+    });
+</script>

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -275,7 +275,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
             getWrapper()._ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PANORAMA_PUBLIC);
             waitAndClick(Ext4Helper.Locators.ext4Button("Submit"));
             waitAndClick(Locator.lkButton("OK")); // Confirm to proceed with the submission.
-            waitAndClick(Locator.linkWithSpan("Back to Experiment Details")); // Navigate to the experiment details page.
+            waitAndClick(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
         }
 
         public void clickSubmit()
@@ -294,7 +294,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
             waitForText("Confirm resubmission request to");
             click(Locator.lkButton("OK")); // Confirm to proceed with the submission.
             waitForText("Request resubmitted to");
-            click(Locator.linkWithSpan("Back to Experiment Details")); // Navigate to the experiment details page.
+            click(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
         }
     }
 


### PR DESCRIPTION
#### Rationale
Fix issues noted while testing on panoramaweb-dr

#### Changes
- Remove "Data Pipeline" tab in the copy on Panorama Public.
- Show column for Panorama Public copy in the JournalExperiment grid.
- JournalExperiment row can be viewed both from the container that contains the source experiment and the Panorama Public copy container.
- Fixed text displayed in the confirm and success views when an experiment is submitted / resubmitted.
- Added optional reply-to email field in the copy experiment form. Used for sending confirmation email to submitter.
- Added action to change assigned PXD and the "complete"/"incomplete" PX submission type.