### PR TITLE
Issue 42768: Add support for assigning DOIs to datasets submitted to Panorama Public

### DIFF
--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.005-20.006.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-20.005-20.006.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+ALTER TABLE panoramapublic.ExperimentAnnotations ADD COLUMN doi VARCHAR(100);

--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -118,6 +118,7 @@
                 <columnTitle>PX ID</columnTitle>
             </column>
             <column columnName="PubmedId"/>
+            <column columnName="doi"/>
         </columns>
     </table>
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -113,7 +113,8 @@ import org.labkey.api.view.*;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.panoramapublic.datacite.DataCiteException;
 import org.labkey.panoramapublic.datacite.DataCiteService;
-import org.labkey.panoramapublic.datacite.DataCiteService.Doi;
+import org.labkey.panoramapublic.datacite.Doi;
+import org.labkey.panoramapublic.datacite.DoiMetadata;
 import org.labkey.panoramapublic.model.DataLicense;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
@@ -3499,7 +3500,7 @@ public class PanoramaPublicController extends SpringActionController
     public static class PublishDoiAction extends DoiAction
     {
         private JournalExperiment _journalExperiment;
-        private DataCiteService.DoiMetadata _metadata;
+        private DoiMetadata _metadata;
         @Override
         public ModelAndView getConfirmView(DoiForm form, BindException errors)
         {
@@ -3525,7 +3526,7 @@ public class PanoramaPublicController extends SpringActionController
             }
             try
             {
-                _metadata = DataCiteService.DoiMetadata.from(_expAnnot, _journalExperiment);
+                _metadata = DoiMetadata.from(_expAnnot);
             }
             catch (DataCiteException e)
             {
@@ -3542,7 +3543,7 @@ public class PanoramaPublicController extends SpringActionController
         @Override
         public boolean doPost(DoiForm form, BindException errors) throws DataCiteException
         {
-            DataCiteService.publish(_expAnnot, _journalExperiment);
+            DataCiteService.publish(_expAnnot);
             return true;
         }
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -101,6 +101,7 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.ProjectAdminRole;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.Button;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.DOM.LK;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HtmlString;
@@ -110,6 +111,9 @@ import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.*;
 import org.labkey.api.view.template.ClientDependency;
+import org.labkey.panoramapublic.datacite.DataCiteException;
+import org.labkey.panoramapublic.datacite.DataCiteService;
+import org.labkey.panoramapublic.datacite.DataCiteService.Doi;
 import org.labkey.panoramapublic.model.DataLicense;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
@@ -222,10 +226,9 @@ public class PanoramaPublicController extends SpringActionController
                 view.addView(new HtmlView("<div><a href=\"" + newJournalUrl + "\">Create a new journal group </a></div>"));
             }
 
-            ModelAndView pxCredentialsLink = getPXCredentialsLink();
-
             view.addView(qView);
-            view.addView(pxCredentialsLink);
+            view.addView(getPXCredentialsLink());
+            view.addView(getDataCiteCredentialsLink());
             view.setFrame(WebPartView.FrameType.PORTAL);
             view.setTitle("Journal groups");
             return view;
@@ -236,6 +239,13 @@ public class PanoramaPublicController extends SpringActionController
             ActionURL url = new ActionURL(ManageProteomeXchangeCredentials.class, getContainer());
             return new HtmlView(DIV(at(style, "margin-top:20px;"),
                     new Link.LinkBuilder("Set ProteomeXchange Credentials").href(url).build()));
+        }
+
+        private ModelAndView getDataCiteCredentialsLink()
+        {
+            ActionURL url = new ActionURL(ManageDataCiteCredentials.class, getContainer());
+            return new HtmlView(DIV(at(style, "margin-top:20px;"),
+                    new Link.LinkBuilder("Set DataCite Credentials").href(url).build()));
         }
 
         @Override
