### PR TITLE
Use q(URLHelper) and h(URLHelper). Use urlFor() instead of buildURL().

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
@@ -570,7 +570,7 @@ a.banner-button-small{
             <h2><%= h(reviewTitle) %></h2>
             <div class="ratingstars">
                 <div class="ratingempty">
-                    <div class="ratingfull" style="width:<%= h(ratingValue * 15) %>px;"></div>
+                    <div class="ratingfull" style="width:<%=ratingValue * 15%>px;"></div>
                 </div>
             </div>
             <br />

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
@@ -312,11 +312,11 @@
                     </div>
                     <div class="ratingcontent">
                         <div class="averagerating"><p><%= averageRatingRounded %> out of 5 stars</p></div>
-                        5 stars:<div id="rating-5-<%= h(tool.getRowId()) %>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[4])%>%;"></div><div style="margin-left:153px !important;"><%= h(ratingsBreakDown[4]) %></div></div><br>
-                        4 stars:<div id="rating-5-<%= h(tool.getRowId()) %>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[3])%>%;"></div><div style="margin-left:153px !important;"><%= h(ratingsBreakDown[3]) %></div></div><br>
-                        3 stars:<div id="rating-5-<%= h(tool.getRowId()) %>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[2])%>%;"></div><div style="margin-left:153px !important;"><%= h(ratingsBreakDown[2]) %></div></div><br>
-                        2 stars:<div id="rating-5-<%= h(tool.getRowId()) %>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[1])%>%;"></div><div style="margin-left:153px !important;"><%= h(ratingsBreakDown[1]) %></div></div><br>
-                        1 stars:<div id="rating-5-<%= h(tool.getRowId()) %>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[0])%>%;"></div><div style="margin-left:153px !important;"><%= h(ratingsBreakDown[0]) %></div></div><br>
+                        5 stars:<div id="rating-5-<%=tool.getRowId()%>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[4])%>%;"></div><div style="margin-left:153px !important;"><%=ratingsBreakDown[4]%></div></div><br>
+                        4 stars:<div id="rating-5-<%=tool.getRowId()%>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[3])%>%;"></div><div style="margin-left:153px !important;"><%=ratingsBreakDown[3]%></div></div><br>
+                        3 stars:<div id="rating-5-<%=tool.getRowId()%>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[2])%>%;"></div><div style="margin-left:153px !important;"><%=ratingsBreakDown[2]%></div></div><br>
+                        2 stars:<div id="rating-5-<%=tool.getRowId()%>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[1])%>%;"></div><div style="margin-left:153px !important;"><%=ratingsBreakDown[1]%></div></div><br>
+                        1 stars:<div id="rating-5-<%=tool.getRowId()%>" class="ratingbox"><div class="ratingboxover" style="width:<%=h(percentOfTotal[0])%>%;"></div><div style="margin-left:153px !important;"><%=ratingsBreakDown[0]%></div></div><br>
                         <div class="ratingfooter">
                             <p>
                                 <a href="<%= h(detailsUrl) %>">See all <%= totalReviews %> reviews</a>

--- a/lincs/src/org/labkey/lincs/view/customGCTForm.jsp
+++ b/lincs/src/org/labkey/lincs/view/customGCTForm.jsp
@@ -255,7 +255,7 @@
     }
 </script>
 
-<labkey:form action="<%=buildURL(LincsController.CreateCustomGCTAction.class)%>" method="post" id="customGCTForm">
+<labkey:form action="<%=urlFor(LincsController.CreateCustomGCTAction.class)%>" method="post" id="customGCTForm">
 
     <input type="hidden" name="selectedAnnotations"/>
 

--- a/lincs/src/org/labkey/lincs/view/downloadCustomGCT.jsp
+++ b/lincs/src/org/labkey/lincs/view/downloadCustomGCT.jsp
@@ -20,7 +20,10 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="org.labkey.lincs.LincsController" %>
+<%@ page import="org.labkey.lincs.LincsController.CustomGCTForm" %>
+<%@ page import="org.labkey.lincs.LincsController.DownloadCustomGCTReportAction" %>
+<%@ page import="org.labkey.lincs.LincsController.GctBean" %>
+<%@ page import="org.labkey.lincs.LincsController.SelectedAnnotation" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.stream.Collectors" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
@@ -35,12 +38,12 @@
     }
 %>
 <%
-    JspView<LincsController.CustomGCTForm> jspView = (JspView<LincsController.CustomGCTForm>) HttpView.currentView();
-    LincsController.CustomGCTForm form = jspView.getModelBean();
-    List<LincsController.SelectedAnnotation> annotations = form.getSelectedAnnotationValues();
-    LincsController.GctBean gctBean = form.getCustomGctBean();
+    JspView<CustomGCTForm> jspView = (JspView<CustomGCTForm>) HttpView.currentView();
+    CustomGCTForm form = jspView.getModelBean();
+    List<SelectedAnnotation> annotations = form.getSelectedAnnotationValues();
+    GctBean gctBean = form.getCustomGctBean();
 
-    ActionURL downloadGctUrl = new ActionURL(LincsController.DownloadCustomGCTReportAction.class, getContainer());
+    ActionURL downloadGctUrl = urlFor(DownloadCustomGCTReportAction.class);
     String fileName = FileUtil.getFileName(gctBean.getGctFile());
     downloadGctUrl.addParameter("fileName", fileName);
 %>
@@ -74,7 +77,7 @@
     <div style="font-weight:bold;">Selected options:</div>
     <p>Experiment type: <%=h(form.getExperimentType())%></p>
     <p>
