### PR TITLE
Issue 43508: Improve visibility of which user ID enabled which ETLs

### DIFF
--- a/signup/src/org/labkey/signup/SignUpListener.java
+++ b/signup/src/org/labkey/signup/SignUpListener.java
@@ -47,24 +47,6 @@ public class SignUpListener implements ContainerListener, UserManager.UserListen
     }
 
     @Override
-    public void userAddedToSite(User user)
-    {
-        // Do nothing
-    }
-
-    @Override
-    public void userAccountDisabled(User user)
-    {
-        // Do nothing.
-    }
-
-    @Override
-    public void userAccountEnabled(User user)
-    {
-        // Do nothing
-    }
-
-    @Override
     public void containerCreated(Container c, User user)
     {
     }


### PR DESCRIPTION
#### Rationale
Eliminate need to implement no-op methods in UserListener via a default implementation

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2490

#### Changes
* Delete no-op methods