@@ -706,6 +716,176 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
+    public class ManageDataCiteCredentials extends FormViewAction<DataCiteCredentialsForm>
+    {
+        @Override
+        public void validateCommand(DataCiteCredentialsForm form, Errors errors)
+        {
+            String user = form.getUser();
+            String password = form.getPassword();
+            String doiPrefix = form.getDoiPrefix();
+
+            if (StringUtils.isBlank(user))
+            {
+                errors.reject(ERROR_MSG, "User name cannot be blank");
+            }
+            if (StringUtils.isBlank(password))
+            {
+                errors.reject(ERROR_MSG, "Password cannot be blank");
+            }
+            if (StringUtils.isBlank(doiPrefix))
+            {
+                errors.reject(ERROR_MSG, "DOI prefix cannot be blank");
+            }
+
+            String testUser = form.getTestUser();
+            String testPassword = form.getTestPassword();
+            String testDoiPrefix = form.getTestDoiPrefix();
+            if (StringUtils.isBlank(testUser))
+            {
+                errors.reject(ERROR_MSG, "Test user name cannot be blank");
+            }
+            if (StringUtils.isBlank(testPassword))
+            {
+                errors.reject(ERROR_MSG, "Test password cannot be blank");
+            }
+            if (StringUtils.isBlank(testDoiPrefix))
+            {
+                errors.reject(ERROR_MSG, "Test DOI prefix cannot be blank");
+            }
+        }
+
+        @Override
+        public boolean handlePost(DataCiteCredentialsForm form, BindException errors)
+        {
+            PropertyManager.PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(DataCiteService.CREDENTIALS, true);
+            map.put(DataCiteService.USER, form.getUser());
+            map.put(DataCiteService.PASSWORD, form.getPassword());
+            map.put(DataCiteService.PREFIX, form.getDoiPrefix());
+            map.put(DataCiteService.TEST_USER, form.getTestUser());
+            map.put(DataCiteService.TEST_PASSWORD, form.getTestPassword());
+            map.put(DataCiteService.TEST_PREFIX, form.getTestDoiPrefix());
+            map.save();
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(DataCiteCredentialsForm form)
+        {
+            return null;
+        }
+
+        @Override
+        public ModelAndView getSuccessView(DataCiteCredentialsForm form)
+        {
+            ActionURL adminUrl = new ActionURL(JournalGroupsAdminViewAction.class, getContainer());
+            return new HtmlView(
+                    DIV("DataCite credentials saved!",
+                    BR(),
+                    new Link.LinkBuilder("Back to Panorama Public Admin Console").href(adminUrl).build()));
+        }
+
+        @Override
+        public ModelAndView getView(DataCiteCredentialsForm form, boolean reshow, BindException errors)
+        {
+            if(!reshow)
+            {
+                PropertyManager.PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(DataCiteService.CREDENTIALS, false);
+                if(map != null)
+                {
+                    form.setUser(map.get(DataCiteService.USER));
+                    form.setPassword(map.get(DataCiteService.PASSWORD));
+                    form.setDoiPrefix(map.get(DataCiteService.PREFIX));
+
+                    form.setTestUser(map.get(DataCiteService.TEST_USER));
+                    form.setTestPassword(map.get(DataCiteService.TEST_PASSWORD));
+                    form.setTestDoiPrefix(map.get(DataCiteService.TEST_PREFIX));
+                }
+            }
+            JspView view = new JspView<>("/org/labkey/panoramapublic/view/manageDataCiteCredentials.jsp", form, errors);
+            view.setFrame(WebPartView.FrameType.PORTAL);
+            view.setTitle("DataCite Credentials");
+            return view;
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            root.addChild("Set DataCite Credentials");
+        }
+    }
+
+    public static class DataCiteCredentialsForm
+    {
+        private String _user;
+        private String _password;
+        private String _doiPrefix;
+        private String _testUser;
+        private String _testPassword;
+        private String _testDoiPrefix;
+
+        public String getTestUser()
+        {
+            return _testUser;
+        }
+
+        public void setTestUser(String testUser)
+        {
+            _testUser = testUser;
+        }
+
+        public String getTestPassword()
+        {
+            return _testPassword;
+        }
+
+        public void setTestPassword(String testPassword)
+        {
+            _testPassword = testPassword;
+        }
+
+        public String getUser()
+        {
+            return _user;
+        }
+
+        public void setUser(String user)
+        {
+            _user = user;
+        }
+
+        public String getPassword()
+        {
+            return _password;
+        }
+
+        public void setPassword(String password)
+        {
+            _password = password;
+        }
+
+        public String getTestDoiPrefix()
+        {
+            return _testDoiPrefix;
+        }
+
+        public void setTestDoiPrefix(String testDoiPrefix)
+        {
+            _testDoiPrefix = testDoiPrefix;
+        }
+
+        public String getDoiPrefix()
+        {
+            return _doiPrefix;
+        }
+
+        public void setDoiPrefix(String doiPrefix)
+        {
+            _doiPrefix = doiPrefix;
+        }
+    }
+
+    @RequiresPermission(AdminOperationsPermission.class)
     public class ManageProteomeXchangeCredentials extends FormViewAction<PXCredentialsForm>
     {
         @Override
@@ -986,6 +1166,8 @@ public class PanoramaPublicController extends SpringActionController
                 CopyExperimentPipelineJob job = new CopyExperimentPipelineJob(info, root, _experiment, _journal);
                 job.setAssignPxId(form.isAssignPxId());
                 job.setUsePxTestDb(form.isUsePxTestDb());
+                job.setAssignDoi(form.isAssignDoi());
+                job.setUseDataCiteTestApi(form.isUseDataCiteTestApi());
                 job.setReviewerEmailPrefix(form.getReviewerEmailPrefix());
                 job.setEmailSubmitter(form.isSendEmail());
                 job.setToEmailAddresses(recipientEmails);
@@ -1036,6 +1218,8 @@ public class PanoramaPublicController extends SpringActionController
         private String _reviewerEmailPrefix;
         private boolean _assignPxId;
         private boolean _usePxTestDb; // Use the test database for getting a PX ID if true
+        private boolean _assignDoi;
+        private boolean _useDataCiteTestApi;
         private boolean _sendEmail;
         private String _toEmailAddresses;
         private String _replyToAddress;
@@ -1050,6 +1234,9 @@ public class PanoramaPublicController extends SpringActionController
 
             form.setAssignPxId(je.isPxidRequested());
             form.setUsePxTestDb(false);
+
+            form.setAssignDoi(true);
+            form.setUseDataCiteTestApi(false);
 
             form.setSendEmail(true);
             Set<String> toEmailAddresses = new HashSet<>();
@@ -1174,6 +1361,26 @@ public class PanoramaPublicController extends SpringActionController
         public void setUsePxTestDb(boolean usePxTestDb)
         {
             _usePxTestDb = usePxTestDb;
+        }
+
+        public boolean isAssignDoi()
+        {
+            return _assignDoi;
+        }
+
+        public void setAssignDoi(boolean assignDoi)
+        {
+            _assignDoi = assignDoi;
+        }
+
+        public boolean isUseDataCiteTestApi()
+        {
+            return _useDataCiteTestApi;
+        }
+
+        public void setUseDataCiteTestApi(boolean useDataCiteTestApi)
+        {
+            _useDataCiteTestApi = useDataCiteTestApi;
         }
 
         public boolean isSendEmail()
@@ -3067,6 +3274,374 @@ public class PanoramaPublicController extends SpringActionController
     // ------------------------------------------------------------------------
 
     // ------------------------------------------------------------------------
+    // BEGIN Actions for DataCite DOI assignment
+    // ------------------------------------------------------------------------
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class DoiOptionsAction extends SimpleViewAction<ExperimentIdForm>
+    {
+        private ExperimentAnnotations _expAnnot;
+
+        @Override
+        public ModelAndView getView(ExperimentIdForm form, BindException errors)
+        {
+            _expAnnot = form.lookupExperiment();
+            if(_expAnnot == null)
+            {
+                errors.reject(ERROR_MSG, "Cannot find experiment with ID " + form.getId());
+                return new SimpleErrorView(errors);
+            }
+            ensureCorrectContainer(getContainer(), _expAnnot.getContainer(), getViewContext());
+            if(!_expAnnot.isJournalCopy())
+            {
+                // DOIs can only be assigned to data on Panorama Public
+                errors.reject(ERROR_MSG, "DOIs can only be assigned to data in the Panorama Public project");
+                return new SimpleErrorView(errors);
+            }
+
+            DOM.Renderable updateDoiForm = DIV(at(style, "margin-top:10px;"),FORM(at(method, "GET", action, new ActionURL(UpdateDoiAction.class, getContainer())),
+                    SPAN(cl("labkey-form-label"), "DOI"),
+                    INPUT(at(type, "hidden", name, "id", value, _expAnnot.getId())),
+                    INPUT(at(type, "Text", name, "doi", value, _expAnnot.getDoi())),
+                    SPAN(at(style, "margin:5px;")),
+                    new Button.ButtonBuilder("Submit").submit(true).build()));
+
+            if(_expAnnot.hasDoi())
+            {
+                return new HtmlView(
+                        DIV(DIV(at(style, "margin-bottom:10px;"), "DOI assigned to the data is " + _expAnnot.getDoi()),
+                                DIV(
+                                new Link.LinkBuilder("Publish DOI").clearClasses().addClass("btn btn-default").href(new ActionURL(PublishDoiAction.class, getContainer()).addParameter("id", _expAnnot.getId())),
+                                SPAN(at(style, "margin:5px;")),
+                                new Link.LinkBuilder("Delete DOI").clearClasses().addClass("btn btn-default").href(new ActionURL(DeleteDoiAction.class, getContainer()).addParameter("id", _expAnnot.getId()))),
+                                updateDoiForm));
+
+            }
+            else
+            {
+               return new HtmlView(
+                       DIV(DIV(new Link.LinkBuilder("Assign New DOI").clearClasses().addClass("btn btn-default").href(getAssignDoiUrl(_expAnnot, getContainer(), false)),
+                       SPAN(at(style, "margin:5px;")),
+                       new Link.LinkBuilder("Assign New Test DOI").clearClasses().addClass("btn btn-default").href(getAssignDoiUrl(_expAnnot, getContainer(), true))),
+                       updateDoiForm));
+            }
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            root.addChild("DOI Actions");
+        }
+    }
+
+    private static ActionURL getAssignDoiUrl(ExperimentAnnotations expAnnot, Container container, boolean testMode)
+    {
+        return new ActionURL(AssignDoiAction.class, container).addParameter("id", expAnnot.getId()).addParameter("testMode", testMode);
+    }
+
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static abstract class DoiAction extends ConfirmAction<DoiForm>
+    {
+        ExperimentAnnotations _expAnnot;
+        // JournalExperiment _journalExperiment;
+        DataCiteException _exception;
+
+        @Override
+        public void validateCommand(DoiForm form, Errors errors)
+        {
+            _expAnnot = form.lookupExperiment();
+            if(_expAnnot == null)
+            {
+                errors.reject(ERROR_MSG, "Cannot find experiment with ID " + form.getId());
+                return;
+            }
+            ensureCorrectContainer(getContainer(), _expAnnot.getContainer(), getViewContext());
+            if(!_expAnnot.isJournalCopy())
+            {
+                errors.reject(ERROR_MSG, "DOIs actions are only allowed on experiments in the Panorama Public project");
+                return;
+            }
+        }
+
+        @Override
+        public boolean handlePost(DoiForm form, BindException errors)
+        {
+            if(errors.getErrorCount() > 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                return doPost(form, errors);
+            }
+            catch (DataCiteException e)
+            {
+                _exception = e;
+                LOG.error(e);
+                return false;
+            }
+        }
+
+        @Override
+        public @NotNull URLHelper getSuccessURL(DoiForm form)
+        {
+            return null;
+        }
+
+        @Override
+        public ModelAndView getSuccessView(DoiForm form)
+        {
+            return new HtmlView(
+                    DIV(getSuccessMessage(),
+                            BR(),
+                            DIV(new Link.LinkBuilder("Back to folder").href(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(_expAnnot.getContainer())))));
+        }
+
+        protected abstract DOM.Renderable getSuccessMessage();
+        protected abstract boolean doPost(DoiForm form, BindException errors) throws DataCiteException;
+
+        public ModelAndView getFailView(DoiForm form, BindException errors)
+        {
+            if(_exception != null)
+            {
+                return new HtmlView(_exception.getHtmlString());
+            }
+            else
+            {
+                return super.getFailView(form, errors);
+            }
+        }
+    }
+
+    @RequiresPermission(AdminOperationsPermission.class)
+    public class AssignDoiAction extends DoiAction
+    {
+        private Doi _doi;
+
+        @Override
+        public ModelAndView getConfirmView(DoiForm form, BindException errors)
+        {
+            return new HtmlView(DIV("Are you sure you want to assign a DOI with the DataCite ", SPAN(at(style, "font-weight:bold;color:red"), form.isTestMode() ? "Test" : "Live"), " API?"));
+        }
+
+        @Override
+        public void validateCommand(DoiForm form, Errors errors)
+        {
+            super.validateCommand(form, errors);
+            if(errors.getErrorCount() > 0)
+            {
+                return;
+            }
+            if(_expAnnot.hasDoi())
+            {
+                errors.reject(ERROR_MSG, "This data is already assigned a DOI: " + _expAnnot.getDoi());
+            }
+        }
+
+        @Override
+        protected HtmlString getSuccessMessage()
+        {
+            return HtmlString.of("DOI assigned: " + _expAnnot.getDoi() + "; State: " + _doi.getState() + "; Findable: " + _doi.isFindable());
+        }
+
+        @Override
+        public boolean doPost(DoiForm form, BindException errors) throws DataCiteException
+        {
+            _doi = DataCiteService.create(form.isTestMode());
+            _expAnnot.setDoi(_doi.getDoi());
+            ExperimentAnnotationsManager.updateDoi(_expAnnot);
+            return true;
+        }
+    }
+
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class DeleteDoiAction extends DoiAction
+    {
+        private String _doi;
+        @Override
+        public ModelAndView getConfirmView(DoiForm form, BindException errors)
+        {
+            return new HtmlView(DIV("Are you sure you want to delete the DOI: " + _expAnnot.getDoi()));
+        }
+
+        @Override
+        public void validateCommand(DoiForm form, Errors errors)
+        {
+            super.validateCommand(form, errors);
+            if(errors.getErrorCount() > 0)
+            {
+                return;
+            }
+            if(!_expAnnot.hasDoi())
+            {
+                errors.reject(ERROR_MSG,"This data is not assigned a DOI");
+            }
+        }
+
+        @Override
+        protected HtmlString getSuccessMessage()
+        {
+            return HtmlString.of("DOI deleted: " + _doi);
+        }
+
+        @Override
+        public boolean doPost(DoiForm form, BindException errors) throws DataCiteException
+        {
+            _doi = _expAnnot.getDoi();
+            DataCiteService.delete(_expAnnot.getDoi());
+            _expAnnot.setDoi(null);
+            ExperimentAnnotationsManager.updateDoi(_expAnnot);
+            return true;
+        }
+    }
+
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class PublishDoiAction extends DoiAction
+    {
+        private JournalExperiment _journalExperiment;
+        private DataCiteService.DoiMetadata _metadata;
+        @Override
+        public ModelAndView getConfirmView(DoiForm form, BindException errors)
+        {
+            return new HtmlView(DIV("Are you sure you want to publish the DOI: " + _expAnnot.getDoi(), BR(), _metadata.getHtmlString()));
+        }
+
+        @Override
+        public void validateCommand(DoiForm form, Errors errors)
+        {
+            super.validateCommand(form, errors);
+            if(errors.getErrorCount() > 0)
+            {
+                return;
+            }
+            _journalExperiment = JournalManager.getRowForJournalCopy(_expAnnot);
+            if(_journalExperiment == null)
+            {
+                errors.reject(ERROR_MSG, "Could not find a row in JournalExperiment for copied experiment " + _expAnnot.getId());
+            }
+            if(!_expAnnot.hasDoi())
+            {
+                errors.reject(ERROR_MSG,"This data is not assigned a DOI");
+            }
+            try
+            {
+                _metadata = DataCiteService.DoiMetadata.from(_expAnnot, _journalExperiment);
+            }
+            catch (DataCiteException e)
+            {
+                errors.reject(ERROR_MSG, e.getMessage());
+            }
+        }
+
+        @Override
+        protected HtmlString getSuccessMessage()
+        {
+            return HtmlString.of("DOI published: " + _expAnnot.getDoi());
+        }
+
+        @Override
+        public boolean doPost(DoiForm form, BindException errors) throws DataCiteException
+        {
+            DataCiteService.publish(_expAnnot, _journalExperiment);
+            return true;
+        }
+    }
+
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class UpdateDoiAction extends DoiAction
+    {
+        @Override
+        public void validateCommand(DoiForm form, Errors errors)
+        {
+            super.validateCommand(form, errors);
+            if(errors.getErrorCount() > 0)
+            {
+                return;
+            }
+            if(_expAnnot.getDoi() == null && StringUtils.isBlank(form.getDoi()))
+            {
+                errors.reject(ERROR_MSG,"Please enter a DOI");
+            }
+            if(_expAnnot.getDoi() != null && _expAnnot.getDoi().equals(form.getDoi()))
+            {
+                errors.reject(ERROR_MSG, "DOI entered is the same as the DOI already assigned to the experiment");
+            }
+        }
+
+        @Override
+        public ModelAndView getConfirmView(DoiForm form, BindException errors)
+        {
+            return _expAnnot.getDoi() != null ?
+                   new HtmlView(DIV("This experiment is assigned the DOI: " + _expAnnot.getDoi() + " Are you sure you want to" +
+                           (StringUtils.isBlank(form.getDoi()) ? " remove it?"
+                                   : " overwrite it with: " + form.getDoi() + "?"),
+                           BR(),
+                           SPAN(at(style, "color:red; font-weight:bold;"), (StringUtils.isBlank(form.getDoi()) ?
+                                   " The DOI " : " The old DOI"), " will NOT be deleted from DataCite.")))
+                    : new HtmlView(DIV("Are you sure you want to set the DOI for this experiment to: " + form.getDoi() + "?"));
+        }
+
+        @Override
+        protected HtmlString getSuccessMessage()
+        {
+            return HtmlString.of("DOI updated to: " + _expAnnot.getDoi());
+        }
+
+        @Override
+        public boolean doPost(DoiForm form, BindException errors)
+        {
+            // TODO: If there is a DOI in the form we should check if it is valid.
+            // All DOI related actions requires AdminOperationsPermission, so for now we assume that the admin knows what they are doing.
+            _expAnnot.setDoi(StringUtils.isBlank(form.getDoi()) ? null : form.getDoi());
+            ExperimentAnnotationsManager.updateDoi(_expAnnot);
+
+            return true;
+        }
+    }
+
+    public static class DoiForm extends ExperimentIdForm
+    {
+        private boolean _testMode;
+        private String _method;
+
+        private String _doi;
+
+        public boolean isTestMode()
+        {
+            return _testMode;
+        }
+
+        public void setTestMode(boolean testMode)
+        {
+            _testMode = testMode;
+        }
+
+        public String getMethod()
+        {
+            return _method;
+        }
+
+        public void setMethod(String method)
+        {
+            _method = method;
+        }
+
+        public String getDoi()
+        {
+            return _doi;
+        }
+
+        public void setDoi(String doi)
+        {
+            _doi = doi;
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // END Actions for DataCite DOI assignment
+    // ------------------------------------------------------------------------
+
+    // ------------------------------------------------------------------------
     // BEGIN Experiment annotation actions
     // ------------------------------------------------------------------------
     private static final String ADD_SELECTED_RUNS = "addSelectedRuns";
@@ -3314,11 +3889,11 @@ public class PanoramaPublicController extends SpringActionController
 
 
             // Experiment details
-            ExperimentAnnotationsDetails exptDetails = new ExperimentAnnotationsDetails(getUser(), exptAnnotations, true);
-            JspView<ExperimentAnnotationsDetails> experimentDetailsView = new JspView<>("/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp", exptDetails);
-            VBox result = new VBox(experimentDetailsView);
+            TargetedMSExperimentWebPart experimentDetailsView = new TargetedMSExperimentWebPart(exptAnnotations, getViewContext(), true);
             experimentDetailsView.setFrame(WebPartView.FrameType.PORTAL);
             experimentDetailsView.setTitle(TargetedMSExperimentWebPart.WEB_PART_NAME);
+            VBox result = new VBox(experimentDetailsView);
+
 
             // List of runs in the experiment.
             PanoramaPublicRunListView runListView = PanoramaPublicRunListView.createView(getViewContext(), exptAnnotations);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -794,12 +794,12 @@ public class PanoramaPublicController extends SpringActionController
                 PropertyManager.PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(DataCiteService.CREDENTIALS, false);
                 if(map != null)
                 {
+                    // Force the user to re-enter the passwords; do not set them in the form
+
                     form.setUser(map.get(DataCiteService.USER));
-                    form.setPassword(map.get(DataCiteService.PASSWORD));
                     form.setDoiPrefix(map.get(DataCiteService.PREFIX));
 
                     form.setTestUser(map.get(DataCiteService.TEST_USER));
-                    form.setTestPassword(map.get(DataCiteService.TEST_PASSWORD));
                     form.setTestDoiPrefix(map.get(DataCiteService.TEST_PREFIX));
                 }
             }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -66,7 +66,7 @@ public class PanoramaPublicModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.005;
+        return 20.006;
     }
 
     @Override

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteException.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteException.java
@@ -3,6 +3,7 @@ package org.labkey.panoramapublic.datacite;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 
 public class DataCiteException extends Exception
 {
@@ -20,7 +21,7 @@ public class DataCiteException extends Exception
 
     public DataCiteException(@NotNull String message, @NotNull DataCiteResponse response)
     {
-        super("Request failed." + message + ". Code: " + response.getResponseCode() + "; Message " + response.getMessage() + "; Body: " + response.getResponseBody());
+        super("Request failed - " + message + ". Code: " + response.getResponseCode() + "; Message " + response.getMessage() + "; Body: " + response.getResponseBody());
         _response = response;
     }
 
@@ -28,8 +29,18 @@ public class DataCiteException extends Exception
     {
         if(_response != null)
         {
-            String s = "<div>Code: " + _response.getResponseCode() + " <br/> Message: " + _response.getMessage() + " <br/> " + _response.getResponseBody();
-            return HtmlString.unsafe(s);
+           return HtmlStringBuilder.of(HtmlString.unsafe("<div>"))
+                    .append("Response code: ").append(_response.getResponseCode())
+                    .append(HtmlString.BR)
+                    .append("Message: ").append(_response.getMessage())
+                    .append(HtmlString.BR)
+                    .append(_response.getResponseBody())
+                    .append(HtmlString.BR).append(HtmlString.BR)
+                    .append("Exception: ")
+                    .append(HtmlString.BR)
+                    .append(ExceptionUtil.renderException(this))
+                    .append(HtmlString.unsafe("</div>"))
+                    .getHtmlString();
         }
         else
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteException.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteException.java
@@ -1,0 +1,39 @@
+package org.labkey.panoramapublic.datacite;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.HtmlString;
+
+public class DataCiteException extends Exception
+{
+    DataCiteService.DataCiteResponse _response;
+
+    public DataCiteException(String message)
+    {
+        super(message);
+    }
+
+    public DataCiteException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public DataCiteException(@NotNull String message, @NotNull DataCiteService.DataCiteResponse response)
+    {
+        super("Request failed." + message + ". Code: " + response.getResponseCode() + "; Message " + response.getMessage() + "; Body: " + response.getResponseBody());
+        _response = response;
+    }
+
+    public HtmlString getHtmlString()
+    {
+        if(_response != null)
+        {
+            String s = "<div>Code: " + _response.getResponseCode() + " <br/> Message: " + _response.getMessage() + " <br/> " + _response.getResponseBody();
+            return HtmlString.unsafe(s);
+        }
+        else
+        {
+            return ExceptionUtil.renderException(this);
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteException.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteException.java
@@ -6,7 +6,7 @@ import org.labkey.api.util.HtmlString;
 
 public class DataCiteException extends Exception
 {
-    DataCiteService.DataCiteResponse _response;
+    private DataCiteResponse _response;
 
     public DataCiteException(String message)
     {
@@ -18,7 +18,7 @@ public class DataCiteException extends Exception
         super(message, cause);
     }
 
-    public DataCiteException(@NotNull String message, @NotNull DataCiteService.DataCiteResponse response)
+    public DataCiteException(@NotNull String message, @NotNull DataCiteResponse response)
     {
         super("Request failed." + message + ". Code: " + response.getResponseCode() + "; Message " + response.getMessage() + "; Body: " + response.getResponseBody());
         _response = response;

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteResponse.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteResponse.java
@@ -1,0 +1,66 @@
+package org.labkey.panoramapublic.datacite;
+
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+class DataCiteResponse
+{
+    private final int _responseCode;
+    private final String _message;
+    private final String _responseBody;
+
+    public DataCiteResponse(int responseCode, String message, String responseBody)
+    {
+        _responseCode = responseCode;
+        _message = message;
+        _responseBody = responseBody;
+    }
+
+    public int getResponseCode()
+    {
+        return _responseCode;
+    }
+
+    public String getMessage()
+    {
+        return _message;
+    }
+
+    public String getResponseBody()
+    {
+        return _responseBody;
+    }
+
+    public boolean success(DataCiteService.METHOD method)
+    {
+        switch (method)
+        {
+            case GET: case PUT: return _responseCode == 200;
+            case POST: return _responseCode == 201;
+            case DELETE: return _responseCode == 204;
+            default:
+                throw new IllegalStateException("Unexpected method: " + method);
+        }
+    }
+
+    public Doi getDoi() throws DataCiteException
+    {
+        return _responseBody == null ? null : Doi.fromJson(getJsonObject(_responseBody));
+    }
+
+    private org.json.simple.JSONObject getJsonObject(String response) throws DataCiteException
+    {
+        JSONParser parser = new JSONParser();
+        try
+        {
+            return (org.json.simple.JSONObject) parser.parse(new StringReader(response));
+        }
+        catch (IOException | ParseException e)
+        {
+            throw new DataCiteException("Error parsing JSON from response: " + response);
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
@@ -1,0 +1,511 @@
+package org.labkey.panoramapublic.datacite;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.labkey.api.data.PropertyManager;
+import org.labkey.api.security.User;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.DateUtil;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.panoramapublic.model.JournalExperiment;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import static org.labkey.api.util.DOM.BR;
+import static org.labkey.api.util.DOM.DIV;
+
+/**
+ * Class for creating, deleting or publishing DOIs with the DataCite API
+ * https://support.datacite.org/reference/dois-2
+ */
+public class DataCiteService
+{
+    public static final String CREDENTIALS = "DataCite Credentials";
+    public static final String USER = "DataCite User";
+    public static final String PASSWORD = "DataCite Password";
+    public static final String PREFIX = "DOI Prefix";
+
+    public static final String TEST_USER = "Test DataCite User";
+    public static final String TEST_PASSWORD = "Test DataCite Password";
+    public static final String TEST_PREFIX = "Test DOI Prefix";
+
+    /**
+     * This will create a 'draft' DOI using either the live or the test DataCite API
+     * @param test if true, the DataCite test API is used for creating the DOI
+     */
+    @NotNull
+    public static Doi create(boolean test) throws DataCiteException
+    {
+        // curl -X POST -H "Content-Type: application/vnd.api+json" --user YOUR_REPOSITORY_ID:YOUR_PASSWORD -d @my_draft_doi.json https://api.test.datacite.org/dois
+        DataCiteConfig config = getDataCiteConfig(test);
+        METHOD method = METHOD.POST;
+        DataCiteResponse response = doRequest(config, getCreateDoiJson(config), method);
+        if(response.success(method))
+        {
+            Doi doi = response.getDoi();
+            if(doi != null && doi.getDoi() != null) return doi;
+            throw new DataCiteException("Could not parse DOI form response: ", response);
+        }
+        throw new DataCiteException("DOI could not be created", response);
+    }
+
+    /**
+     * This will delete a DOI. The DataCite API (live or test) that will be used is determined by looking
+     * at the DOI prefix of the given DOI.
+     */
+    public static void delete(@NotNull String doi) throws DataCiteException
+    {
+        // curl --request DELETE --url https://api.test.datacite.org/dois/id
+        METHOD method = METHOD.DELETE;
+        DataCiteResponse response = doRequest(getDataCiteConfig(doi), null, method);
+        if(!response.success(method))
+        {
+            throw new DataCiteException("DOI could not be deleted", response);
+        }
+    }
+
+    /**
+     * This will publish a DOI, i.e make it 'findable'. The DataCite API (live or test) that will be used is determined by looking
+     * at the DOI prefix in the DOI assigned to the given ExperimentAnnotations
+     */
+    public static void publish(@NotNull ExperimentAnnotations expAnnot, @NotNull JournalExperiment je) throws DataCiteException
+    {
+        // # PUT /dois/:id
+        //$ curl -X PUT -H "Content-Type: application/vnd.api+json" --user YOUR_REPOSITORY_ID:YOUR_PASSWORD -d @my_doi_update.json https://api.test.datacite.org/dois/:id
+        METHOD method = METHOD.PUT;
+        DataCiteResponse response = doRequest(getDataCiteConfig(expAnnot.getDoi()), DoiMetadata.from(expAnnot, je).getJson(), method);
+        if(!response.success(method))
+        {
+            throw new DataCiteException("DOI could not be published", response);
+        }
+    }
+
+    private static DataCiteResponse doRequest(DataCiteConfig config, @Nullable JSONObject json, METHOD method) throws DataCiteException
+    {
+        String auth = Base64.getEncoder().encodeToString((config.getName() + ":" + config.getPassword()).getBytes(StandardCharsets.UTF_8));
+        HttpURLConnection conn = null;
+        try
+        {
+            URL url = new URL(config.getUrl());
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setDoOutput(true);
+            conn.setInstanceFollowRedirects(false);
+            conn.setRequestProperty("Authorization", "Basic " + auth);
+            conn.setRequestMethod(method.name());
+            if(json != null)
+            {
+                byte[] postData = json.toString().getBytes(StandardCharsets.UTF_8);
+                int postDataLength = postData.length;
+
+                conn.setRequestProperty("Content-Type", "application/vnd.api+json");
+                conn.setRequestProperty("charset", "utf-8");
+                conn.setRequestProperty("Content-Length", Integer.toString(postDataLength));
+                conn.setUseCaches(false);
+                try (DataOutputStream wr = new DataOutputStream(conn.getOutputStream()))
+                {
+                    wr.write(postData);
+                    wr.flush();
+                }
+            }
+
+            int responseCode = conn.getResponseCode();
+            String message = conn.getResponseMessage();
+            String response;
+            try (InputStream in = conn.getInputStream())
+            {
+                response = IOUtils.toString(in, StandardCharsets.UTF_8);
+            }
+            catch (IOException e)
+            {
+                try (InputStream in = conn.getErrorStream())
+                {
+                    response = IOUtils.toString(in, StandardCharsets.UTF_8);
+                }
+            }
+
+            return new DataCiteResponse(responseCode, message, response);
+        }
+        catch (IOException e)
+        {
+            throw new DataCiteException("Error submitting " + method + " request to " + config.getUrl(), e);
+        }
+        finally
+        {
+            if (conn != null)
+            {
+                conn.disconnect();
+            }
+        }
+    }
+
+    private static JSONObject getCreateDoiJson(DataCiteConfig config)
+    {
+        /* Example:
+         {
+           "data": {
+           "type": "dois",
+           "attributes": {
+              "prefix": "10.70027"
+             }
+           }
+         }
+         */
+        return new JSONObject().put("data", Objects.requireNonNull(new JSONObject().put("type", "dois"))
+                                                            .put("attributes", new JSONObject(Collections.singletonMap("prefix", config.getPrefix()))));
+    }
+
+    /**
+     * This will return the DataCiteConfig object containing the account name, password, DOI prefix and API URL for the DataCite API
+     * @param test if true, the returned DataCiteConfig will be for the DataCite test API
+     */
+    private static DataCiteConfig getDataCiteConfig(boolean test) throws DataCiteException
+    {
+        PropertyManager.PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(DataCiteService.CREDENTIALS, false);
+        return getConfig(map, null, test);
+    }
+
+    /**
+     * This will return the DataCiteConfig object containing the account name, password, DOI prefix and API URL for the DataCite API
+     * that should be used for managing the given DOI. The DOI prefix is used to determine if the live or test API should be used.
+     * @param doi
+     */
+    private static DataCiteConfig getDataCiteConfig(@NotNull String doi) throws DataCiteException
+    {
+        PropertyManager.PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(DataCiteService.CREDENTIALS, false);
+        DataCiteConfig testConfig = getConfig(map, doi, true);
+        DataCiteConfig config = getConfig(map, doi, false);
+        if(testConfig.hasPrefix(doi))
+        {
+            return testConfig;
+        }
+        if(config.hasPrefix(doi))
+        {
+            return config;
+        }
+        throw new DataCiteException("Unrecognized prefix in DOI: " + doi);
+    }
+
+    private static DataCiteConfig getConfig(PropertyManager.PropertyMap map, @Nullable String doi, boolean test) throws DataCiteException
+    {
+        if(map == null)
+        {
+            throw new DataCiteException("DataCite configuration is not saved");
+        }
+        String testUrl = test ? "https://api.test.datacite.org/dois" : "https://api.datacite.org/dois";
+        if(doi != null)
+        {
+            testUrl += "/" + doi;
+        }
+        String user = map.get(test ? DataCiteService.TEST_USER : DataCiteService.USER);
+        String passwd = map.get(test ? DataCiteService.TEST_PASSWORD : DataCiteService.PASSWORD);
+        String doiPrefix = map.get(test ? DataCiteService.TEST_PREFIX : DataCiteService.PREFIX);
+
+        DataCiteConfig config = new DataCiteConfig(user, passwd, doiPrefix, testUrl);
+        if(!config.valid())
+        {
+            List<String> missing = new ArrayList<>();
+            if(StringUtils.isBlank(user)) missing.add("user name");
+            if(StringUtils.isBlank(passwd)) missing.add("password");
+            if(StringUtils.isBlank(doiPrefix)) missing.add("DOI prefix");
+            throw new DataCiteException("DataCite " + (test ? "test " : "") + "configuration is missing the following properties: " + StringUtils.join(missing, ","));
+        }
+        return config;
+    }
+
+    /**
+     * This class encapsulates the metadata that will be submitted to DataCite when a DOI is made 'findable'
+     */
+    public static class DoiMetadata
+    {
+        private String _url; // The Panorama Public access URL for the data
+        private String _labHead;
+        private String _submitter;
+        private String _title;
+        private String _abstract;
+        private int _year;
+        private String _doi;
+
+        private DoiMetadata() {}
+
+        public static DoiMetadata from(ExperimentAnnotations expAnnot, JournalExperiment je) throws DataCiteException
+        {
+            DoiMetadata metadata = new DoiMetadata();
+            metadata._url = expAnnot.getShortUrl().renderShortURL();
+            User labHead = expAnnot.getLabHeadUser();
+            if(labHead != null)
+            {
+                metadata._labHead = getUserName(labHead, "Lab Head");
+            }
+            User submitter = expAnnot.getSubmitterUser();
+            if(submitter == null)
+            {
+                throw new DataCiteException("Submitter not found for experiment");
+            }
+            metadata._submitter = getUserName(submitter, "Submitter");
+            metadata._title = expAnnot.getTitle();
+            metadata._abstract = expAnnot.getAbstract();
+            metadata._year = DateUtil.now().get(Calendar.YEAR);
+            metadata._doi = expAnnot.getDoi();
+
+            return metadata;
+        }
+
+        private static String getUserName(@NotNull User user, @NotNull String userType) throws DataCiteException
+        {
+            if(StringUtils.isBlank(user.getFirstName()))
+            {
+                throw new DataCiteException("First name missing for " + userType + " " + user.getEmail());
+            }
+            if(StringUtils.isBlank(user.getLastName()))
+            {
+                throw new DataCiteException("Last name missing for " + userType + " " + user.getEmail());
+            }
+            return user.getLastName() + ", " + user.getFirstName();
+        }
+
+        public JSONObject getJson()
+        {
+            /* Example
+                {
+                  "data": {
+                    "id": "10.5438/0012",
+                    "type": "dois",
+                    "attributes": {
+                      "event": "publish",
+                      "doi": "10.5438/0012",
+                      "creators": [{
+                        "name": "DataCite Metadata Working Group"
+                      }],
+                      "titles": [{
+                        "title": "DataCite Metadata Schema Documentation for the Publication and Citation of Research Data v4.0"
+                      }],
+                      "publisher": "DataCite e.V.",
+                      "publicationYear": 2016,
+                      "types": {
+                        "resourceTypeGeneral": "Text"
+                      },
+                      "url": "https://schema.datacite.org/meta/kernel-4.0/index.html",
+                      "schemaVersion": "http://datacite.org/schema/kernel-4"
+                    }
+                  }
+                }
+             */
+            JSONObject data = new JSONObject();
+            data.put("id", _doi);
+            data.put("type", "dois");
+            data.put("attributes", getAttributes());
+
+            return new JSONObject().put("data", data);
+        }
+
+        private JSONObject getAttributes()
+        {
+            JSONObject attribs = new JSONObject();
+            attribs.put("event", "publish");
+            attribs.put("doi", _doi);
+            attribs.put("publisher", "Panorama Public");
+            attribs.put("publicationYear", _year);
+            attribs.put("url", _url);
+            attribs.put("types", new JSONObject().put("resourceTypeGeneral", "Dataset"));
+            JSONArray creators = new JSONArray();
+            creators.put(new JSONObject().put("name", _submitter).put("nameType", "Personal"));
+            if(_labHead != null)
+            {
+                creators.put(new JSONObject().put("name", _labHead).put("nameType", "Personal"));
+            }
+            attribs.put("creators", creators);
+            attribs.put("titles", new JSONArray().put(new JSONObject().put("title", _title)));
+
+            JSONArray descriptions = new JSONArray();
+            descriptions.put(new JSONObject().put("description", _abstract).put("descriptionType", "Abstract"));
+            attribs.put("descriptions", descriptions);
+
+            return attribs;
+        }
+
+        public @NotNull DOM.Renderable getHtmlString()
+        {
+            String creators = _submitter;
+            if(_labHead != null)
+            {
+                creators += ", " + _labHead;
+            }
+            return DIV("DOI: " + _doi,
+                    BR(), "Publisher: Panorama Public",
+                    BR(), "Publication Year: " + _year,
+                    BR(), "URL " + _url,
+                    BR(), "Type: Dataset",
+                    BR(), "Title: " + _title,
+                    BR(), "Creators: " + creators,
+                    BR(), "JSON: " + getJson().toString());
+        }
+    }
+
+    private static class DataCiteConfig
+    {
+        private final String _name;
+        private final String _password;
+        private final String _prefix; // The DOI prefix
+        private final String _url; // The API URL
+
+        public DataCiteConfig(String name, String password, String prefix, String url)
+        {
+            _name = name;
+            _password = password;
+            _prefix = prefix;
+            _url = url;
+        }
+
+        public String getName()
+        {
+            return _name;
+        }
+
+        public String getPassword()
+        {
+            return _password;
+        }
+
+        public String getPrefix()
+        {
+            return _prefix;
+        }
+
+        public String getUrl()
+        {
+            return _url;
+        }
+
+        public boolean valid()
+        {
+            return !StringUtils.isBlank(_name) && !StringUtils.isBlank(_password) && !StringUtils.isBlank(_prefix) && !StringUtils.isBlank(_url);
+        }
+
+        public boolean hasPrefix(String doi)
+        {
+            return doi != null && doi.startsWith(getPrefix());
+        }
+    }
+
+    private enum METHOD {GET, POST, PUT, DELETE}
+
+    static class DataCiteResponse
+    {
+        private final int _responseCode;
+        private final String _message;
+        private final String _responseBody;
+
+        public DataCiteResponse(int responseCode, String message, String responseBody)
+        {
+            _responseCode = responseCode;
+            _message = message;
+            _responseBody = responseBody;
+        }
+
+        public int getResponseCode()
+        {
+            return _responseCode;
+        }
+
+        public String getMessage()
+        {
+            return _message;
+        }
+
+        public String getResponseBody()
+        {
+            return _responseBody;
+        }
+
+        public boolean success(METHOD method)
+        {
+            switch (method)
+            {
+                case GET: case PUT: return _responseCode == 200;
+                case POST: return _responseCode == 201;
+                case DELETE: return _responseCode == 204;
+                default:
+                    throw new IllegalStateException("Unexpected method: " + method);
+            }
+        }
+
+        public Doi getDoi() throws DataCiteException
+        {
+            return _responseBody == null ? null : Doi.fromJson(getJsonObject(_responseBody));
+        }
+
+        private org.json.simple.JSONObject getJsonObject(String response) throws DataCiteException
+        {
+            JSONParser parser = new JSONParser();
+            try
+            {
+                return (org.json.simple.JSONObject) parser.parse(new StringReader(response));
+            }
+            catch (IOException | ParseException e)
+            {
+                throw new DataCiteException("Error parsing JSON from response: " + response);
+            }
+        }
+    }
+
+    public static class Doi
+    {
+        private final String _doi;
+        private final String _state; // e.g. 'draft', 'findable' etc.
+
+        private Doi(String doi, String state)
+        {
+            _doi = doi;
+            _state = state;
+        }
+
+        public String getDoi()
+        {
+            return _doi;
+        }
+
+        public String getState()
+        {
+            return _state;
+        }
+
+        public boolean isFindable()
+        {
+            return "findable".equals(_state);
+        }
+
+        static Doi fromJson(@NotNull org.json.simple.JSONObject json)
+        {
+            if(json.containsKey("data"))
+            {
+                org.json.simple.JSONObject data = (org.json.simple.JSONObject) json.get("data");
+                org.json.simple.JSONObject attribs = (org.json.simple.JSONObject) data.get("attributes");
+                if(attribs != null)
+                {
+                    String doi = (String) attribs.get("doi");
+                    String state = (String) attribs.get("state");
+                    return new Doi(doi, state);
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/Doi.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/Doi.java
@@ -1,0 +1,48 @@
+package org.labkey.panoramapublic.datacite;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Doi
+{
+    private final String _doi;
+    private final String _state; // e.g. 'draft', 'findable' etc.
+
+    private Doi(String doi, String state)
+    {
+        _doi = doi;
+        _state = state;
+    }
+
+    public String getDoi()
+    {
+        return _doi;
+    }
+
+    public String getState()
+    {
+        return _state;
+    }
+
+    public boolean isFindable()
+    {
+        return "findable".equals(_state);
+    }
+
+    @Nullable
+    static Doi fromJson(@NotNull org.json.simple.JSONObject json)
+    {
+        if(json.containsKey("data"))
+        {
+            org.json.simple.JSONObject data = (org.json.simple.JSONObject) json.get("data");
+            org.json.simple.JSONObject attribs = (org.json.simple.JSONObject) data.get("attributes");
+            if(attribs != null)
+            {
+                String doi = (String) attribs.get("doi");
+                String state = (String) attribs.get("state");
+                return new Doi(doi, state);
+            }
+        }
+        return null;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DoiMetadata.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DoiMetadata.java
@@ -1,0 +1,144 @@
+package org.labkey.panoramapublic.datacite;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.labkey.api.security.User;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.DateUtil;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+
+import java.util.Calendar;
+
+import static org.labkey.api.util.DOM.BR;
+import static org.labkey.api.util.DOM.DIV;
+
+/**
+ * This class encapsulates the metadata that will be submitted to DataCite when a DOI is made 'findable'
+ */
+public class DoiMetadata
+{
+    private String _url; // The Panorama Public access URL for the data
+    private String _labHead;
+    private String _submitter;
+    private String _title;
+    private String _abstract;
+    private int _year;
+    private String _doi;
+
+    private DoiMetadata() {}
+
+    public static DoiMetadata from(ExperimentAnnotations expAnnot) throws DataCiteException
+    {
+        DoiMetadata metadata = new DoiMetadata();
+        metadata._url = expAnnot.getShortUrl().renderShortURL();
+        User labHead = expAnnot.getLabHeadUser();
+        if(labHead != null)
+        {
+            metadata._labHead = getUserName(labHead, "Lab Head");
+        }
+        User submitter = expAnnot.getSubmitterUser();
+        if(submitter == null)
+        {
+            throw new DataCiteException("Submitter not found for experiment");
+        }
+        metadata._submitter = getUserName(submitter, "Submitter");
+        metadata._title = expAnnot.getTitle();
+        metadata._abstract = expAnnot.getAbstract();
+        metadata._year = DateUtil.now().get(Calendar.YEAR);
+        metadata._doi = expAnnot.getDoi();
+
+        return metadata;
+    }
+
+    private static String getUserName(@NotNull User user, @NotNull String userType) throws DataCiteException
+    {
+        if(StringUtils.isBlank(user.getFirstName()))
+        {
+            throw new DataCiteException("First name is missing for " + userType + " " + user.getEmail());
+        }
+        if(StringUtils.isBlank(user.getLastName()))
+        {
+            throw new DataCiteException("Last name is missing for " + userType + " " + user.getEmail());
+        }
+        return user.getLastName() + ", " + user.getFirstName();
+    }
+
+    public JSONObject getJson()
+    {
+        /* Example
+            {
+              "data": {
+                "id": "10.5438/0012",
+                "type": "dois",
+                "attributes": {
+                  "event": "publish",
+                  "doi": "10.5438/0012",
+                  "creators": [{
+                    "name": "DataCite Metadata Working Group"
+                  }],
+                  "titles": [{
+                    "title": "DataCite Metadata Schema Documentation for the Publication and Citation of Research Data v4.0"
+                  }],
+                  "publisher": "DataCite e.V.",
+                  "publicationYear": 2016,
+                  "types": {
+                    "resourceTypeGeneral": "Text"
+                  },
+                  "url": "https://schema.datacite.org/meta/kernel-4.0/index.html",
+                  "schemaVersion": "http://datacite.org/schema/kernel-4"
+                }
+              }
+            }
+         */
+        JSONObject data = new JSONObject();
+        data.put("id", _doi);
+        data.put("type", "dois");
+        data.put("attributes", getAttributes());
+
+        return new JSONObject().put("data", data);
+    }
+
+    private JSONObject getAttributes()
+    {
+        JSONObject attribs = new JSONObject();
+        attribs.put("event", "publish");
+        attribs.put("doi", _doi);
+        attribs.put("publisher", "Panorama Public");
+        attribs.put("publicationYear", _year);
+        attribs.put("url", _url);
+        attribs.put("types", new JSONObject().put("resourceTypeGeneral", "Dataset"));
+        JSONArray creators = new JSONArray();
+        creators.put(new JSONObject().put("name", _submitter).put("nameType", "Personal"));
+        if(_labHead != null)
+        {
+            creators.put(new JSONObject().put("name", _labHead).put("nameType", "Personal"));
+        }
+        attribs.put("creators", creators);
+        attribs.put("titles", new JSONArray().put(new JSONObject().put("title", _title)));
+
+        JSONArray descriptions = new JSONArray();
+        descriptions.put(new JSONObject().put("description", _abstract).put("descriptionType", "Abstract"));
+        attribs.put("descriptions", descriptions);
+
+        return attribs;
+    }
+
+    public @NotNull DOM.Renderable getHtmlString()
+    {
+        String creators = _submitter;
+        if(_labHead != null)
+        {
+            creators += "; " + _labHead;
+        }
+        return DIV("DOI: " + _doi,
+                BR(), "Publisher: Panorama Public",
+                BR(), "Publication Year: " + _year,
+                BR(), "URL " + _url,
+                BR(), "Type: Dataset",
+                BR(), "Title: " + _title,
+                BR(), "Creators: " + creators,
+                BR(), "JSON: " + getJson().toString());
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
@@ -76,6 +76,7 @@ public class ExperimentAnnotations
     private String _submitterAffiliation;
     private String _pxid;
     private String _pubmedId;
+    private String _doi;
 
     private static Pattern taxIdPattern = Pattern.compile("(.*)\\(taxid:(\\d+)\\)");
 
@@ -516,5 +517,20 @@ public class ExperimentAnnotations
     public boolean isFinal()
     {
         return isPublic() && isPublished();
+    }
+
+    public String getDoi()
+    {
+        return _doi;
+    }
+
+    public void setDoi(String doi)
+    {
+        _doi = doi;
+    }
+
+    public boolean hasDoi()
+    {
+        return !StringUtils.isBlank(_doi);
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -58,7 +58,7 @@ import org.labkey.panoramapublic.PanoramaPublicManager;
 import org.labkey.panoramapublic.PanoramaPublicNotification;
 import org.labkey.panoramapublic.datacite.DataCiteException;
 import org.labkey.panoramapublic.datacite.DataCiteService;
-import org.labkey.panoramapublic.datacite.DataCiteService.Doi;
+import org.labkey.panoramapublic.datacite.Doi;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.JournalExperiment;
 import org.labkey.panoramapublic.proteomexchange.ProteomeXchangeService;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentJobSupport.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentJobSupport.java
@@ -39,6 +39,9 @@ public interface CopyExperimentJobSupport
     boolean assignPxId();
     boolean usePxTestDb();
 
+    boolean assignDoi();
+    boolean useDataCiteTestApi();
+
     boolean emailSubmitter();
     List<String> toEmailAddresses();
     String replyToAddress();

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -54,6 +54,9 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     private boolean _assignPxId;
     private boolean _usePxTestDb = true;
 
+    private boolean _assignDoi;
+    private boolean _useDataCiteTestApi;
+
     private boolean _emailSubmitter;
     private List<String> _toEmailAddresses;
     private String _replyToAddress;
@@ -177,6 +180,18 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     }
 
     @Override
+    public boolean assignDoi()
+    {
+        return _assignDoi;
+    }
+
+    @Override
+    public boolean useDataCiteTestApi()
+    {
+        return _useDataCiteTestApi;
+    }
+
+    @Override
     public boolean emailSubmitter()
     {
         return _emailSubmitter;
@@ -213,6 +228,16 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     public void setUsePxTestDb(boolean usePxTestDb)
     {
         _usePxTestDb = usePxTestDb;
+    }
+
+    public void setAssignDoi(boolean assignDoi)
+    {
+        _assignDoi = assignDoi;
+    }
+
+    public void setUseDataCiteTestApi(boolean useDataCiteTestApi)
+    {
+        _useDataCiteTestApi = useDataCiteTestApi;
     }
 
     public void setEmailSubmitter(boolean emailSubmitter)

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
@@ -417,6 +417,12 @@ public class ExperimentAnnotationsManager
                         " SET pxId = ? WHERE Id = ?", pxId, expAnnotations.getId());
     }
 
+    public static void updateDoi(ExperimentAnnotations expAnnotations)
+    {
+        new SqlExecutor(PanoramaPublicManager.getSchema()).execute("UPDATE " + PanoramaPublicManager.getTableInfoExperimentAnnotations() +
+                " SET doi = ? WHERE Id = ?", expAnnotations.getDoi(), expAnnotations.getId());
+    }
+
     public static DataLicense getLicenseSelectedForSubmission(Integer submittedExperimentId)
     {
         if(submittedExperimentId == null) return null;

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -184,15 +184,14 @@
         <a class="button-small button-small-red" style="float:left; margin:0px 5px 0px 2px;" href="<%=h(publishUrl)%>"><%=h(publishButtonText)%></a>
     <%}%>
     <%if(canEdit){%>
-    <a style="float:left; margin-top:2px; margin-left:2px;" href="<%=h(editUrl)%>">[Edit]</a>
-    <a style="float:left; margin-top:2px; margin-left:2px;" href="<%=h(deleteUrl)%>">[Delete]</a>
+    <a style="margin-top:2px; margin-left:2px;" href="<%=h(editUrl)%>">[Edit]</a>
+    <a style="margin-top:2px; margin-left:2px;" href="<%=h(deleteUrl)%>">[Delete]</a>
     <%}%>
     <%if(!showingFullDetails) {%>
-    <a style="float:left; margin-top:2px; margin-left:2px;" href="<%=h(experimentDetailsUrl)%>">[More Details...]</a>
+    <a style="margin-top:2px; margin-left:2px;" href="<%=h(experimentDetailsUrl)%>">[More Details...]</a>
     <%}%>
 </div>
 
-<br/>
 <% if(!StringUtils.isBlank(accessUrl)) {%>
     <div class="link">
        <strong><%=h(linkText)%>: </strong>
@@ -200,11 +199,6 @@
        <a class="button-small button-small-green" style="margin:0px 5px 0px 2px;" href="" onclick="showShareLink(this, '<%=h(accessUrl)%>'); return false;">Share</a>
     </div>
  <% } %>
-<%if(license != null){%>
-<div class="link">
-    <strong>Data License: </strong> <%=license.getDisplayLinkHtml()%>
-</div>
-<%}%>
 <%if(annot.getCitation() != null && annot.getPublicationLink() != null){%>
     <div class="link"><%=h(annot.getCitation())%> <strong><br />[<a href="<%=h(annot.getPublicationLink())%>" target="_blank">Publication</a>]</strong></div>
 <%}%>
@@ -214,18 +208,26 @@
 <%if(annot.getCitation() == null && annot.getPublicationLink() != null){%>
     <div class="link"><strong><br />[<a href="<%=h(annot.getPublicationLink())%>" target="_blank">Publication</a>]</strong></div>
 <%}%>
-<%if(annot.getPxid() != null){%>
-    <div class="link">
-        <strong>ProteomeXchange ID: </strong> <a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=<%=h(annot.getPxid())%>" target="_blank"><%=h(annot.getPxid())%></a>
-    </div>
-<%}%>
-
-<%if(getUser().hasSiteAdminPermission()) {
-    ActionURL pxActionsUrl = urlFor(GetPxActionsAction.class);
-    pxActionsUrl.addParameter("id", annot.getId());
-%>
-<br/><div><%=link("ProteomeXchange Actions", pxActionsUrl)%></div>
-<%}%>
+<div>
+    <% boolean addSep = false; %>
+    <% if(license != null){%>
+    <span class="link">
+        <strong>License: </strong> <%=license.getDisplayLinkHtml()%>
+    </span>
+    <% addSep = true; }%>
+    <%if(annot.getPxid() != null){%>
+    <%if(addSep) {%> <span style="margin-right:10px;margin-left:10px;">|</span> <%}%>
+    <span class="link">
+        <a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=<%=h(annot.getPxid())%>" target="_blank"><%=h(annot.getPxid())%></a>
+    </span>
+    <% addSep = true; }%>
+    <%if(annot.hasDoi()){%>
+    <%if(addSep) {%> <span style="margin-right:10px;margin-left:10px;">|</span> <%}%>
+    <span class="link">
+        <strong>DOI: </strong> <a href="https://doi.org/<%=h(annot.getDoi())%>" target="_blank"><%=h(annot.getDoi())%></a>
+    </span>
+    <%}%>
+</div>
 
 <ul>
     <%if(annot.getOrganism() != null){%>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -212,19 +212,19 @@
     <% boolean addSep = false; %>
     <% if(license != null){%>
     <span class="link">
-        <strong>License: </strong> <%=license.getDisplayLinkHtml()%>
+        <strong>Data License: </strong> <%=license.getDisplayLinkHtml()%>
     </span>
     <% addSep = true; }%>
     <%if(annot.getPxid() != null){%>
     <%if(addSep) {%> <span style="margin-right:10px;margin-left:10px;">|</span> <%}%>
     <span class="link">
-        <a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=<%=h(annot.getPxid())%>" target="_blank"><%=h(annot.getPxid())%></a>
+        <strong>ProteomeXchange: </strong><a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=<%=h(annot.getPxid())%>" target="_blank"><%=h(annot.getPxid())%></a>
     </span>
     <% addSep = true; }%>
     <%if(annot.hasDoi()){%>
     <%if(addSep) {%> <span style="margin-right:10px;margin-left:10px;">|</span> <%}%>
     <span class="link">
-        <strong>DOI: </strong> <a href="https://doi.org/<%=h(annot.getDoi())%>" target="_blank"><%=h(annot.getDoi())%></a>
+        <strong>doi:</strong><a href="https://doi.org/<%=h(annot.getDoi())%>" target="_blank"><%=h(annot.getDoi())%></a>
     </span>
     <%}%>
 </div>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/manageDataCiteCredentials.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/manageDataCiteCredentials.jsp
@@ -1,0 +1,47 @@
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.JournalGroupsAdminViewAction" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController.DataCiteCredentialsForm" %>
+<%@ page extends="org.labkey.api.jsp.FormPage" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<labkey:errors/>
+<%
+    DataCiteCredentialsForm form = ((JspView<DataCiteCredentialsForm>) HttpView.currentView()).getModelBean();
+    ActionURL panoramaPublicAdminUrl = urlFor(JournalGroupsAdminViewAction.class);
+%>
+<p>
+<labkey:form method="post">
+    <table>
+        <tr>
+            <td  class='labkey-form-label'>User:</td>
+            <td><input size="50" type="text" name="user" value="<%=h(form.getUser())%>"></td>
+        </tr>
+        <tr>
+            <td  class='labkey-form-label'>Password:</td>
+            <td><input size="50" type="text" name="password" value="<%=h(form.getPassword())%>"></td>
+        </tr>
+        <tr>
+            <td  class='labkey-form-label'>DOI Prefix:</td>
+            <td><input size="50" type="text" name="doiPrefix" value="<%=h(form.getDoiPrefix())%>"></td>
+        </tr>
+        <tr>
+            <td  class='labkey-form-label'>Test User:</td>
+            <td><input size="50" type="text" name="testUser" value="<%=h(form.getTestUser())%>"></td>
+        </tr>
+        <tr>
+            <td  class='labkey-form-label'>Password:</td>
+            <td><input size="50" type="text" name="testPassword" value="<%=h(form.getTestPassword())%>"></td>
+        </tr>
+        <tr>
+            <td  class='labkey-form-label'>Test DOI Prefix:</td>
+            <td><input size="50" type="text" name="testDoiPrefix" value="<%=h(form.getTestDoiPrefix())%>"></td>
+        </tr>
+        <tr>
+            <td style="padding-top: 10px; padding-right: 5px;"><%=button("Save Credentials").submit(true)%></td>
+            <td style="padding-top: 10px; padding-left: 5px;"><%=button("Cancel").href(panoramaPublicAdminUrl)%></td>
+        </tr>
+    </table>
+
+</labkey:form>
+</p>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
@@ -193,6 +193,19 @@
                     boxLabel: 'Check this box for tests so that we get an ID from the ProteomeXchange test database rather than their production database.'
                 },
                 {
+                    xtype: 'checkbox',
+                    fieldLabel: "Assign Digital Object Identifier",
+                    checked: <%=bean.isAssignDoi()%>,
+                    name: 'assignDoi'
+                },
+                {
+                    xtype: 'checkbox',
+                    fieldLabel: "Use DataCite Test API for creating DOI",
+                    checked: <%=bean.isUseDataCiteTestApi()%>,
+                    name: 'useDataCiteTestApi',
+                    boxLabel: 'Check this box for tests so that we get a DOI with the DataCite test API.'
+                },
+                {
                     xtype: 'textfield',
                     hidden: <%=!je.isKeepPrivate() || isRecopy%>,
                     fieldLabel: "Reviewer Email Prefix",

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -136,6 +136,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         // Enter the name of the destination folder in the Panorama Public project
         setFormElement(Locator.tagWithName("input", "destContainerName"), DESTINATION_FOLDER);
         _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Send Email to Submitter:"));
+        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Assign Digital Object Identifier:")); // Don't try to assign a DOI
         // Locator.extButton("Begin Copy"); // Locator.extButton() does not work.
         click(Ext4Helper.Locators.ext4Button("Begin Copy"));
 
@@ -193,6 +194,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         // Enter the name of the destination folder in the Panorama Public project
         setFormElement(Locator.tagWithName("input", "destContainerName"), DESTINATION_FOLDER);
         _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Send Email to Submitter:"));
+        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Assign Digital Object Identifier:")); // Don't try to assign a DOI
         click(Ext4Helper.Locators.ext4Button("Begin Copy"));
 
         // Wait for the pipeline job to finish


### PR DESCRIPTION
#### Rationale
We are partnering with UW Libraries to assign Digital Object Identifiers (DOIs) to datasets submitted to Panorama Public. UW Libraries is a member of DataCite, a DOI registration organization primarily for research datasets. 

#### Changes
* Admins can enter the DataCite credentials through the Panorama Public Admin Console link
* A DOI is assigned to a dataset when it is copied to Panorama Public.  The admin doing the copy can decide if a DOI is assigned or not with a checkbox in the copy form
* DOI can also be assigned, deleted or published from the NavMenu added to the TargetedMSExperimentWebPart 