-        <%for(LincsController.SelectedAnnotation annotation: annotations) { %>
+        <%for(SelectedAnnotation annotation: annotations) { %>
             <%=h(annotation.getDisplayName())%>:
             <%=h(annotation.getSortedValues().stream()
                     .collect(Collectors.joining(", ")))%>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -24,6 +24,9 @@
 <%@ page import="org.labkey.api.view.ShortURLRecord" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.ExperimentAnnotationsDetails" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.GetPxActionsAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.ShowExperimentAnnotationsAction" %>
 <%@ page import="org.labkey.panoramapublic.model.DataLicense" %>
 <%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
 <%@ page import="org.labkey.panoramapublic.model.Journal" %>
@@ -47,8 +50,8 @@
 %>
 
 <%
-    JspView<PanoramaPublicController.ExperimentAnnotationsDetails> me = (JspView<PanoramaPublicController.ExperimentAnnotationsDetails>) HttpView.currentView();
-    PanoramaPublicController.ExperimentAnnotationsDetails annotDetails = me.getModelBean();
+    JspView<ExperimentAnnotationsDetails> me = (JspView<ExperimentAnnotationsDetails>) HttpView.currentView();
+    ExperimentAnnotationsDetails annotDetails = me.getModelBean();
     ExperimentAnnotations annot = annotDetails.getExperimentAnnotations();
     ActionURL editUrl = PanoramaPublicController.getEditExperimentDetailsURL(getContainer(), annot.getId(),
             PanoramaPublicController.getViewExperimentDetailsURL(annot.getId(), getContainer()));
@@ -61,7 +64,7 @@
     final boolean canPublish = annotDetails.isCanPublish();
     final boolean showingFullDetails = annotDetails.isFullDetails();
 
-    ActionURL experimentDetailsUrl = new ActionURL(PanoramaPublicController.ShowExperimentAnnotationsAction.class, getContainer());
+    ActionURL experimentDetailsUrl = urlFor(ShowExperimentAnnotationsAction.class);
     experimentDetailsUrl.addParameter("id", annot.getId());
 
     Journal journal = null;
@@ -218,7 +221,7 @@
 <%}%>
 
 <%if(getUser().hasSiteAdminPermission()) {
-    ActionURL pxActionsUrl = new ActionURL(PanoramaPublicController.GetPxActionsAction.class, getContainer());
+    ActionURL pxActionsUrl = urlFor(GetPxActionsAction.class);
     pxActionsUrl.addParameter("id", annot.getId());
 %>
 <br/><div><%=link("ProteomeXchange Actions", pxActionsUrl)%></div>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/managePxCredentials.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/managePxCredentials.jsp
@@ -1,14 +1,14 @@
+<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
-<%@ page import="org.labkey.api.util.URLHelper" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.JournalGroupsAdminViewAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.PXCredentialsForm" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <labkey:errors/>
 <%
-    PanoramaPublicController.PXCredentialsForm form = ((JspView<PanoramaPublicController.PXCredentialsForm>) HttpView.currentView()).getModelBean();
-    ActionURL panoramaPublicAdminUrl = new ActionURL(PanoramaPublicController.JournalGroupsAdminViewAction.class, getContainer());
+    PXCredentialsForm form = ((JspView<PXCredentialsForm>) HttpView.currentView()).getModelBean();
+    ActionURL panoramaPublicAdminUrl = urlFor(JournalGroupsAdminViewAction.class);
 %>
 <p>
 <labkey:form method="post">

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
@@ -15,22 +15,25 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
+<%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
+<%@ page import="org.labkey.api.security.roles.RoleManager" %>
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.api.security.roles.RoleManager" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
-<%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.CopyExperimentAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.CopyExperimentForm" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.GetPxActionsAction" %>
 <%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
 <%@ page import="org.labkey.panoramapublic.model.Journal" %>
 <%@ page import="org.labkey.panoramapublic.model.JournalExperiment" %>
-<%@ page import="org.labkey.panoramapublic.query.JournalManager" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.panoramapublic.query.ExperimentAnnotationsManager" %>
-<%@ page import="org.labkey.api.portal.ProjectUrls" %>
+<%@ page import="org.labkey.panoramapublic.query.JournalManager" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <labkey:errors/>
@@ -44,8 +47,8 @@
 %>
 
 <%
-    JspView<PanoramaPublicController.CopyExperimentForm> me = (JspView<PanoramaPublicController.CopyExperimentForm>) HttpView.currentView();
-    PanoramaPublicController.CopyExperimentForm bean = me.getModelBean();
+    JspView<CopyExperimentForm> me = (JspView<CopyExperimentForm>) HttpView.currentView();
+    CopyExperimentForm bean = me.getModelBean();
     ExperimentAnnotations expAnnot = bean.lookupExperiment();
     Journal journal = bean.lookupJournal();
     JournalExperiment je = JournalManager.getJournalExperiment(expAnnot.getId(), journal.getId());
@@ -62,7 +65,7 @@
         }
     }
 
-    ActionURL pxActionsUrl = new ActionURL(PanoramaPublicController.GetPxActionsAction.class, getContainer());
+    ActionURL pxActionsUrl = urlFor(GetPxActionsAction.class);
     pxActionsUrl.addParameter("id", expAnnot.getId());
 
     ActionURL pxValidationUrl = PanoramaPublicController.getPrePublishExperimentCheckURL(expAnnot.getId(), expAnnot.getContainer(), true);
@@ -238,7 +241,7 @@
                     handler: function() {
                         var values = form.getForm().getValues();
                         form.submit({
-                            url: <%=q(new ActionURL(PanoramaPublicController.CopyExperimentAction.class, getContainer()).getLocalURIString())%>,
+                            url: <%=q(urlFor(CopyExperimentAction.class))%>,
                             method: 'POST',
                             params: values
                         });
@@ -249,7 +252,7 @@
                     text: 'Validate for ProteomeXchange',
                     cls: 'labkey-button',
                     handler: function(btn) {
-                        window.open(<%=q(pxValidationUrl.getLocalURIString())%>, "_blank");
+                        window.open(<%=q(pxValidationUrl)%>, "_blank");
                     }
                 }
             ]

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
@@ -267,7 +267,7 @@
         {
             var values = publishForm.getForm().getValues();
             // console.log(values);
-            publishForm.submit({url: <%=q(submitUrl.getLocalURIString())%>, method: 'GET', params: values});
+            publishForm.submit({url: <%=q(submitUrl)%>, method: 'GET', params: values});
         }
         else
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
@@ -25,6 +25,11 @@
 <%@ page import="org.labkey.api.view.ShortURLRecord" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.PublishExperimentAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.PublishExperimentForm" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.PublishExperimentFormBean" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.RepublishJournalExperimentAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.UpdateJournalExperimentAction" %>
 <%@ page import="org.labkey.panoramapublic.model.DataLicense" %>
 <%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
 <%@ page import="org.labkey.panoramapublic.model.Journal" %>
@@ -43,9 +48,9 @@
 
 <labkey:errors/>
 <%
