### PR TITLE
Switch to DisplayColumn.getFormattedHtml() and use HtmlString

### DIFF
--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -29,6 +29,7 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
@@ -455,9 +456,9 @@ public class LincsDataTable extends FilteredTable
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            return (String)getDisplayValue(ctx);
+            return HtmlString.of((String)getDisplayValue(ctx));
         }
 
         @Override

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -48,6 +48,7 @@ import org.labkey.api.security.roles.FolderAdminRole;
 import org.labkey.api.security.roles.ProjectAdminRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.SimpleNamedObject;
 import org.labkey.api.util.UniqueID;
@@ -224,9 +225,9 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
                 return getValue(ctx);
             }
             @Override
-            public @NotNull String getFormattedValue(RenderContext ctx)
+            public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
             {
-                return (String)getValue(ctx);
+                return HtmlString.of((String)getValue(ctx));
             }
             @Override
             public Class getValueClass()
@@ -261,9 +262,9 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
             }
 
             @Override
-            public @NotNull String getFormattedValue(RenderContext ctx)
+            public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
             {
-                return (String) getDisplayValue(ctx);
+                return HtmlString.of((String) getDisplayValue(ctx));
             }
 
             @Override
@@ -385,7 +386,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
         }
 
         @Override
-        public @NotNull String getFormattedValue(RenderContext ctx)
+        public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
         {
             Integer userId = ctx.get(getColumnInfo().getFieldKey(), Integer.class);
             String userDisplayName = null;
@@ -393,7 +394,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
             {
                 userDisplayName = getUserDisplayName(UserManager.getUser(userId));
             }
-            return userDisplayName == null ? super.getFormattedValue(ctx) : userDisplayName;
+            return userDisplayName == null ? super.getFormattedHtml(ctx) : HtmlString.of(userDisplayName);
         }
     }
 
@@ -452,9 +453,9 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            return h(getValue(ctx));
+            return HtmlString.of(getValue(ctx));
         }
 
         @Override
@@ -491,9 +492,9 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
-            return h(getValue(ctx));
+            return HtmlString.of(getValue(ctx));
         }
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalExperimentTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalExperimentTableInfo.java
@@ -26,6 +26,7 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.panoramapublic.PanoramaPublicManager;
@@ -73,7 +74,7 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
         licenseCol.setURLTargetWindow("_blank");
         licenseCol.setDisplayColumnFactory(colInfo -> new DataColumn(colInfo){
             @Override
-            public Object getValue(RenderContext ctx)
+            public DataLicense getValue(RenderContext ctx)
             {
                 return ctx.get(FieldKey.fromParts("DataLicense"), DataLicense.class);
             }
@@ -81,21 +82,21 @@ public class JournalExperimentTableInfo extends FilteredTable<PanoramaPublicSche
             @Override
             public Object getDisplayValue(RenderContext ctx)
             {
-                DataLicense license = (DataLicense) getValue(ctx);
+                DataLicense license = getValue(ctx);
                 return license != null ? license.getDisplayName() : super.getDisplayValue(ctx);
             }
 
             @Override
-            public @NotNull String getFormattedValue(RenderContext ctx)
+            public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
             {
-                DataLicense license = (DataLicense) getValue(ctx);
-                return license != null ? license.getDisplayName() : super.getFormattedHtml(ctx);
+                DataLicense license = getValue(ctx);
+                return license != null ? HtmlString.of(license.getDisplayName()) : super.getFormattedHtml(ctx);
             }
 
             @Override
             public String renderURL(RenderContext ctx)
             {
-                DataLicense license = (DataLicense) getValue(ctx);
+                DataLicense license = getValue(ctx);
                 return license != null ? license.getUrl() : super.renderURL(ctx);
             }
         });

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/ShortUrlDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/ShortUrlDisplayColumnFactory.java
@@ -22,6 +22,7 @@ import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.DisplayColumnFactory;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.view.ShortURLRecord;
 
 import java.util.Set;
@@ -54,10 +55,10 @@ public class ShortUrlDisplayColumnFactory implements DisplayColumnFactory
         }
 
         @Override @NotNull
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             String shortUrl = getShortUrlDisplayValue(ctx);
-            return shortUrl != null ? shortUrl : super.getFormattedValue(ctx);
+            return shortUrl != null ? HtmlString.of(shortUrl) : super.getFormattedHtml(ctx);
         }
 
         private String getShortUrlDisplayValue(RenderContext ctx)

--- a/pwebdashboard/src/org/labkey/pwebdashboard/ProjectAdminsTable.java
+++ b/pwebdashboard/src/org/labkey/pwebdashboard/ProjectAdminsTable.java
@@ -119,11 +119,11 @@ public class ProjectAdminsTable extends ContainerTable
 
         @NotNull
         @Override
-        public String getFormattedValue(RenderContext ctx)
+        public HtmlString getFormattedHtml(RenderContext ctx)
         {
             String value = h(getValue(ctx));
             if(value != null) value = value.replaceAll(",", "<br />");
-            return value != null ? value : "";
+            return HtmlString.unsafe(value);
         }
 
         @Nullable


### PR DESCRIPTION
#### Rationale
Switch to using HtmlString when rendering a grid or details value to ensure proper encoding. Fix up many problematic subclasses.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1602

#### Changes
* Remove deprecated getFormattedValue(), consolidate on getFormattedHtml()
* Use HtmlString to signal this is specifically for HTML