### PR TITLE
Add build.gradle file in anticipation of removal of modules/build.gradle

### DIFF
--- a/SkylineToolsStore/build.gradle
+++ b/SkylineToolsStore/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.module'
+}

--- a/lincs/build.gradle
+++ b/lincs/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     implementation ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")
             {

--- a/panoramapublic/build.gradle
+++ b/panoramapublic/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     external "org.apache.httpcomponents:httpmime:${httpmimeVersion}"

--- a/pwebdashboard/build.gradle
+++ b/pwebdashboard/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:targetedms", depProjectConfig: "published", depExtension: "module")

--- a/signup/build.gradle
+++ b/signup/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
 }

--- a/testresults/build.gradle
+++ b/testresults/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     external "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
 }


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  

#### Changes
* apply module plugin in build.gradle file