-    JspView<PanoramaPublicController.PublishExperimentFormBean> me = (JspView<PanoramaPublicController.PublishExperimentFormBean>) HttpView.currentView();
-    PanoramaPublicController.PublishExperimentFormBean bean = me.getModelBean();
-    PanoramaPublicController.PublishExperimentForm form = bean.getForm();
+    JspView<PublishExperimentFormBean> me = (JspView<PublishExperimentFormBean>) HttpView.currentView();
+    PublishExperimentFormBean bean = me.getModelBean();
+    PublishExperimentForm form = bean.getForm();
 
     String shortAccessUrl = StringUtils.trimToEmpty(form.getShortAccessUrl());
 
@@ -62,12 +67,12 @@
     boolean isUpdate = bean.getForm().isUpdate();
     boolean isResubmit = bean.getForm().isResubmit();
     String publishButtonText = isUpdate ? "Update" : (isResubmit ? "Resubmit" : "Submit");
-    String submitUrl = isUpdate ? new ActionURL(PanoramaPublicController.UpdateJournalExperimentAction.class, getContainer()).getLocalURIString()
+    ActionURL submitUrl = isUpdate ? new ActionURL(UpdateJournalExperimentAction.class, getContainer())
             : (isResubmit ?
-              new ActionURL(PanoramaPublicController.RepublishJournalExperimentAction.class, getContainer()).getLocalURIString()
-            : new ActionURL(PanoramaPublicController.PublishExperimentAction.class, getContainer()).getLocalURIString());
+              new ActionURL(RepublishJournalExperimentAction.class, getContainer())
+            : new ActionURL(PublishExperimentAction.class, getContainer()));
 
-    String cancelUrl = PanoramaPublicController.getViewExperimentDetailsURL(bean.getForm().getId(), getContainer()).getLocalURIString();
+    ActionURL cancelUrl = PanoramaPublicController.getViewExperimentDetailsURL(bean.getForm().getId(), getContainer());
 
     boolean siteAdmin = getUser().hasSiteAdminPermission();
     boolean getLabHeadUserInfo = form.isGetPxid() && expAnnotations.getLabHeadUser() == null;

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
@@ -1,28 +1,31 @@
 <%
