### PR TITLE
Call Container.hasPermission()

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
@@ -501,7 +501,7 @@ public class ExperimentAnnotations
     public boolean isPublic()
     {
         // If the container where this experiment lives is readable to site:guests then the data is public.
-        return getContainer().getPolicy().hasPermissions(SecurityManager.getGroup(Group.groupGuests), ReadPermission.class);
+        return getContainer().hasPermission(SecurityManager.getGroup(Group.groupGuests), ReadPermission.class);
     }
 
     public DataLicense getDataLicense()

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
@@ -269,7 +269,7 @@ public class JournalManager
             // If the user is not the one that created this shortUrl (e.g. the experiment is being resubmitted by a different lab member)
             // then we need to add this user as an editor to the record's SecurityPolicy.
             MutableSecurityPolicy policy = new MutableSecurityPolicy(SecurityPolicyManager.getPolicy(shortAccessUrlRecord));
-            if (!policy.hasPermission(user, UpdatePermission.class))
+            if (!policy.getOwnPermissions(user).contains(UpdatePermission.class))
             {
                 policy.addRoleAssignment(user, EditorRole.class);
                 SecurityPolicyManager.savePolicy(policy);
@@ -345,7 +345,7 @@ public class JournalManager
     private static void addPermission(Container folder, UserPrincipal journalGroup)
     {
         SecurityPolicy oldPolicy = folder.getPolicy();
-        if(oldPolicy.hasPermission(journalGroup, FolderExportPermission.class))
+        if (oldPolicy.getOwnPermissions(journalGroup).contains(FolderExportPermission.class))
             return;
         MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(folder, oldPolicy);
 
@@ -380,7 +380,7 @@ public class JournalManager
     private static void removePermission(Container folder, UserPrincipal journalGroup)
     {
         SecurityPolicy oldPolicy = folder.getPolicy();
-        if(!oldPolicy.hasPermission(journalGroup, FolderExportPermission.class))
+        if (!oldPolicy.getOwnPermissions(journalGroup).contains(FolderExportPermission.class))
             return;
         List<Role> roles = oldPolicy.getAssignedRoles(journalGroup);
 


### PR DESCRIPTION
#### Rationale
Create new permission check choke-point.  Replace/unify Container.hasPermission() and SecurityPolicy.hasPermission()
* SecurityManager.hasAllPermissions()
* SecurityManager.hasAnyPermissions()
* SecurityManager.getPermissions()
* SecurityManager.getPermissionNames()

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/118
* https://github.com/LabKey/ehrModules/pull/195
* https://github.com/LabKey/snd/pull/97
* https://github.com/LabKey/platform/pull/2359
* https://github.com/LabKey/MacCossLabModules/pull/122
* https://github.com/LabKey/wnprc-modules/pull/86

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->