### PR TITLE
Add missing dependencies on httpmime

### DIFF
--- a/panoramapublic/build.gradle
+++ b/panoramapublic/build.gradle
@@ -2,6 +2,7 @@ import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
+    external "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "published", depExtension: "module")

--- a/panoramapublic/resources/credits/jars.txt
+++ b/panoramapublic/resources/credits/jars.txt
@@ -1,0 +1,4 @@
+{table}
+Filename|Component|Version|Source|License|LabKey Dev|Purpose
+httpmime-4.5.3.jar|Apache HTTP Mime|4.5.3|{link:Apache|http://hc.apache.org/httpcomponents-client-ga}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|HTTP client for requests of remote servers
+{table}


### PR DESCRIPTION
#### Rationale
With version 1.4.0 of the labkey-client-api, we will convert the dependencies on opencsv and httpmime from api dependencies to implementation dependencies since they are not actually a part of the api for this jar file.  Since both of these dependencies are included in the api module transitively, we compromise a bit and do not include them in the `jars.txt` for each individual module.

#### Related Pull Requests
* https://github.com/LabKey/labkey-api-java/pull/14

#### Changes
* Add explicit dependencies where missing