-    /*
-     * Copyright (c) 2018-2019 LabKey Corporation
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+/*
+ * Copyright (c) 2018-2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.api.portal.ProjectUrls" %>
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.ExportPxXmlAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.GetPxActionsAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.PxXmlSummaryAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.UpdatePxDetailsAction" %>
 <%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
-<%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <labkey:errors/>
@@ -138,7 +141,7 @@
         function submitPxForm() {
             var values = form.getForm().getValues();
             form.submit({
-                url: <%=q(new ActionURL(PanoramaPublicController.GetPxActionsAction.class, getContainer()).getLocalURIString())%>,
+                url: <%=q(urlFor(GetPxActionsAction.class))%>,
                 method: 'POST',
                 params: values
             });
@@ -160,7 +163,7 @@
                     xtype: 'component',
                     fieldLabel: "PX XML Summary",
                     autoEl: {tag: 'a',
-                        href: <%=q(new ActionURL(PanoramaPublicController.PxXmlSummaryAction.class, getContainer()).addParameter("id", expAnnot.getId()).getLocalURIString())%>,
+                        href: <%=q(urlFor(PxXmlSummaryAction.class).addParameter("id", expAnnot.getId()))%>,
                         html: 'Get PX XML Summary',
                         style: 'font-weight: bold;'}
                 },
@@ -168,7 +171,7 @@
                     xtype: 'component',
                     fieldLabel: "Export PX XML",
                     autoEl: {tag: 'a',
-                        href: <%=q(new ActionURL(PanoramaPublicController.ExportPxXmlAction.class, getContainer()).addParameter("id", expAnnot.getId()).getLocalURIString())%>,
+                        href: <%=q(urlFor(ExportPxXmlAction.class).addParameter("id", expAnnot.getId()))%>,
                         html: 'Export PX XML file',
                         style: 'font-weight: bold'}
                 },
@@ -176,8 +179,8 @@
                     xtype: 'component',
                     fieldLabel: "Update PX ID And Submission Type",
                     autoEl: {tag: 'a',
-                        href: <%=q(new ActionURL(PanoramaPublicController.UpdatePxDetailsAction.class, getContainer()).addParameter("id", expAnnot.getId())
-                                 .addReturnURL(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(expAnnot.getContainer())).getLocalURIString())%>,
+                        href: <%=q(urlFor(UpdatePxDetailsAction.class).addParameter("id", expAnnot.getId())
+                                 .addReturnURL(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(expAnnot.getContainer())))%>,
                         html: 'Update PX ID And Submission Type',
                         style: 'font-weight: bold'}
                 }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/updatePxDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/updatePxDetails.jsp
@@ -1,8 +1,10 @@
+<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.PxDetailsForm" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.UpdatePxDetailsAction" %>
 <%@ page import="org.labkey.panoramapublic.model.ExperimentAnnotations" %>
 <%@ page extends="org.labkey.api.jsp.FormPage" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -16,7 +18,7 @@
 %>
 
 <%
-    PanoramaPublicController.PxDetailsForm form = ((JspView<PanoramaPublicController.PxDetailsForm>) HttpView.currentView()).getModelBean();
+    PxDetailsForm form = ((JspView<PxDetailsForm>) HttpView.currentView()).getModelBean();
     ExperimentAnnotations expAnnot = form.lookupExperiment();
     ActionURL cancelUrl = form.getReturnActionURL(PanoramaPublicController.getViewExperimentDetailsURL(expAnnot.getId(), expAnnot.getContainer()));
 %>
@@ -77,7 +79,7 @@
                     handler: function() {
                         var values = form.getForm().getValues();
                         form.submit({
-                            url: <%=q(new ActionURL(PanoramaPublicController.UpdatePxDetailsAction.class, getContainer()).getLocalURIString())%>,
+                            url: <%=q(urlFor(UpdatePxDetailsAction.class))%>,
                             method: 'POST',
                             params: values
                         });
@@ -88,7 +90,7 @@
                     text: 'Cancel',
                     cls: 'labkey-button',
                     hrefTarget: '_self',
-                    href: <%=q(cancelUrl.getLocalURIString())%>
+                    href: <%=q(cancelUrl)%>
                 }
             ]
         });

--- a/signup/src/org/labkey/signup/SignUpAdmin.jsp
+++ b/signup/src/org/labkey/signup/SignUpAdmin.jsp
@@ -3,20 +3,22 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
 <%@ page import="org.labkey.api.data.PropertyManager" %>
-<%@ page import="org.labkey.api.security.SecurityManager" %>
+<%@ page import="org.labkey.api.security.Group" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ page import="org.labkey.api.security.SecurityManager" %>
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.signup.SignUpController" %>
+<%@ page import="org.labkey.signup.SignUpController.AddGroupChangeProperty" %>
+<%@ page import="org.labkey.signup.SignUpController.AddPropertyAction" %>
+<%@ page import="org.labkey.signup.SignUpController.RemoveGroupChangeProperty" %>
+<%@ page import="org.labkey.signup.SignUpController.RemovePropertyAction" %>
 <%@ page import="org.labkey.signup.SignUpModule" %>
+<%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.Set" %>
-<%@ page import="java.util.Arrays" %>
-<%@ page import="org.labkey.api.security.Group" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
 <%
     JspView<User> me = (JspView<User>) HttpView.currentView();
     User data = me.getModelBean();
@@ -52,12 +54,12 @@
 
 <!--Creates drop down list of all containers-->
 <h4 style="padding:0px; margin: 0px;">Add new user group rule</h4>
-<form <%=formAction(SignUpController.AddPropertyAction.class, Method.Post)%>><labkey:csrf/>
+<form <%=formAction(AddPropertyAction.class, Method.Post)%>><labkey:csrf/>
     <select id="containerId" name="containerId" onchange="loadGroups(this.value)">
         <option disabled selected> -- select an option -- </option>
         <%for(Container c: list) {
         m.put(String.valueOf(c.getRowId()), SecurityManager.getGroups(c.getProject(), false));%> <!--Adds container and associated groups to map-->
-        <option value="<%=h(c.getRowId())%>"><%=h(c.getPath())%></option>
+        <option value="<%=c.getRowId()%>"><%=h(c.getPath())%></option>
     <%}%>
     </select>
     <!--Creates a drop down list of all groups in selected container (dynamic) no ajax-->
@@ -80,7 +82,7 @@
             <tr>
                 <td><%=h(c.getPath())%></td>
                 <td><%=h(property.get(SignUpModule.SIGNUP_GROUP_NAME))%></td>
-                <td><%=link("Remove", new ActionURL(SignUpController.RemovePropertyAction.class, getContainer()).addParameter("containerId", c.getRowId())).usePost()%></td>
+                <td><%=link("Remove", urlFor(RemovePropertyAction.class).addParameter("containerId", c.getRowId())).usePost()%></td>
             </tr>
         <%}
     }%>
@@ -92,7 +94,7 @@
 
 <!--Creates drop down list of all groups-->
 <h4 style="padding:0px; margin: 0px;">Add group conversion rule</h4>
-<form <%=formAction(SignUpController.AddGroupChangeProperty.class, Method.Post)%>><labkey:csrf/>
+<form <%=formAction(AddGroupChangeProperty.class, Method.Post)%>><labkey:csrf/>
     <select id="oldgroup" name="oldgroup">
         <option disabled selected> -- select an option -- </option>
         <%for(Container c: list) {
@@ -100,7 +102,7 @@
             List<Group> groups = SecurityManager.getGroups(c.getProject(), false);%>
         <option disabled><%=h(c.getName())%></option>
           <%for(Group g: groups) {%>
-          <option value="<%=h(g.getUserId())%>">--<%=h(g.getName())%></option>
+          <option value="<%=g.getUserId()%>">--<%=h(g.getName())%></option>
         <%}}}%>
     </select>
     <select id="newgroup" name="newgroup">
@@ -110,7 +112,7 @@
                 List<Group>  groups = SecurityManager.getGroups(c.getProject(), false);%>
         <option disabled><%=h(c.getName())%></option>
         <%for(Group g: groups) {%>
-        <option value="<%=h(g.getUserId())%>">--<%=h(g.getName())%></option>
+        <option value="<%=g.getUserId()%>">--<%=h(g.getName())%></option>
         <%}}}%>
     </select>
     <labkey:button text="Add Rule" />
@@ -130,7 +132,7 @@
         <tr>
             <td><%=h(SecurityManager.getGroup(Integer.parseInt(key)))%> (<%=h(key)%>)</td>
             <td><%=h(SecurityManager.getGroup(Integer.parseInt(rule)))%> (<%=h(rule)%>)</td>
-            <td><%=link("Remove", new ActionURL(SignUpController.RemoveGroupChangeProperty.class, getContainer()).addParameters(Map.of("oldgroup", key, "newgroup", rule))).usePost()%></td>
+            <td><%=link("Remove", urlFor(RemoveGroupChangeProperty.class).addParameters(Map.of("oldgroup", key, "newgroup", rule))).usePost()%></td>
         </tr>
         <%}}}%>
 </table>

--- a/signup/src/org/labkey/signup/signupPage.jsp
+++ b/signup/src/org/labkey/signup/signupPage.jsp
@@ -1,18 +1,18 @@
-<%@ page import="org.labkey.api.view.HttpView" %>
-<%@ page import="org.labkey.signup.SignUpController" %>
-<%@ page import="org.labkey.signup.SignUpManager" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.signup.SignUpController.BeginAction" %>
+<%@ page import="org.labkey.signup.SignUpController.SignupForm" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
-    SignUpController.SignupForm form = (SignUpController.SignupForm)HttpView.currentModel();
-    ActionURL url = new ActionURL(SignUpController.BeginAction.class, getContainer());
+    SignupForm form = (SignupForm)HttpView.currentModel();
+    ActionURL url = urlFor(BeginAction.class);
 %>
 
 <!-- Display errors here -->
 <labkey:errors/>
 
-<form action="<%=h(url.getLocalURIString())%>" method=post>
+<form action="<%=h(url)%>" method=post>
     <labkey:csrf/>
     <table>
         <tr>

--- a/testresults/src/org/labkey/testresults/view/failureDetail.jsp
+++ b/testresults/src/org/labkey/testresults/view/failureDetail.jsp
@@ -71,7 +71,7 @@
 <div style="float: left;">
     <h2><%=h(failedTest)%></h2>
     <h4>Viewing data for: <%=h(df.format(data.getStartDate()))%> - <%=h(df.format(data.getEndDate()))%></h4>
-    <h4>Total failures: <%=h(runs.length)%></h4>
+    <h4>Total failures: <%=runs.length%></h4>
 </div>
 <br />
 <!-- Bar & Pie chart containers -->
@@ -115,15 +115,15 @@
             for (RunDetail run : runs) { %>
         <tr>
             <td>
-                <a href="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=<%=h(run.getId())%>">
+                <a href="<%=h(urlFor(TestResultsController.ShowRunAction.class).addParameter("runId", run.getId()))%>">
                     <%=h(run.getUserName())%>
                 </a>
             </td>
             <td><%=h(df.format(run.getPostTime()))%></td>
-            <td><%=h(run.getDuration())%></td>
+            <td><%=run.getDuration()%></td>
             <td><%=h(run.getOs())%></td>
             <td><%=h(run.getRevisionFull())%></td>
-            <td><%=h(run.getFailedtests())%></td>
+            <td><%=run.getFailedtests()%></td>
             <td><%=h(run.getHang() != null ? run.getHang().getTestName() : "-")%></td>
             <td>
                 <% for (TestFailDetail fail: run.getFailures()) {
@@ -135,7 +135,7 @@
                             String dateString = jsDf.format(cal.getTime());
                             dates.put(dateString, dates.get(dateString) + 1); %>
                 <pre style="text-align: left; padding:10px;"
-                     class="pass-<%=h(fail.getPass())%>">Pass: <%=h(fail.getPass())%> Language: <%=h(fail.getLanguage())%> --- <%=h(fail.getStacktrace())%>
+                     class="pass-<%=fail.getPass()%>">Pass: <%=fail.getPass()%> Language: <%=h(fail.getLanguage())%> --- <%=h(fail.getStacktrace())%>
                             </pre>
                         <% }
                     } %>
@@ -157,7 +157,7 @@
                     for (String l: lang.keySet()) {
                         Double percent = lang.get(l) * 100;
                 %>
-                ['<%=h(l)%>', <%=h(percent.intValue())%>],
+                ['<%=h(l)%>', <%=percent.intValue()%>],
                 <% } %>  ],
             type: 'pie'
         },

--- a/testresults/src/org/labkey/testresults/view/flagged.jsp
+++ b/testresults/src/org/labkey/testresults/view/flagged.jsp
@@ -1,24 +1,19 @@
-<%@ page import="org.labkey.api.data.Container" %>
-<%@ page import="org.labkey.api.settings.AppProps" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
-<%@ page import="org.labkey.testresults.TestResultsController" %>
-<%@ page import="org.labkey.testresults.view.TestsDataBean" %>
+<%@ page import="org.labkey.testresults.TestResultsController.ShowRunAction" %>
 <%@ page import="org.labkey.testresults.model.RunDetail" %>
+<%@ page import="org.labkey.testresults.view.TestsDataBean" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.Collections" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
-    /**
-     * User: Yuval Boss, yuval(at)uw.edu
-     * Date: 10/05/2015
+    /*
+      User: Yuval Boss, yuval(at)uw.edu
+      Date: 10/05/2015
      */
     JspView<?> me = (JspView<?>) HttpView.currentView();
     TestsDataBean data = (TestsDataBean)me.getModelBean();
