### PR TITLE
Issue 42801: Ask user if they want to include subfolders in data submitted to Panorama Public

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
@@ -34,7 +34,7 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.InsertPermission;
+import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.GUID;
@@ -162,7 +162,7 @@ public class ExperimentAnnotationsManager
         // Get all the runs contained in the folder and its subfolders.
         List<ExpRun> runs = new ArrayList<>();
         // 'children' includes the root container.
-        List<Container> children = ContainerManager.getAllChildren(experiment.getContainer(), user, InsertPermission.class);
+        List<Container> children = ContainerManager.getAllChildren(experiment.getContainer(), user, ReadPermission.class);
         for(Container child: children)
         {
             runs.addAll(expService.getExpRuns(child, null, null));

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/missingExperimentInfo.jsp
@@ -27,6 +27,7 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="org.labkey.panoramapublic.model.JournalExperiment" %>
 <%@ page import="org.labkey.panoramapublic.query.JournalManager" %>
+<%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
@@ -79,7 +80,7 @@
         <%=h(continueSubmissionText)%> <br><br>
     <% } %>
     The following information is required for a "complete" ProteomeXchange submission. <span style="margin-left:10px;">
-    <% if(!bean.isNotSubmitting()) {%> <%=link(continueSubmissionText).onClick("submitForm();")%></span> <% } %>
+    <% if(bean.isSubmitting()) {%> <%=button(continueSubmissionText).onClick("submitForm();")%></span> <% } %>
 
     <% if(status.hasMissingMetadata()) { %>
     <div style="margin-top:10px;margin-bottom:20px;">
@@ -218,7 +219,9 @@
         <%=button("Upload Library Source Data").href(rawFilesUrl).build()%> <span>(Drag and drop to the files browser in the Raw Data tab to upload files)</span>
     </div>
     <%}%>
-
+<div style="margin-top:30px;">
+    <%=button("Cancel").href(urlProvider(ProjectUrls.class).getBeginURL(getContainer())).build()%>
+</div>
 </div>
 <div id="publishExperimentForm"></div>
 <script type="text/javascript">
@@ -256,6 +259,11 @@
                     xtype: 'hidden',
                     name: 'incompletePxSubmission',
                     value: <%=doIncompletePxSubmission%>,
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'doSubfolderCheck',
+                    value: <%=bean.doSubfolderCheck()%>
                 }
             ]
         });

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
@@ -170,6 +170,11 @@
                 },
                 {
                     xtype: 'hidden',
+                    name: 'doSubfolderCheck',
+                    value: <%=bean.getForm().doSubfolderCheck()%>
+                },
+                {
+                    xtype: 'hidden',
                     name: 'dataValidated',
                     value: <%=bean.getForm().isDataValidated()%>
                 },

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -1,5 +1,7 @@
 package org.labkey.test.tests.panoramapublic;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,6 +13,7 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.External;
 import org.labkey.test.categories.MacCossLabModules;
 import org.labkey.test.components.BodyWebPart;
+import org.labkey.test.components.SubfoldersWebPart;
 import org.labkey.test.pages.InsertPage;
 import org.labkey.test.tests.targetedms.TargetedMSTest;
 import org.labkey.test.util.APIContainerHelper;
@@ -24,6 +27,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.File;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -38,10 +42,14 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
 
     private static String PANORAMA_PUBLIC = "Panorama Public " + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     private static final String PANORAMA_PUBLIC_GROUP = "panoramapublictest";
-    private static final String DESTINATION_FOLDER = "Test Copy";
 
     private static final String ADMIN_USER = "admin@panoramapublic.test";
     private static final String SUBMITTER = "submitter@panoramapublic.test";
+    private static final String SUBMITTER_2 = "submitter_2@panoramapublic.test";
+    private static final String REVIEWER_PREFIX = "panoramapublictest_reviewer";
+
+    private static final String INCLUDE_SUBFOLDERS_AND_SUBMIT = "Include Subfolders And Continue";
+    private static final String EXCLUDE_SUBFOLDERS_AND_SUBMIT = "Skip Subfolders And Continue";
 
     PortalHelper portalHelper = new PortalHelper(this);
 
