### PR TITLE
Wait for page loads

### DIFF
--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -115,7 +115,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         testSubmitWithMissingRawFiles(portalHelper, expWebPart);
 
         // Submit the experiment by clicking the "Continue without a ProteomeXchange ID" link
-        portalHelper.click(Locator.folderTab("Panorama Dashboard"));
+        clickAndWait(Locator.folderTab("Panorama Dashboard"));
         expWebPart.submitWithoutPXId();
         assertTextPresent("Copy Pending!");
 
@@ -291,12 +291,12 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
 
         public void submitWithoutPXId()
         {
-            findElement(Locator.linkContainingText("Submit")).click();
-            waitAndClick(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
+            clickAndWait(Locator.linkContainingText("Submit"));
+            clickAndWait(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
             getWrapper()._ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PANORAMA_PUBLIC);
-            waitAndClick(Ext4Helper.Locators.ext4Button("Submit"));
-            waitAndClick(Locator.lkButton("OK")); // Confirm to proceed with the submission.
-            waitAndClick(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
+            clickAndWait(Ext4Helper.Locators.ext4Button("Submit"));
+            clickAndWait(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+            clickAndWait(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
         }
 
         public void clickSubmit()
@@ -309,13 +309,13 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
             Locator.XPathLocator resubmitLink = Locator.linkContainingText("Resubmit");
             assertNotNull("Expected to see a \"Resubmit\" button", resubmitLink);
             clickAndWait(resubmitLink);
-            waitAndClick(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
+            clickAndWait(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
             waitForText("Resubmit Request to ");
-            click(Ext4Helper.Locators.ext4Button(("Resubmit")));
+            clickAndWait(Ext4Helper.Locators.ext4Button(("Resubmit")));
             waitForText("Confirm resubmission request to");
-            click(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+            clickAndWait(Locator.lkButton("OK")); // Confirm to proceed with the submission.
             waitForText("Request resubmitted to");
-            click(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
+            clickAndWait(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
         }
     }
 


### PR DESCRIPTION
#### Rationale
When a test does something that triggers a page load, it needs to wait for the navigation. Otherwise, it's possible for subsequent actions to fail because the test isn't on the page they expect. I noticed some intermittent failures on TeamCity in the `PanoramaPublicTest` due to this.

#### Changes
* Use `clickAndWait` to handle navigation properly
