### PR TITLE
Issue 43639: Avoid outputting date directly in JSP via toString()

### DIFF
--- a/testresults/src/org/labkey/testresults/view/flagged.jsp
+++ b/testresults/src/org/labkey/testresults/view/flagged.jsp
@@ -31,7 +31,7 @@
             Collections.reverse(Arrays.asList(runs));
             for(RunDetail run: runs) {%>
         <tr>
-            <td><a href="<%=h(urlFor(ShowRunAction.class).addParameter("runId", run.getId()))%>">  id: <%=run.getId()%> / <%=run.getUserid()%> / <%=run.getPostTime()%></a></td>
+            <td><a href="<%=h(urlFor(ShowRunAction.class).addParameter("runId", run.getId()))%>">  id: <%=run.getId()%> / <%=run.getUserid()%> / <%=formatDateTime(run.getPostTime())%></a></td>
         </tr>
         <%}%>
     </table>

--- a/testresults/src/org/labkey/testresults/view/multiFailureDetail.jsp
+++ b/testresults/src/org/labkey/testresults/view/multiFailureDetail.jsp
@@ -112,7 +112,7 @@
                 <%=h(run.getUserName())%> <br />
                 Duration: <%=run.getDuration()%> <br />
                 OS: <%=h(run.getOs())%> <br />
-                Post Time: <%=run.getPostTime()%> <br />
+                Post Time: <%=formatDateTime(run.getPostTime())%> <br />
                 Rev: <%=run.getRevision()%> <br />
                 Run Failures: <%=run.getFailures().length%>
                 </a></p>


### PR DESCRIPTION
#### Rationale
We've gotten stricter about HTML encoding in JSPs

#### Changes
* Use explicit formatting call for Date instead of relying on toString()