@@ -56,6 +64,9 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
     {
         PanoramaPublicTest init = (PanoramaPublicTest)getCurrentTest();
         init.createPanoramaPublicJournalProject();
+
+        // Create the test project
+        init.setupFolder(FolderType.Experiment);
     }
 
     private void createPanoramaPublicJournalProject()
@@ -73,6 +84,12 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         _userHelper.createUser(ADMIN_USER);
         ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
         _permissionsHelper.addUserToProjGroup(ADMIN_USER, PANORAMA_PUBLIC, PANORAMA_PUBLIC_GROUP);
+
+        // Add the Messages webpart
+        goToProjectHome(PANORAMA_PUBLIC);
+        DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
+        assertEquals(0, expListTable.getDataRowCount()); // Table should be empty since we have not yet copied any experiments.
+        portalHelper.addWebPart("Messages");
     }
 
     protected File getSampleDataPath(String file)
@@ -83,50 +100,161 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
     @Test
     public void testExperimentCopy()
     {
-        goToProjectHome(PANORAMA_PUBLIC);
-        DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
-        assertEquals(0, expListTable.getDataRowCount()); // Table should be empty since we have not yet copied any experiments.
-
         // Set up our source folder. We will create an experiment here and submit it to our "Panorama Public" project.
-        setupFolder(FolderType.Experiment);
+        String projectName = getProjectName();
+        String folderName = "Folder 1";
+        String targetFolder = "Test Copy 1";
+        String experimentTitle = "This is a test experiment";
+        setupSourceFolder(projectName, folderName, SUBMITTER);
+
         impersonate(SUBMITTER);
 
         // Add the "Targeted MS Experiment" webpart
-        portalHelper.click(Locator.folderTab("Panorama Dashboard"));
+        TargetedMsExperimentWebPart expWebPart = createTargetedMsExperimentWebPart(experimentTitle);
+
+        // Should show error message since there are no Skyline documents in the folder.
+        testSubmitWithNoSkyDocs(expWebPart);
+
+        // Import a Skyline document to the folder
+        importData(SKY_FILE_1, 1);
+
+        // Should show an error message since the submitter's account info does not have a first and last name
+        testSubmitWithIncompleteAccountInfo(expWebPart);
+        updateSubmitterAccountInfo("One");
+
+        // Click Submit.  Expect to see the missing information page. Submit the experiment by clicking the
+        // "Continue without a ProteomeXchange ID" link
+        testSubmitWithMissingRawFiles(portalHelper, expWebPart);
+
+        // Copy the experiment to the Panorama Public project
+        copyExperimentAndVerify(projectName, folderName, experimentTitle, false, targetFolder);
+
+        // Test re-submit experiment
+        goToProjectFolder(projectName, folderName);
+        impersonate(SUBMITTER);
+        goToDashboard();
+        expWebPart.clickResubmit();
+        resubmitWithoutPxd();
+        goToDashboard();
+        assertTextPresent("Copy Pending!");
+
+        copyExperimentAndVerify(projectName, folderName, experimentTitle, true, targetFolder);
+    }
+
+    @Test
+    public void testCopyExperimentWithSubfolder()
+    {
+        String projectName = getProjectName();
+        String sourceFolder = "Folder 2";
+        String subfolder = "Subfolder_for_test";
+        String targetFolder = "Test Copy 2";
+        String experimentTitle = "Test experiment with subfolders";
+
+        setupSourceFolder(projectName, sourceFolder, SUBMITTER, SUBMITTER_2);
+        impersonate(SUBMITTER);
+        updateSubmitterAccountInfo("One");
+
+        // Add the "Targeted MS Experiment" webpart
+        TargetedMsExperimentWebPart expWebPart = createTargetedMsExperimentWebPart(experimentTitle);
+
+        // Import a Skyline document to the folder
+        importData(SKY_FILE_1, 1);
+
+        // Create a subfolder
+        _containerHelper.createSubfolder(projectName, sourceFolder, subfolder, "Collaboration", null, false);
+
+        goToProjectFolder(projectName, sourceFolder);
+        testSubmitWithSubfolders(expWebPart);
+
+        // Copy the experiment to the Panorama Public project
+        copyExperimentAndVerify(projectName, sourceFolder, subfolder, experimentTitle, false, targetFolder);
+
+        // Remove permissions for SUBMITTER_2 from the subfolder, and try to resubmit the experiment as SUBMITTER_2. This user
+        // should not be able to resubmit because the experiment was configured by SUBMITTER to include subfolders, and read permissions
+        // in all subfolders are required for submitting an experiment.
+        goToProjectFolder(projectName, sourceFolder + "/" + subfolder);
+        ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+        permissionsHelper.removeUserRoleAssignment(SUBMITTER_2, "Folder Administrator", projectName + "/" + sourceFolder + "/" + subfolder);
+        permissionsHelper.assertNoPermission(SUBMITTER_2, "Reader");
+
+        goToProjectFolder(projectName, sourceFolder);
+        impersonate(SUBMITTER_2);
+        updateSubmitterAccountInfo("Two"); // Add first and last name
+        goToDashboard();
+        expWebPart.clickResubmit();
+        assertTextPresent("This experiment is configured to include subfolders but you do not have read permissions in the following folders");
+        assertTextPresent(subfolder);
+        assertTextPresent("Read permissions are required in all subfolders to include data from subfolders");
+        assertElementPresent(Locator.linkWithText("Back To Folder"));
+        assertElementPresent(Locator.linkWithText("Exclude Subfolders"));
+    }
+
+    @NotNull
+    private PanoramaPublicTest.TargetedMsExperimentWebPart createTargetedMsExperimentWebPart(String experimentTitle)
+    {
+        goToDashboard();
         portalHelper.enterAdminMode();
         portalHelper.addBodyWebPart("Targeted MS Experiment");
 
         // Create a new experiment
         TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
         TargetedMsExperimentInsertPage insertPage = expWebPart.startInsert();
-        insertPage.insert();
+        insertPage.insert(experimentTitle);
+        return expWebPart;
+    }
 