-    final String contextPath = AppProps.getInstance().getContextPath();
-    Container c = getContainer();
 %>
 
 <%@include file="menu.jsp" %>
@@ -36,7 +31,7 @@
             Collections.reverse(Arrays.asList(runs));
             for(RunDetail run: runs) {%>
         <tr>
-            <td><a href="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=<%=h(run.getId())%>">  id: <%=h(run.getId())%> / <%=h(run.getUserid())%> / <%=h(run.getPostTime())%></a></td>
+            <td><a href="<%=h(urlFor(ShowRunAction.class).addParameter("runId", run.getId()))%>">  id: <%=run.getId()%> / <%=run.getUserid()%> / <%=run.getPostTime()%></a></td>
         </tr>
         <%}%>
     </table>

--- a/testresults/src/org/labkey/testresults/view/multiFailureDetail.jsp
+++ b/testresults/src/org/labkey/testresults/view/multiFailureDetail.jsp
@@ -90,8 +90,8 @@
 <div style="float:left;">
     <h2>All Failures</h2>
     <h4>Viewing data for: <%=h(df.format(data.getStartDate()))%> - <%=h(df.format(data.getEndDate()))%></h4>
-    <h4>Total failures: <%=h(runs.length)%></h4>
-    <h4>Unique users: <%=h(users.size())%></h4>
+    <h4>Total failures: <%=runs.length%></h4>
+    <h4>Unique users: <%=users.size()%></h4>
 </div>
 <br />
 <!-- Bar & Pie chart containers -->
@@ -108,13 +108,13 @@
     for(RunDetail run: runs) { %>
         <tr>
             <td>
-                <p style="width:200px;"><a href="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=<%=h(run.getId())%>">
+                <p style="width:200px;"><a href="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=<%=run.getId()%>">
                 <%=h(run.getUserName())%> <br />
-                Duration: <%=h(run.getDuration())%> <br />
+                Duration: <%=run.getDuration()%> <br />
                 OS: <%=h(run.getOs())%> <br />
-                Post Time: <%=h(run.getPostTime())%> <br />
-                Rev: <%=h(run.getRevision())%> <br />
-                Run Failures: <%=h(run.getFailures().length)%>
+                Post Time: <%=run.getPostTime()%> <br />
+                Rev: <%=run.getRevision()%> <br />
+                Run Failures: <%=run.getFailures().length%>
                 </a></p>
             </td>
             <td>
@@ -122,7 +122,7 @@
                     for(TestFailDetail fail: run.getFailures()) {
                             failCounter++; %>
                         <pre style="text-align: left; padding:10px;"
-                             class="pass-<%=h(fail.getPass())%>">Pass: <%=h(fail.getPass())%> Language: <%=h(fail.getLanguage())%> --- <%=h(fail.getStacktrace())%>
+                             class="pass-<%=fail.getPass()%>">Pass: <%=fail.getPass()%> Language: <%=h(fail.getLanguage())%> --- <%=h(fail.getStacktrace())%>
                         </pre>
                     <%}%>
                 <%
@@ -148,7 +148,7 @@
                     Double percent = lang.get(l) * 100;
                 %>
 
-                ['<%=h(l)%>', <%=h(percent.intValue())%>],
+                ['<%=h(l)%>', <%=percent.intValue()%>],
                 <%}%>  ],
             type : 'pie'
         },

