### PR TITLE
Move dependencies declarations out of module.properties files

### DIFF
--- a/lincs/build.gradle
+++ b/lincs/build.gradle
@@ -7,4 +7,5 @@ dependencies {
                 exclude group: "org.json", module:"json"
             }
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:targetedms", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/lincs/module.properties
+++ b/lincs/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.lincs.LincsModule
-ModuleDependencies: TargetedMS
 Label: LINCS MODULE
 Description: This module contains the functionality \
     for the LINCS project on PanoramaWeb.


### PR DESCRIPTION
#### Rationale
We have deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Move module dependency declarations from `module.properties` files to `build.gradle` files