-        // Should show error message since there are no Skyline documents in the folder.
-        testSubmitWithNoSkyDocs(portalHelper, expWebPart);
+    private void verifyCopy(String experimentTitle, String projectName, String folderName, String subfolderName, boolean recopy)
+    {
+        // Verify the copy
+        goToProjectHome(PANORAMA_PUBLIC);
+        DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
+        expListTable.ensureColumnPresent("Title");
+        expListTable.setFilter("Title", "Equals", experimentTitle);
+        // expListTable.setFilter("Share", "Is Not Blank");
+        assertEquals(1, expListTable.getDataRowCount()); // The table should have one row for the copied experiment.
+        expListTable.ensureColumnPresent("Runs");
+        expListTable.ensureColumnPresent("Public"); // Column to indicate if the data is public or not
+        expListTable.ensureColumnPresent("Data License");
+        Assert.assertTrue(expListTable.getDataAsText(0,"Title").contains(experimentTitle));
+        assertEquals("1", expListTable.getDataAsText(0, "Runs"));
+        assertEquals("No", expListTable.getDataAsText(0, "Public"));
+        assertEquals("CC BY 4.0", expListTable.getDataAsText(0, "Data License"));
+        clickAndWait(expListTable.link(0, "Title"));
+        assertTextPresentInThisOrder("Targeted MS Experiment", // Webpart title
+                experimentTitle, // Title of the experiment
+                "Data License", "CC BY 4.0" // This is the default data license
+        );
+        if(subfolderName != null)
+        {
+            SubfoldersWebPart subfoldersWp = SubfoldersWebPart.getWebPart(getDriver());
+            assertNotNull(subfoldersWp);
+            List<String> subfolderNames = subfoldersWp.GetSubfolderNames();
+            assertEquals(1, subfolderNames.size());
+            assertEquals(subfolderName.toUpperCase(), subfolderNames.get(0));
+        }
 
-        // Import a Skyline document to the folder
-        importData(SKY_FILE_1, 1);
+        // Verify that notifications got posted on message board
+        goToProjectHome(PANORAMA_PUBLIC);
+        clickAndWait(Locator.linkContainingText("/" + projectName + "/" + folderName));
+        assertTextPresent((recopy ? "RECOPIED": "COPIED") + ": Experiment ID ");
+        assertTextPresent("Email was not sent to submitter");
+    }
 