--- a/testresults/src/org/labkey/testresults/view/runDetail.jsp
+++ b/testresults/src/org/labkey/testresults/view/runDetail.jsp
@@ -11,9 +11,9 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%
-    /**
-     * User: Yuval Boss, yuval(at)uw.edu
-     * Date: 1/14/2015
+    /*
+      User: Yuval Boss, yuval(at)uw.edu
+      Date: 1/14/2015
      */
     JspView<?> me = (JspView<?>) HttpView.currentView();
     TestsDataBean data = (TestsDataBean)me.getModelBean();
@@ -75,14 +75,14 @@
         <% if (hang != null) { %><span style="color: red;">(POSSIBLE HANG: <%=h(hang)%>)</span><% } %>
     </h2>
     <p>
-        Run Id: <%=h(run.getId())%><br>
-        User : <a href="<%=h(new ActionURL(TestResultsController.ShowUserAction.class, c))%>user=<%=h(run.getUserName())%>"><%=h(run.getUserName())%></a><br>
+        Run Id: <%=run.getId()%><br>
+        User : <a href="<%=h(urlFor(TestResultsController.ShowUserAction.class))%>user=<%=h(run.getUserName())%>"><%=h(run.getUserName())%></a><br>
         OS: <%=h(run.getOs())%><br>
         Revision: <%=h(run.getRevisionFull())%><br>
-        Passed Tests : <%=h(run.getPasses().length)%><br>
+        Passed Tests : <%=run.getPasses().length%><br>
         Memory : <%=h(run.getAverageMemory())%><br>
-        Failures : <%=h(failures.length)%><br>
-        Leaks : <%=h(testmemoryleaks.length)%><br>
+        Failures : <%=failures.length%><br>
+        Leaks : <%=testmemoryleaks.length%><br>
         Timestamp:  <%=h((run.getTimestamp() == null) ? "N/A" : run.getTimestamp())%><br>
         <a id="trainset" style="cursor: pointer;"><%=h((run.isTrainRun()) ? "Remove from training set" : "Add to training set")%></a>
     </p>
@@ -108,13 +108,13 @@
                 "Press 'Ok' to flag this run.  You will be able to unflag the run but while the run " +
                 "remains flagged it will not be used in analyses across the module."
                 <% } %>)) {
-                    window.location.href = "<%=h(new ActionURL(TestResultsController.FlagRunAction.class, c))%>" + "runId=<%=h(run.getId())%>" + "&flag=<%=!run.isFlagged()%>";
+                    window.location.href = "<%=h(new ActionURL(TestResultsController.FlagRunAction.class, c))%>" + "runId=<%=run.getId()%>" + "&flag=<%=!run.isFlagged()%>";
                 }
             }
         });
         $('#deleteRun').click(function() {
             if (confirm("Press 'Ok' to delete this run and all associated passes, leaks, failures, and hangs."))
-                window.location.href = "<%=h(new ActionURL(TestResultsController.DeleteRunAction.class, c))%>" + "runId=<%=h(run.getId())%>";
+                window.location.href = "<%=h(new ActionURL(TestResultsController.DeleteRunAction.class, c))%>" + "runId=<%=run.getId()%>";
         });
     </script>
 </div>
