### PR TITLE
Update cromwell job to work on develop

### DIFF
--- a/lincs/build.gradle
+++ b/lincs/build.gradle
@@ -10,6 +10,7 @@ dependencies {
                 // exclude this because it gets in the way of our own JSON object implementations from server/api
                 exclude group: "org.json", module:"json"
             }
+    external "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:targetedms", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/lincs/src/org/labkey/lincs/cromwell/CromwellGctTask.java
+++ b/lincs/src/org/labkey/lincs/cromwell/CromwellGctTask.java
@@ -19,6 +19,7 @@ import org.labkey.lincs.LincsController;
 import org.labkey.lincs.LincsModule;
 import org.labkey.lincs.psp.LincsPspJobSupport;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -77,14 +78,13 @@ public class CromwellGctTask extends PipelineJob.Task<CromwellGctTask.Factory>
         {
             User user = getJob().getUser();
 
-            String apiKey = SecurityManager.beginTransformSession(user); // Creates a key that expires in a day
-            try
+            try (SecurityManager.TransformSession session = SecurityManager.createTransformSession(user))
             {
-                submitJob(cromwellConfig, assayType, run, apiKey, log);
+                submitJob(cromwellConfig, assayType, run, session.getApiKey(), log);
             }
-            finally
+            catch (IOException e)
             {
-                SecurityManager.endTransformSession(apiKey);
+                throw new PipelineJobException(e);
             }
         }
         else


### PR DESCRIPTION
#### Rationale
The new cromwell integration doesn't build against develop. Gradle doesn't add an 'httpmime' dependency automatically anymore and transform sessions are handled differently now.

#### Related Pull Requests
* LabKey/platform#1707
* #98 

#### Changes
* Add 'httpmime' dependency to lincs module
* Update "CromwellGctTask" to use new transform session management
