### PR TITLE
Dependency version update for 21.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /hidra
 /hidra_uw_intake
+*/resources/credits/dependencies.txt
+*/resources/credits/jars.txt

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-moduleContainer=:server:modules:maccossLabModules
+moduleContainer=:server:modules:MacCossLabModules

--- a/lincs/build.gradle
+++ b/lincs/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.ExternalDependency;
 
 plugins {
     id 'org.labkey.build.module'
@@ -10,7 +11,19 @@ dependencies {
                 // exclude this because it gets in the way of our own JSON object implementations from server/api
                 exclude group: "org.json", module:"json"
             }
-    external "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
+
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.apache.httpcomponents:httpmime:${httpmimeVersion}",
+                    "Apache HTTP Mime",
+                    "Apache",
+                    "http://hc.apache.org/httpcomponents-client-ga",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "HTTP client for requests of remote servers"
+            )
+    )
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:targetedms", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/panoramapublic/build.gradle
+++ b/panoramapublic/build.gradle
@@ -1,4 +1,5 @@
 import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.ExternalDependency;
 
 plugins {
     id 'org.labkey.build.module'
@@ -6,7 +7,18 @@ plugins {
 
 dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
-    external "org.apache.httpcomponents:httpmime:${httpmimeVersion}"
+    BuildUtils.addExternalDependency(
+            project,
+            new ExternalDependency(
+                    "org.apache.httpcomponents:httpmime:${httpmimeVersion}",
+                    "Apache HTTP Mime",
+                    "Apache",
+                    "http://hc.apache.org/httpcomponents-client-ga",
+                    ExternalDependency.APACHE_2_LICENSE_NAME,
+                    ExternalDependency.APACHE_2_LICENSE_URL,
+                    "HTTP client for requests of remote servers"
+            )
+    )
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "published", depExtension: "module")

--- a/panoramapublic/resources/credits/jars.txt
+++ b/panoramapublic/resources/credits/jars.txt
@@ -1,4 +1,0 @@
-{table}
-Filename|Component|Version|Source|License|LabKey Dev|Purpose
-httpmime-4.5.3.jar|Apache HTTP Mime|4.5.3|{link:Apache|http://hc.apache.org/httpcomponents-client-ga}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|adam|HTTP client for requests of remote servers
-{table}

--- a/testresults/build.gradle
+++ b/testresults/build.gradle
@@ -1,7 +1,19 @@
+import org.labkey.gradle.util.BuildUtils
+import org.labkey.gradle.util.ExternalDependency
+
 plugins {
     id 'org.labkey.build.module'
 }
 
-dependencies {
-    external "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}"
-}
+BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+                "commons-fileupload:commons-fileupload:${commonsFileuploadVersion}",
+                "Commons File Upload",
+                "Apache",
+                "http://jakarta.apache.org/commons/fileupload/",
+                ExternalDependency.APACHE_2_LICENSE_NAME,
+                ExternalDependency.APACHE_2_LICENSE_URL,
+                "Parses HTTP multipart/form-data POSTs"
+        )
+)

--- a/testresults/resources/credits/jars.txt
+++ b/testresults/resources/credits/jars.txt
@@ -1,4 +1,4 @@
 {table}
-Filename|Component|Version|Source|License|Purpose
-commons-fileupload-1.3.1.jar|Commons File Upload|1.3.1|{link:Apache|http://jakarta.apache.org/commons/fileupload/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Parses HTTP multipart/form-data POSTs
+Filename|Component|Source|License|Purpose
+commons-fileupload-1.4.jar|Commons File Upload|{link:Apache|http://jakarta.apache.org/commons/fileupload/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Parses HTTP multipart/form-data POSTs
 {table}

--- a/testresults/resources/credits/jars.txt
+++ b/testresults/resources/credits/jars.txt
@@ -1,4 +1,0 @@
-{table}
-Filename|Component|Source|License|Purpose
-commons-fileupload-1.4.jar|Commons File Upload|{link:Apache|http://jakarta.apache.org/commons/fileupload/}|{link:Apache 2.0|http://www.apache.org/licenses/LICENSE-2.0}|Parses HTTP multipart/form-data POSTs
-{table}


### PR DESCRIPTION
#### Rationale
Keeping dependency versions updated.  We also take this opportunity to transition some of the modules to use the new `BuildUtils.addExternalDependency` method that provides the information to be used in populating the `jars.txt` file so we can remove it from and ignore it in git.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2352

#### Changes
* Use `BuildUtils.addExternalDependency`, bringing in version updates.