-        // Should show an error message since the submitter's account info does not have a first and last name
-        testSubmitWithIncompleteAccountInfo(portalHelper, expWebPart);
-        updateSubmitterAccountInfo();
+    private void copyExperimentAndVerify(String projectName, String folderName, String experimentTitle, boolean recopy, String destinationFolder)
+    {
+        copyExperimentAndVerify(projectName, folderName, null, experimentTitle, recopy, destinationFolder);
+    }
 
-        // Click Submit.  Expect to see the missing information page
-        testSubmitWithMissingRawFiles(portalHelper, expWebPart);
-
-        // Submit the experiment by clicking the "Continue without a ProteomeXchange ID" link
-        portalHelper.click(Locator.folderTab("Panorama Dashboard"));
-        expWebPart.submitWithoutPXId();
-        assertTextPresent("Copy Pending!");
-
-        // Copy the experiment to the Panorama Public project
-        stopImpersonating();
+    private void copyExperimentAndVerify(String projectName, String folderName, @Nullable String subfolderName, String experimentTitle, boolean recopy, String destinationFolder)
+    {
+        if(isImpersonating())
+        {
+            stopImpersonating();
+        }
         goToProjectHome(PANORAMA_PUBLIC);
         impersonateGroup(PANORAMA_PUBLIC_GROUP, false);
-        portalHelper.addWebPart("Messages");
-        assertTextPresent("NEW: Experiment ID ");
-        assertTextPresent("Target: " + PANORAMA_PUBLIC);
-        clickAndWait(Locator.linkWithText("view message or respond"));
+
+        clickAndWait(Locator.linkContainingText("/" + projectName + "/" + folderName));
         Locator.XPathLocator copyLink = Locator.linkContainingText("Copy Link");
         assertNotNull(copyLink);
         clickAndWait(copyLink);
@@ -134,109 +262,73 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         // In the copy form's folder tree view select the Panorama Public project as the destination.
         Locator.tagWithClass("span", "x4-tree-node-text").withText(PANORAMA_PUBLIC).waitForElement(new WebDriverWait(getDriver(), 5)).click();
         // Enter the name of the destination folder in the Panorama Public project
-        setFormElement(Locator.tagWithName("input", "destContainerName"), DESTINATION_FOLDER);
+        setFormElement(Locator.tagWithName("input", "destContainerName"), destinationFolder);
         _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Send Email to Submitter:"));
         _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Assign Digital Object Identifier:")); // Don't try to assign a DOI
+
+        if(recopy)
+        {
+            assertTextPresent("This experiment was last copied on");
+            Locator.XPathLocator deletePreviousCopyCb = Ext4Helper.Locators.checkbox(this, "Delete Previous Copy:");
+            assertNotNull("Expected to see \"Delete Previous Copy\" checkbox", deletePreviousCopyCb);
+            _ext4Helper.checkCheckbox(deletePreviousCopyCb);
+        }
+        else
+        {
+            setFormElement(Locator.tagWithName("input", "reviewerEmailPrefix"), REVIEWER_PREFIX);
+        }
+
         // Locator.extButton("Begin Copy"); // Locator.extButton() does not work.
         click(Ext4Helper.Locators.ext4Button("Begin Copy"));
 
         // Wait for the pipeline job to finish
         waitForText("Copying experiment");
-        waitForPipelineJobsToComplete(1, "Copying experiment: " + TargetedMsExperimentInsertPage.EXP_TITLE, false);
+        waitForPipelineJobsToComplete(1, "Copying experiment: " + experimentTitle, false);
 
-        // Verify the copy
-        goToProjectHome(PANORAMA_PUBLIC);
-        expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
-        assertEquals(1, expListTable.getDataRowCount()); // The table should have a row for the copied experiment.
-        expListTable.ensureColumnPresent("Title");
-        Assert.assertTrue(expListTable.getDataAsText(0,"Title").contains(TargetedMsExperimentInsertPage.EXP_TITLE));
-        expListTable.ensureColumnPresent("Runs");
-        expListTable.ensureColumnPresent("Public"); // Column to indicate if the data is public or not
-        expListTable.ensureColumnPresent("Data License");
-        assertEquals("1", expListTable.getDataAsText(0, "Runs"));
-        assertEquals("No", expListTable.getDataAsText(0, "Public"));
-        assertEquals("CC BY 4.0", expListTable.getDataAsText(0, "Data License"));
-        clickAndWait(expListTable.link(0, "Title"));
-        assertTextPresentInThisOrder("Targeted MS Experiment", // Webpart title
-                TargetedMsExperimentInsertPage.EXP_TITLE, // Title of the experiment
-                "Data License", "CC BY 4.0" // This is the default data license
-        );
-
-        // Verify that notifications got posted on message board
-        goToProjectHome(PANORAMA_PUBLIC);
-        clickAndWait(Locator.linkWithText("view message or respond"));
-        assertTextPresent("COPIED: Experiment ID ");
-        assertTextPresent("Email was not sent to submitter");
-
-
-        // Test re-submit experiment
-        stopImpersonating();
-        goToProjectHome(getProjectName());
-        impersonate(SUBMITTER);
-        portalHelper.click(Locator.folderTab("Panorama Dashboard"));
-        expWebPart.resubmitWithoutPxd();
+        verifyCopy(experimentTitle, projectName, folderName, subfolderName, recopy);
 
         stopImpersonating();
-        goToProjectHome(PANORAMA_PUBLIC);
-        impersonateGroup(PANORAMA_PUBLIC_GROUP, false);
-        // Messages webpart is already added.
-        assertEquals(1, countText("view message or respond")); // Expect to see only 1 message thread
-        clickAndWait(Locator.linkWithText("view message or respond"));
-        copyLink = Locator.linkContainingText("Copy Link");
-        assertNotNull(copyLink);
-        clickAndWait(copyLink);
-        // In the copy form's folder tree view select the Panorama Public project as the destination.
-        assertTextPresent("This experiment was last copied on");
-        Locator.XPathLocator deletePreviousCopyCb = Ext4Helper.Locators.checkbox(this, "Delete Previous Copy:");
-        assertNotNull("Expected to see \"Delete Previous Copy\" checkbox", deletePreviousCopyCb);
-        _ext4Helper.uncheckCheckbox(deletePreviousCopyCb);
-        Locator.tagWithClass("span", "x4-tree-node-text").withText(PANORAMA_PUBLIC).waitForElement(new WebDriverWait(getDriver(), 5)).click();
-        // Enter the name of the destination folder in the Panorama Public project
-        setFormElement(Locator.tagWithName("input", "destContainerName"), DESTINATION_FOLDER);
-        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Send Email to Submitter:"));
-        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Assign Digital Object Identifier:")); // Don't try to assign a DOI
-        click(Ext4Helper.Locators.ext4Button("Begin Copy"));
-
-        // Wait for the pipeline job to finish
-        waitForText("Copying experiment");
-        waitForPipelineJobsToComplete(1, "Copying experiment: " + TargetedMsExperimentInsertPage.EXP_TITLE, false);
     }
 