@@ -167,22 +167,22 @@ if (testmemoryleaks.length > 0) { %>
     <% for (TestPassDetail detail: passes) { %>
        <tr>
            <td><%=h(detail.getTestName())%></td>
-           <td><%=h(detail.getPass())%></td>
+           <td><%=detail.getPass()%></td>
            <td><%=h(detail.getLanguage())%></td>
-           <td><%=h(detail.getDuration())%></td>
-           <td><%=h(data.round(detail.getManagedMemory(), 2))%></td>
-           <td><%=h(data.round(detail.getTotalMemory(),2))%></td>
+           <td><%=detail.getDuration()%></td>
+           <td><%=data.round(detail.getManagedMemory(), 2)%></td>
+           <td><%=data.round(detail.getTotalMemory(), 2)%></td>
            <td><%=h((detail.getTimestamp() == null) ? "N/A" : dfMDHM.format(detail.getTimestamp()))%></td>
        </tr>
     <% } %>
-    <tr><td<% if (hang != null) { %> style="background: yellow;"<% } %>>Posted: <%=h(run.getPostTime())%></td></tr>
+    <tr><td<% if (hang != null) { %> style="background: yellow;"<% } %>>Posted: <%=h(formatDateTime(run.getPostTime()))%></td></tr>
     </table>
 <!--Handles add/remove from training data set-->
 <script>
     $('#trainset').click(function() {
         var csrf_header = {"X-LABKEY-CSRF": LABKEY.CSRF};
         $(this).off().text("Please wait...");
-        $.post('<%=h(new ActionURL(TestResultsController.TrainRunAction.class, c))%>runId=<%=h(run.getId())%>&train=<%=h((run.isTrainRun()) ? "false" : "true")%>', csrf_header, function(data){
+        $.post('<%=h(new ActionURL(TestResultsController.TrainRunAction.class, c))%>runId=<%=run.getId()%>&train=<%=h(run.isTrainRun() ? "false" : "true")%>', csrf_header, function(data){
             if (data.Success) {
                 location.reload();
             } else {
@@ -244,7 +244,7 @@ if (testmemoryleaks.length > 0) { %>
 
 <% } else { %>
     <!--Content to display if data is null-->
-<form action="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>">
+<form action="<%=h(urlFor(TestResultsController.ShowRunAction.class))%>">
     <br />
     Run Id:<br>
     <input type="text" name="runId">

--- a/testresults/src/org/labkey/testresults/view/rundown.jsp
+++ b/testresults/src/org/labkey/testresults/view/rundown.jsp
@@ -3,6 +3,7 @@
 <%@ page import="org.labkey.api.data.statistics.StatsService" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.testresults.TestResultsController.ShowRunAction" %>
 <%@ page import="org.labkey.testresults.model.BackgroundColor" %>
 <%@ page import="org.labkey.testresults.model.RunDetail" %>
 <%@ page import="org.labkey.testresults.model.RunProblems" %>
@@ -14,8 +15,8 @@
 <%@ page import="java.text.SimpleDateFormat" %>
 <%@ page import="java.util.Date" %>
 <%@ page import="java.util.List" %>
-<%@ page import="java.util.Map" %>
 <%@ page import="static org.labkey.testresults.TestResultsModule.ViewType" %>
+<%@ page import="java.util.Map" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     /*
@@ -124,7 +125,7 @@
                             for (User u : statRunUserMap.keySet()) {
                                 for (RunDetail run : statRunUserMap.get(u)) {
                         %>
-                        <tr class="highlightrun highlighttr-<%=h(run.getId())%>">
+                        <tr class="highlightrun highlighttr-<%=run.getId()%>">
                             <%
                                 int passes =  run.getPassedtests();
                                 int failures = run.getFailedtests();
@@ -191,32 +192,32 @@
                                 <% } else if (runStatus == 2) { %>rundown-error
                                 <% } %>"
                                 data-sort-value="<%=h(run.getUserName())%>">
-                                <a title="<%=h(title)%>" style="color: #000 !important; font-weight: 400;" href="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=<%=h(run.getId())%>" target="_blank">
-                                    <%=h(run.getUserName() + "("+h(run.getId())+")")%>
+                                <a title="<%=h(title)%>" style="color: #000 !important; font-weight: 400;" href="<%=h(new ActionURL(ShowRunAction.class, c))%>runId=<%=run.getId()%>" target="_blank">
+                                    <%=h(run.getUserName() + "(" + run.getId() + ")")%>
                                 </a>
                             </td>
-                            <td style="font-size: 11px;" data-sort-value="<%=h(run.getPostTime().getTime())%>"><%=h(dfMDHM.format(run.getPostTime()))%></td>
+                            <td style="font-size: 11px;" data-sort-value="<%=run.getPostTime().getTime()%>"><%=h(dfMDHM.format(run.getPostTime()))%></td>
                             <td class="<% if (durationStatus > 0) { %>rundown-error<% } %>">
-                                <%=h(run.getDuration())%>
+                                <%=run.getDuration()%>
                                 <% if (run.getHang() != null) { %><img src='<%=h(contextPath)%>/TestResults/img/hangicon.png'><% } %>
                             <td title="<%=h(u.runBoundHtmlString(warningBoundary, errorBoundary))%>"
                                 class="rundown-user-passes <% if (passStatus == 1) { %>rundown-warn<% } else if (passStatus == 2) { %>rundown-error<% } %>">
-                                <%=h(passes)%>
+                                <%=passes%>
                             </td>
                             <td title="<%=h(u.memBoundHtmlString(warningBoundary, errorBoundary))%>"
                                 class="rundown-user-mem <% if (memStatus == 1) { %>rundown-warn<% } else if (memStatus == 2) { %>rundown-error<% } %>">
                                 <%=h(run.getAverageMemory()) %>
                             </td>
                             <td class="<% if (failStatus > 0) { %>rundown-error<% } %>">
-                                <%=h(failures)%>
+                                <%=failures%>
                                 <% if (failStatus > 0) { %><img src='<%=h(contextPath)%>/TestResults/img/fail.png'><% } %>
                             </td>
                             <td class="<% if (leakStatus > 0) { %>rundown-error<% } %>">
-                                <%=h(testmemoryleaks)%>
+                                <%=testmemoryleaks%>
                                 <% if (leakStatus > 0) { %><img src='<%=h(contextPath)%>/TestResults/img/leak.png'><% } %>
                             </td>
                             <td>
-                                <a style="cursor: pointer;" runid="<%=h(run.getId())%>" train="<%=h((run.isTrainRun()) ? "false" : "true")%>" class="traindata"><%=h((run.isTrainRun()) ? "Untrain" : "Train")%></a>
+                                <a style="cursor: pointer;" runid="<%=run.getId()%>" train="<%=h(run.isTrainRun() ? "false" : "true")%>" class="traindata"><%=h(run.isTrainRun() ? "Untrain" : "Train")%></a>
                             </td>
                         </tr>
                         <% }
@@ -243,8 +244,8 @@
                             </td>
                             <% for (RunDetail run : problemRuns) { %>
                             <td style="max-width: 60px; width: 60px; overflow: hidden; text-overflow: ellipsis; padding: 0;" title="<%=h(run.getUserName())%>">
-                                <a href="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=<%=h(run.getId())%>" target="_blank">
-                                    <%=h(run.getUserName())%>(<%=h(run.getId())%>)
+                                <a href="<%=h(urlFor(ShowRunAction.class))%>runId=<%=run.getId()%>" target="_blank">
+                                    <%=h(run.getUserName())%>(<%=run.getId()%>)
                                 </a>
                             </td>
                             <% } %>
@@ -257,7 +258,7 @@
                                 <a href="<%=h(new ActionURL(TestResultsController.ShowFailures.class, c))%>end=<%=h(df.format(selectedDate))%>&failedTest=<%=h(test)%>" target="_blank"><%=h(test)%></a>
                             </td>
                             <% for (RunDetail run : problemRuns) { %>
-                            <td class="highlightrun highlighttd-<%=h(run.getId())%>" style="width: 60px; overflow: hidden; padding: 0;">
+                            <td class="highlightrun highlighttd-<%=run.getId()%>" style="width: 60px; overflow: hidden; padding: 0;">
                                 <% if (problems.isFail(run, test)) { %><img src="<%=h(contextPath)%>/TestResults/img/fail.png"><% } %>
                                 <% if (problems.isLeak(run, test)) { %><img src="<%=h(contextPath)%>/TestResults/img/leak.png"><% } %>
                                 <% if (problems.isHang(run, test)) { %><img src="<%=h(contextPath)%>/TestResults/img/hangicon.png"><% } %>
@@ -273,7 +274,7 @@
         </div>
     </div>
     <script type="text/javascript">
-        $('#stats').text("<%=h(errorRuns)%> Errors | <%=h(warningRuns)%> Warnings | <%=h(goodRuns)%> Passes | <%=h(missingUsers.length)%> Missing");
+        $('#stats').text("<%=errorRuns%> Errors | <%=warningRuns%> Warnings | <%=goodRuns%> Passes | <%=missingUsers.length%> Missing");
     </script>
     <% } %>
     <br />
@@ -309,7 +310,7 @@
         <!--Basic test run information about duration, # of passses, # of failures, and # of testmemoryleaks-->
         <div class="centeredContent">
         <% if (!topFailures.isEmpty()) { %>
-            <!--Top Failures, occurences, and language pie chart table-->
+            <!--Top Failures, occurrences, and language pie chart table-->
             <table class="decoratedtable" style="float:left;">
                 <tr>
                     <td><h4>Top Failures</h4></td>
@@ -319,7 +320,7 @@
                 <% for (String key: topFailures.keySet()) { %>
                 <tr>
                     <td><a href="<%=h(new ActionURL(TestResultsController.ShowFailures.class, c))%>failedTest=<%=h(key)%>&end=<%=h(df.format(selectedDate))%>&viewType=<%=h(viewType)%>" target="_blank"><%=h(key)%></a></td>
-                    <td><%=h(topFailures.get(key).size())%></td>
+                    <td><%=topFailures.get(key).size()%></td>
                     <td>
                         <div id="<%=h(key)%>" class="c3chart" style="width: 120px; height: 120px;"></div>
                         <script>
@@ -332,7 +333,7 @@
                             for (String l: lang.keySet()) {
                                 double percent = lang.get(l) * 100;
                         %>
-                                ['<%=h(l)%>', <%=h((int)percent)%>],
+                                ['<%=h(l)%>', <%=(int)percent%>],
                         <% } %> ],
                             type: 'pie',
                                 onclick: function (d, i) { console.log("onclick", d, i); },
@@ -365,7 +366,7 @@
                 <% for (String key: topLeaks.keySet()) { %>
                 <tr>
                     <td><%=h(key)%></td>
-                    <td><%=h(topLeaks.get(key).size())%></td>
+                    <td><%=topLeaks.get(key).size()%></td>
                     <% double[] leakbytes = new double[topLeaks.get(key).size()];
                         for (int i = 0; i < topLeaks.get(key).size(); i++) {
                             leakbytes[i] = topLeaks.get(key).get(i).getBytes();
@@ -462,7 +463,7 @@
                         }
                         var id = m[1];
                         window.open(
-                            '<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId='+ id,
+                            '<%=h(new ActionURL(ShowRunAction.class, c))%>runId='+ id,
                             '_blank' // <- This is what makes it open in a new window.
                         );
                     }

--- a/testresults/src/org/labkey/testresults/view/trainingdata.jsp
+++ b/testresults/src/org/labkey/testresults/view/trainingdata.jsp
@@ -149,12 +149,12 @@
                         if (firstRunId == -1) { firstRunId = run.getId(); }
             %>
             <tr>
-                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=h(run.getPostTime())%></td>
-                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=h(run.getDuration())%></td>
-                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=h(run.getPassedtests())%></td>
-                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=h(run.getFailedtests())%></td>
+                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=h(formatDateTime(run.getPostTime()))%></td>
+                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=run.getDuration()%></td>
+                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=run.getPassedtests()%></td>
+                <td style="border-left: 1px solid #000; padding-left: 5px;"><%=run.getFailedtests()%></td>
                 <td style="border-left: 1px solid #000; padding-left: 5px;"><%=h(run.getAverageMemory())%></td>
-                <td style="border-left: 1px solid #000; padding-left: 5px;"><a style="cursor: pointer;" runid="<%=h(run.getId())%>" class="removedata">Remove</a></td>
+                <td style="border-left: 1px solid #000; padding-left: 5px;"><a style="cursor: pointer;" runid="<%=run.getId()%>" class="removedata">Remove</a></td>
             </tr>
             <% }
             } %>

--- a/testresults/src/org/labkey/testresults/view/user.jsp
+++ b/testresults/src/org/labkey/testresults/view/user.jsp
@@ -2,6 +2,7 @@
 <%@ page import="org.labkey.api.data.TableSelector" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.testresults.TestResultsController.ShowRunAction" %>
 <%@ page import="org.labkey.testresults.TestResultsSchema" %>
 <%@ page import="org.labkey.testresults.model.RunDetail" %>
 <%@ page import="org.labkey.testresults.model.User" %>
@@ -171,19 +172,19 @@
                     if (!userFailCount.containsKey(key))
                         userFailCount.put(key, 0);
                     userFailCount.put(key, userFailCount.get(key) + run.getFailedtests()); %>
-                <tr class="run-row" data-run-id="<%=h(run.getId())%>" data-timestamp="<%=h(run.getPostTime().getTime())%>">
-                    <td><a href="<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=<%=h(run.getId())%>">run details</a></td>
+                <tr class="run-row" data-run-id="<%=run.getId()%>" data-timestamp="<%=run.getPostTime().getTime()%>">
+                    <td><a href="<%=h(urlFor(ShowRunAction.class).addParameter("runId", run.getId()))%>">run details</a></td>
                     <% if (!showSingleUser) { %><td><%=h(run.getUserName())%></td><% } %>
                     <td><%=h(df.format(run.getPostTime()))%></td>
-                    <td><%=h(run.getDuration())%></td>
-                    <td><%=h(run.getPassedtests())%></td>
-                    <td><%=h(run.getAveragemem())%></td>
+                    <td><%=run.getDuration()%></td>
+                    <td><%=run.getPassedtests()%></td>
+                    <td><%=run.getAveragemem()%></td>
 <%--                    <td><%=h(run.getMedianmem())%></td>--%>
-                    <td><%=h(run.getFailedtests())%></td>
-                    <td><%=h(run.getLeakedtests())%></td>
+                    <td><%=run.getFailedtests()%></td>
+                    <td><%=run.getLeakedtests()%></td>
                     <td><%=h(run.getOs())%></td>
                     <td><%=h(run.getRevisionFull())%></td>
-                    <td><a class="trainset" runId="<%=h(run.getId())%>" runTrained="<%=run.isTrainRun()%>" style="cursor:pointer;">
+                    <td><a class="trainset" runId="<%=run.getId()%>" runTrained="<%=run.isTrainRun()%>" style="cursor:pointer;">
                         <%=h((run.isTrainRun()) ? "Remove from training set" : "Add to training set")%>
                     </a></td>
                 </tr>
@@ -301,7 +302,7 @@
                 }
             });
             if (minRow)
-                location.href = '<%=h(new ActionURL(TestResultsController.ShowRunAction.class, c))%>runId=' + minRow.data("run-id");
+                location.href = '<%=h(new ActionURL(ShowRunAction.class, c))%>runId=' + minRow.data("run-id");
         };
         <% } %>
 


### PR DESCRIPTION
#### Rationale
Use `q(URLHelper)` and `h(URLHelper)`. Use `urlFor()` instead of `buildURL()`. Stop encoding ints.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549
