### PR TITLE
Declare api and implementation dependencies to align with code usages

### DIFF
--- a/testresults/build.gradle
+++ b/testresults/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    external "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
+}

--- a/testresults/resources/credits/jars.txt
+++ b/testresults/resources/credits/jars.txt
@@ -1,0 +1,4 @@
+{table}
+Filename|Component|Version|Source|License|Purpose
+commons-fileupload-1.3.1.jar|Commons File Upload|1.3.1|{link:Apache|http://jakarta.apache.org/commons/fileupload/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Parses HTTP multipart/form-data POSTs
+{table}


### PR DESCRIPTION
#### Rationale
It is generally best practice to explicitly declare dependencies that are used in your code rather than relying on them to come through transitively.  Though in reality the risk of these transitive dependencies disappearing is low and would be easily noticed, the declaration of proper dependencies will assure that our published `pom` files are accurate and others will not have to separately declare some dependencies that we rely on when using our jar files.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1574

#### Changes
* Update dependencies and `jars.txt`