-    protected void setupFolder(FolderType folderType)
+    protected void setupSourceFolder(String projectName, String folderName, String ... adminUsers)
     {
-        super.setupFolder(folderType);
-        _userHelper.deleteUser(SUBMITTER);
-        _userHelper.createUser(SUBMITTER);
-        ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
-        _permissionsHelper.addMemberToRole(SUBMITTER, "Project Administrator", PermissionsHelper.MemberType.user, getProjectName());
+        setupSubfolder(projectName, folderName, FolderType.Experiment); // Create the subfolder
+
+        ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+        for(String user: adminUsers)
+        {
+            _userHelper.deleteUser(user);
+            _userHelper.createUser(user);
+            permissionsHelper.addMemberToRole(user, "Folder Administrator", PermissionsHelper.MemberType.user, projectName + "/" + folderName);
+        }
     }
 
-    private void testSubmitWithIncompleteAccountInfo(PortalHelper portal, TargetedMsExperimentWebPart expWebPart)
+    private void testSubmitWithIncompleteAccountInfo(TargetedMsExperimentWebPart expWebPart)
     {
-        portal.click(Locator.folderTab("Panorama Dashboard"));
+        goToDashboard();
         expWebPart.clickSubmit();
         assertTextPresent("First and last names missing for data submitter: " + SUBMITTER);
     }
 
-    private void updateSubmitterAccountInfo()
+    private void updateSubmitterAccountInfo(String lastName)
     {
         goToMyAccount();
         clickButton("Edit");
-        setFormElement(Locator.name("quf_FirstName"), "Panorama");
-        setFormElement(Locator.name("quf_LastName"), "Submitter");
+        setFormElement(Locator.name("quf_FirstName"), "Submitter");
+        setFormElement(Locator.name("quf_LastName"), lastName);
         clickButton("Submit");
     }
 
-    private void testSubmitWithNoSkyDocs(PortalHelper portal, TargetedMsExperimentWebPart expWebPart)
+    private void testSubmitWithNoSkyDocs(TargetedMsExperimentWebPart expWebPart)
     {
-        portal.click(Locator.folderTab("Panorama Dashboard"));
+        goToDashboard();
         expWebPart.clickSubmit();
         assertTextPresent("There are no Skyline documents included in this experiment");
     }
 
     private void testSubmitWithMissingRawFiles(PortalHelper portal, TargetedMsExperimentWebPart expWebPart)
     {
-        portal.click(Locator.folderTab("Panorama Dashboard"));
+        goToDashboard();
         expWebPart.clickSubmit();
         assertTextPresent("Missing raw data");
         assertTextPresent(RAW_FILE_WIFF);
@@ -244,11 +336,60 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
 
         portal.click(Locator.folderTab("Raw Data"));
         _fileBrowserHelper.uploadFile(getSampleDataPath(RAW_FILE_WIFF));
-        portal.click(Locator.folderTab("Panorama Dashboard"));
+        goToDashboard();
         expWebPart.clickSubmit();
         assertTextPresent("Missing raw data");
         assertTextPresent(RAW_FILE_WIFF_SCAN);
         assertEquals(1, countText(RAW_FILE_WIFF));
+
+        submitWithoutPXId();
+
+        goToDashboard();
+        assertTextPresent("Copy Pending!");
+    }
+
+    private void testSubmitWithSubfolders(TargetedMsExperimentWebPart expWebPart)
+    {
+        goToDashboard();
+        expWebPart.clickSubmit();
+        assertTextPresent("Confirm Include Subfolders");
+        assertTextPresent("Would you like to include data from the following subfolders in the experiment?");
+        assertElementPresent(Locator.linkWithText(INCLUDE_SUBFOLDERS_AND_SUBMIT));
+        assertElementPresent(Locator.linkWithText(EXCLUDE_SUBFOLDERS_AND_SUBMIT));
+
+        clickAndWait(Locator.linkWithText(INCLUDE_SUBFOLDERS_AND_SUBMIT));
+
+        submitWithoutPXId();
+
+        goToDashboard();
+        assertTextPresent("Copy Pending!");
+    }
+
+    public void submitWithoutPXId()
+    {
+        clickContinueWithoutPxId();
+        _ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PanoramaPublicTest.PANORAMA_PUBLIC);
+        clickAndWait(Ext4Helper.Locators.ext4Button("Submit"));
+        clickAndWait(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+        clickAndWait(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
+    }
+
+    public void resubmitWithoutPxd()
+    {
+        clickContinueWithoutPxId();
+        waitForText("Resubmit Request to ");
+        click(Ext4Helper.Locators.ext4Button(("Resubmit")));
+        waitForText("Confirm resubmission request to");
+        click(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+        waitForText("Request resubmitted to");
+        click(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
+    }
+
+    private void clickContinueWithoutPxId()
+    {
+        // Expect to be on the missing information page
+        assertTextPresent("Missing Information in Submission Request");
+        clickAndWait(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
     }
 
     @Override
@@ -257,6 +398,11 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         // these tests use the UIContainerHelper for project creation, but we can use the APIContainerHelper for deletion
         APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
         apiContainerHelper.deleteProject(PANORAMA_PUBLIC, afterTest);
+
+        _userHelper.deleteUsers(false,ADMIN_USER, SUBMITTER, SUBMITTER_2,
+                // Delete the two reviewer accounts created when experiments are copied to the Panorama Public project
+                REVIEWER_PREFIX + "@proteinms.net",
+                REVIEWER_PREFIX + "1@proteinms.net");
 
         super.doCleanup(afterTest);
     }
@@ -274,7 +420,7 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
 
         public TargetedMsExperimentWebPart(BaseWebDriverTest test, int index)
         {
-            super(test.getDriver(), DEFAULT_TITLE, 0);
+            super(test.getDriver(), DEFAULT_TITLE, index);
             _test = test;
         }
 
@@ -285,20 +431,10 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
             return _dataRegionTable;
         }
 
-        public PanoramaPublicTest.TargetedMsExperimentInsertPage startInsert()
+        public TargetedMsExperimentInsertPage startInsert()
         {
             findElement(Locator.linkContainingText("Create New Experiment")).click();
-            return new PanoramaPublicTest.TargetedMsExperimentInsertPage(_test.getDriver());
-        }
-
-        public void submitWithoutPXId()
-        {
-            findElement(Locator.linkContainingText("Submit")).click();
-            waitAndClick(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
-            getWrapper()._ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PANORAMA_PUBLIC);
-            waitAndClick(Ext4Helper.Locators.ext4Button("Submit"));
-            waitAndClick(Locator.lkButton("OK")); // Confirm to proceed with the submission.
-            waitAndClick(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
+            return new TargetedMsExperimentInsertPage(_test.getDriver());
         }
 
         public void clickSubmit()
@@ -306,25 +442,17 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
             clickAndWait(Locator.linkContainingText("Submit"));
         }
 
-        public void resubmitWithoutPxd()
+        public void clickResubmit()
         {
             Locator.XPathLocator resubmitLink = Locator.linkContainingText("Resubmit");
             assertNotNull("Expected to see a \"Resubmit\" button", resubmitLink);
             clickAndWait(resubmitLink);
-            waitAndClick(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
-            waitForText("Resubmit Request to ");
-            click(Ext4Helper.Locators.ext4Button(("Resubmit")));
-            waitForText("Confirm resubmission request to");
-            click(Locator.lkButton("OK")); // Confirm to proceed with the submission.
-            waitForText("Request resubmitted to");
-            click(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
         }
     }
 
-    private class TargetedMsExperimentInsertPage extends InsertPage
+    private static class TargetedMsExperimentInsertPage extends InsertPage
     {
         private static final String DEFAULT_TITLE = "Targeted MS Experiment";
-        public static final String EXP_TITLE = "This is a test experiment";
 
         public TargetedMsExperimentInsertPage(WebDriver driver)
         {
@@ -337,10 +465,10 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
             waitForElement(elements().expTitle);
         }
 
-        public void insert()
+        public void insert(String experimentTitle)
         {
             Elements elements = elements();
-            setFormElement(elements.expTitle, EXP_TITLE);
+            setFormElement(elements.expTitle, experimentTitle);
             setFormElement(elements.expAbstract, "This is a really short, 50 character long abstract");
             clickAndWait(elements.submit);
         }


### PR DESCRIPTION
#### Rationale
It is possible for a user to configure an experiment submitted to Panorama Public to include subfolders. However, the option is hard to find, and it is not obvious to the user if subfolders will be included in the copy made to Panorama Public. If there are subfolders, we want the user to confirm that they want to include (or exclude) them when they submit an experiment copy request to Panorama Public

#### Changes
- When a user submits a request to Panorama Public, and the experiment is not configured to include subfolders, then the user will be presented options to either include subfolders or submit just the folder without subfolders
- Submitting user is required to have read permissions in all subfolders if they want to include them in the submission request.
- look for ReadPermission instead of InsertPermission when including subfolders in the experiment.
- Update the SecurityPolicy on the ShortURL if the user resubmitting an experiment is different from the one who originally submitted it
