### PR TITLE
Issue 42942: Support chromatogram libraries in Panorama Public

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -112,6 +112,7 @@ import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.*;
 import org.labkey.api.view.template.ClientDependency;
+import org.labkey.panoramapublic.chromlib.ChromLibStateManager;
 import org.labkey.panoramapublic.datacite.DataCiteException;
 import org.labkey.panoramapublic.datacite.DataCiteService;
 import org.labkey.panoramapublic.datacite.Doi;
@@ -1501,11 +1502,21 @@ public class PanoramaPublicController extends SpringActionController
 
             if (!form.isDataValidated())
             {
-                // Cannot publish if this is not an "Experimental data" folder.
+                // Cannot publish if this is not an "Experimental data"  or Library folder.
                 TargetedMSService.FolderType folderType = TargetedMSService.get().getFolderType(_experimentAnnotations.getContainer());
                 if (!isSupportedFolderType(folderType))
                 {
-                    errors.reject(ERROR_MSG, "Targeted MS folders of type \"" + folderType + "\" cannot be submitted to " + _journal.getName() + ".");
+                    errors.reject(ERROR_MSG, "Targeted MS folders of type \"" + folderType + "\" cannot be submitted.");
+                    return new SimpleErrorView(errors);
+                }
+                
+                // Do not allow submitting a library folder with conflicts.  This check is also done on any library sub-folders
+                // if the experiment is configured to include subfolders.
+                Container libraryFolderWithConflicts = getLibraryFolderWithConflicts(getUser(), _experimentAnnotations);
+                if(libraryFolderWithConflicts != null)
+                {
+                    errors.reject(ERROR_MSG, String.format("The chromatogram library folder '%s' has conflicts. Please resolve the conflicts before submitting.",
+                            libraryFolderWithConflicts.getName()));
                     return new SimpleErrorView(errors);
                 }
 
@@ -1549,6 +1560,23 @@ public class PanoramaPublicController extends SpringActionController
             {
                 return getPublishFormView(form, _experimentAnnotations, errors);
             }
+        }
+
+        private Container getLibraryFolderWithConflicts(User user, ExperimentAnnotations exptAnnotations)
+        {
+            List<Container> containers = exptAnnotations.isIncludeSubfolders() ?
+                    ContainerManager.getAllChildren(exptAnnotations.getContainer(), user)
+                    : Collections.singletonList(exptAnnotations.getContainer());
+
+            for(Container container: containers)
+            {
+                TargetedMSService.FolderType folderType = TargetedMSService.get().getFolderType(container);
+                if(isLibraryFolder(folderType) && ChromLibStateManager.getConflictCount(user, container, folderType) > 0)
+                {
+                    return container;
+                }
+            }
+            return null;
         }
 
         private HtmlView getConfirmIncludeSubfoldersView(ExperimentAnnotations expAnnotations, List<Container> allSubfolders, ActionURL skipSubfolderCheckUrl)

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -160,6 +160,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.*;
 import static org.labkey.api.util.DOM.Attribute.action;
 import static org.labkey.api.util.DOM.Attribute.method;
 import static org.labkey.api.util.DOM.Attribute.name;
@@ -343,7 +344,7 @@ public class PanoramaPublicController extends SpringActionController
                 // Make this an "Experiment data" folder.
                 Module targetedMSModule = ModuleLoader.getInstance().getModule(TargetedMSService.MODULE_NAME);
                 ModuleProperty moduleProperty = targetedMSModule.getModuleProperties().get(TargetedMSService.FOLDER_TYPE_PROP_NAME);
-                moduleProperty.saveValue(getUser(), container, TargetedMSService.FolderType.Experiment.toString());
+                moduleProperty.saveValue(getUser(), container, Experiment.toString());
                 // Display only the "Targeted MS Experiment List" webpart.
                 Portal.WebPart webPart = Portal.getPortalPart(TargetedMSExperimentsWebPart.WEB_PART_NAME).createWebPart();
                 List<Portal.WebPart> newWebParts = Collections.singletonList(webPart);
@@ -1502,9 +1503,9 @@ public class PanoramaPublicController extends SpringActionController
             {
                 // Cannot publish if this is not an "Experimental data" folder.
                 TargetedMSService.FolderType folderType = TargetedMSService.get().getFolderType(_experimentAnnotations.getContainer());
-                if (folderType != TargetedMSService.FolderType.Experiment)
+                if (!isSupportedFolderType(folderType))
                 {
-                    errors.reject(ERROR_MSG, "Only Targeted MS folders of type \"Experimental data\" can be submitted to " + _journal.getName() + ".");
+                    errors.reject(ERROR_MSG, "Targeted MS folders of type \"" + folderType + "\" cannot be submitted to " + _journal.getName() + ".");
                     return new SimpleErrorView(errors);
                 }
 
@@ -4132,7 +4133,7 @@ public class PanoramaPublicController extends SpringActionController
 
             Container c = _experimentAnnotations.getContainer();
             TargetedMSService.FolderType folderType = TargetedMSService.get().getFolderType(c);
-            if(folderType == TargetedMSService.FolderType.Experiment)
+            if(isSupportedFolderType(folderType))
             {
                 _lastPublishedRecord = JournalManager.getLastPublishedRecord(_experimentAnnotations.getId());
 
@@ -4182,6 +4183,16 @@ public class PanoramaPublicController extends SpringActionController
         {
             _lastPublishedRecord = lastPublishedRecord;
         }
+    }
+
+    private static boolean isSupportedFolderType(TargetedMSService.FolderType folderType)
+    {
+        return folderType == Experiment || isLibraryFolder(folderType);
+    }
+
+    private static boolean isLibraryFolder(TargetedMSService.FolderType folderType)
+    {
+        return folderType == Library || folderType == LibraryProtein;
     }
 
     public static class ViewExperimentAnnotationsForm

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
@@ -19,11 +19,7 @@ package org.labkey.panoramapublic;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.module.Module;
-import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.module.ModuleProperty;
 import org.labkey.api.portal.ProjectUrls;
-import org.labkey.api.security.User;
 import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.PageFlowUtil;
@@ -76,15 +72,5 @@ public class PanoramaPublicManager
     public static ActionURL getRawDataTabUrl(Container container)
     {
         return PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(container, TargetedMSService.RAW_FILES_TAB);
-    }
-
-    public static void makePanoramaExperimentalDataFolder(Container container, User user)
-    {
-        Module targetedMSModule = ModuleLoader.getInstance().getModule(TargetedMSService.MODULE_NAME);
-        ModuleProperty moduleProperty = targetedMSModule.getModuleProperties().get(TargetedMSService.FOLDER_TYPE_PROP_NAME);
-        if(container.getActiveModules().contains(targetedMSModule))
-        {
-            moduleProperty.saveValue(user, container, TargetedMSService.FolderType.Experiment.toString());
-        }
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateException.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateException.java
@@ -1,0 +1,19 @@
+package org.labkey.panoramapublic.chromlib;
+
+public class ChromLibStateException extends Exception
+{
+    public ChromLibStateException(String message)
+    {
+        super(message);
+    }
+
+    public ChromLibStateException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public ChromLibStateException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
@@ -64,9 +64,9 @@ public abstract class ChromLibStateExporter
                 if(run.getRepresentativeDataState() == RunRepresentativeDataState.NotRepresentative)
                 {
                     _log.info(String.format("'%s' does not contain any library %ss. Ignoring.", run.getFileName(), libTypeString()));
-                    continue; // TODO: Check if this is OK
+                    continue;
                 }
-                _log.info(String.format("Exporting library state of %s in '%s'.", libTypeString(), run.getFileName()));
+                _log.info(String.format("Exporting library state of %ss in '%s'.", libTypeString(), run.getFileName()));
                 exportLibStateForRun(run, svc, _log, writer, container, user);
             }
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
@@ -1,0 +1,191 @@
+package org.labkey.panoramapublic.chromlib;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
+import org.labkey.api.targetedms.ITargetedMSRun;
+import org.labkey.api.targetedms.RunRepresentativeDataState;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.api.writer.PrintWriters;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class ChromLibStateExporter
+{
+    private final Logger _log;
+    private static final String TAB = "\t";
+
+    public ChromLibStateExporter(Logger log)
+    {
+        _log = log;
+    }
+
+    abstract String libTypeString();
+    abstract List<String> headers();
+    abstract void exportLibStateForRun(ITargetedMSRun run, TargetedMSService svc, Logger log, PrintWriter writer, Container container, User user);
+
+    public static void exportLibState(@NotNull File file, @NotNull Container container, User user, Logger log) throws ChromLibStateException
+    {
+        TargetedMSService svc = TargetedMSService.get();
+        TargetedMSService.FolderType folderType = svc.getFolderType(container);
+        if(TargetedMSService.FolderType.LibraryProtein.equals(folderType))
+        {
+            new ProteinLibStateExporter(log).exportLibraryState(container, file, user, svc);
+        }
+        else if (TargetedMSService.FolderType.Library.equals(folderType))
+        {
+            new PeptideLibStateExporter(log).exportLibraryState(container, file, user, svc);
+        }
+        else
+        {
+            throw new ChromLibStateException(String.format("'%s' is not a chromatogram library folder.", container));
+        }
+    }
+
+    void exportLibraryState(Container container, File file, User user, TargetedMSService svc) throws ChromLibStateException
+    {
+        _log.info(String.format("Exporting %s library state in container '%s' to file '%s'.", libTypeString(), container.getPath(), file.getPath()));
+
+        try(PrintWriter writer = PrintWriters.getPrintWriter(file))
+        {
+            writer.write(StringUtils.join(headers(), TAB)); // Header row
+            writer.println();
+
+            // Get a list of runs in the folder
+            List<ITargetedMSRun> runs = svc.getRuns(container);
+            for (ITargetedMSRun run : runs)
+            {
+                if(run.getRepresentativeDataState() == RunRepresentativeDataState.NotRepresentative)
+                {
+                    _log.info(String.format("'%s' does not contain any library %ss. Ignoring.", run.getFileName(), libTypeString()));
+                    continue; // TODO: Check if this is OK
+                }
+                _log.info(String.format("Exporting library state of %s in '%s'.", libTypeString(), run.getFileName()));
+                exportLibStateForRun(run, svc, _log, writer, container, user);
+            }
+        }
+        catch (FileNotFoundException e)
+        {
+            throw new ChromLibStateException(e);
+        }
+        _log.info("Done exporting library state.");
+    }
+
+    private static class ProteinLibStateExporter extends ChromLibStateExporter
+    {
+        public ProteinLibStateExporter(Logger log)
+        {
+            super(log);
+        }
+
+        @Override
+        String libTypeString()
+        {
+            return "protein";
+        }
+
+        @Override
+        List<String> headers()
+        {
+            return ChromLibStateManager.PROTEIN_LIB_HEADERS;
+        }
+
+        @Override
+        void exportLibStateForRun(ITargetedMSRun run, TargetedMSService svc, Logger log, PrintWriter writer, Container container, User user)
+        {
+            // For each run get a list of peptide groups
+            List<LibPeptideGroup> peptideGroups = ChromLibStateManager.getPeptideGroups(run, svc);
+            log.info(String.format("Found %d peptide groups.", peptideGroups.size()));
+            for (LibPeptideGroup pepGrp : peptideGroups)
+            {
+                // For each run / peptide group write the representative state
+                // - run, run_state
+                // - peptidegroup_label, peptidegroup_sequenceid, peptidegroup_state
+                List<String> values = List.of(run.getFileName(), run.getRepresentativeDataState().toString(),
+                        pepGrp.getLabel(), (pepGrp.getSequenceId() == null ? "" : String.valueOf(pepGrp.getSequenceId())),
+                        pepGrp.getRepresentativeDataState().toString());
+                writer.write(StringUtils.join(values, TAB));
+                writer.println();
+            }
+        }
+    }
+
+    private static class PeptideLibStateExporter extends ChromLibStateExporter
+    {
+        public PeptideLibStateExporter(Logger log)
+        {
+            super(log);
+        }
+
+        @Override
+        String libTypeString()
+        {
+            return "peptide";
+        }
+
+        @Override
+        List<String> headers()
+        {
+            return ChromLibStateManager.PEP_LIB_HEADERS;
+        }
+
+        @Override
+        void exportLibStateForRun(ITargetedMSRun run, TargetedMSService svc, Logger log, PrintWriter writer, Container container, User user)
+        {
+            // For each run get a list of peptide groups
+            List<LibPeptideGroup> peptideGroups = ChromLibStateManager.getPeptideGroups(run, svc);
+            for (LibPeptideGroup pepGrp : peptideGroups)
+            {
+                // For each peptide group get a list of precursors
+                List<LibPrecursor> precursors = ChromLibStateManager.getPrecursors(pepGrp, container, user, svc);
+                for(LibPrecursor precursor: precursors)
+                {
+                    writePeptideLibRow(writer, run, pepGrp, precursor);
+                }
+                // For each peptide group get a list of molecule precursors
+                List<LibMoleculePrecursor> moleculePrecursors = ChromLibStateManager.getMoleculePrecursors(pepGrp, container, user, svc);
+                for(LibMoleculePrecursor precursor: moleculePrecursors)
+                {
+                    writePeptideLibRow(writer, run, pepGrp, precursor);
+                }
+            }
+        }
+
+        private void writePeptideLibRow(PrintWriter writer, ITargetedMSRun run, LibPeptideGroup pepGrp, LibGeneralPrecursor precursor)
+        {
+            // For each run / peptide group / precursor write the representative state
+            // - run, run_state
+            // - peptidegroup_label, peptidegroup_sequenceid
+            // - precursor_mz, precursor_charge, precursor_state
+            // - precursor_modified_sequence (for Precursors; empty for MoleculePrecursors)
+            // - mol_precursor_custom_ion_name, mol_precursor_ion_formula, mol_precursor_mass_monoisotopic, mol_precursor_mass_average (for MoleculePrecursors; empty for Precursors)
+            var values = new ArrayList<>(List.of(run.getFileName(), run.getRepresentativeDataState().toString(),
+                    pepGrp.getLabel(), (pepGrp.getSequenceId() == null ? "" : String.valueOf(pepGrp.getSequenceId())), pepGrp.getRepresentativeDataState().toString(),
+                    String.valueOf(precursor.getMz()), String.valueOf(precursor.getCharge()), precursor.getRepresentativeDataState().toString()));
+            if(precursor instanceof LibPrecursor)
+            {
+                values.add(((LibPrecursor) precursor).getModifiedSequence());
+                values.add(""); // custom ion name (only for molecule precursors)
+                values.add(""); // ion formula (only for molecule precursors)
+                values.add(""); // mass monoisotopic (only for molecule precursors)
+                values.add(""); // mass averate (only for molecule precursors)
+            }
+            else if(precursor instanceof LibMoleculePrecursor)
+            {
+                values.add(""); // modified sequence (only for proteomic precursors)
+                values.add(((LibMoleculePrecursor) precursor).getCustomIonName());
+                values.add(((LibMoleculePrecursor) precursor).getIonFormula());
+                values.add(String.valueOf(((LibMoleculePrecursor) precursor).getMassMonoisotopic()));
+                values.add(String.valueOf(((LibMoleculePrecursor) precursor).getMassAverage()));
+            }
+            writer.write(StringUtils.join(values, TAB));
+            writer.println();
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
@@ -34,7 +34,7 @@ public abstract class ChromLibStateExporter
     {
         TargetedMSService svc = TargetedMSService.get();
         TargetedMSService.FolderType folderType = svc.getFolderType(container);
-        if(TargetedMSService.FolderType.LibraryProtein.equals(folderType))
+        if (TargetedMSService.FolderType.LibraryProtein.equals(folderType))
         {
             new ProteinLibStateExporter(log).exportLibraryState(container, file, user, svc);
         }
@@ -61,7 +61,7 @@ public abstract class ChromLibStateExporter
             List<ITargetedMSRun> runs = svc.getRuns(container);
             for (ITargetedMSRun run : runs)
             {
-                if(run.getRepresentativeDataState() == RunRepresentativeDataState.NotRepresentative)
+                if (run.getRepresentativeDataState() == RunRepresentativeDataState.NotRepresentative)
                 {
                     _log.info(String.format("'%s' does not contain any library %ss. Ignoring.", run.getFileName(), libTypeString()));
                     continue;
@@ -144,13 +144,13 @@ public abstract class ChromLibStateExporter
             {
                 // For each peptide group get a list of precursors
                 List<LibPrecursor> precursors = ChromLibStateManager.getPrecursors(pepGrp, container, user, svc);
-                for(LibPrecursor precursor: precursors)
+                for (LibPrecursor precursor: precursors)
                 {
                     writePeptideLibRow(writer, run, pepGrp, precursor);
                 }
                 // For each peptide group get a list of molecule precursors
                 List<LibMoleculePrecursor> moleculePrecursors = ChromLibStateManager.getMoleculePrecursors(pepGrp, container, user, svc);
-                for(LibMoleculePrecursor precursor: moleculePrecursors)
+                for (LibMoleculePrecursor precursor: moleculePrecursors)
                 {
                     writePeptideLibRow(writer, run, pepGrp, precursor);
                 }
@@ -168,7 +168,7 @@ public abstract class ChromLibStateExporter
             var values = new ArrayList<>(List.of(run.getFileName(), run.getRepresentativeDataState().toString(),
                     pepGrp.getLabel(), (pepGrp.getSequenceId() == null ? "" : String.valueOf(pepGrp.getSequenceId())), pepGrp.getRepresentativeDataState().toString(),
                     String.valueOf(precursor.getMz()), String.valueOf(precursor.getCharge()), precursor.getRepresentativeDataState().toString()));
-            if(precursor instanceof LibPrecursor)
+            if (precursor instanceof LibPrecursor)
             {
                 values.add(((LibPrecursor) precursor).getModifiedSequence());
                 values.add(""); // custom ion name (only for molecule precursors)
@@ -176,7 +176,7 @@ public abstract class ChromLibStateExporter
                 values.add(""); // mass monoisotopic (only for molecule precursors)
                 values.add(""); // mass averate (only for molecule precursors)
             }
-            else if(precursor instanceof LibMoleculePrecursor)
+            else if (precursor instanceof LibMoleculePrecursor)
             {
                 values.add(""); // modified sequence (only for proteomic precursors)
                 values.add(((LibMoleculePrecursor) precursor).getCustomIonName());

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
@@ -34,17 +34,11 @@ public abstract class ChromLibStateExporter
     {
         TargetedMSService svc = TargetedMSService.get();
         TargetedMSService.FolderType folderType = svc.getFolderType(container);
-        if (TargetedMSService.FolderType.LibraryProtein.equals(folderType))
+        switch (folderType)
         {
-            new ProteinLibStateExporter(log).exportLibraryState(container, file, user, svc);
-        }
-        else if (TargetedMSService.FolderType.Library.equals(folderType))
-        {
-            new PeptideLibStateExporter(log).exportLibraryState(container, file, user, svc);
-        }
-        else
-        {
-            throw new ChromLibStateException(String.format("'%s' is not a chromatogram library folder.", container));
+            case LibraryProtein -> new ProteinLibStateExporter(log).exportLibraryState(container, file, user, svc);
+            case Library -> new PeptideLibStateExporter(log).exportLibraryState(container, file, user, svc);
+            default -> throw new ChromLibStateException(String.format("'%s' is not a chromatogram library folder.", container));
         }
     }
 
@@ -174,7 +168,7 @@ public abstract class ChromLibStateExporter
                 values.add(""); // custom ion name (only for molecule precursors)
                 values.add(""); // ion formula (only for molecule precursors)
                 values.add(""); // mass monoisotopic (only for molecule precursors)
-                values.add(""); // mass averate (only for molecule precursors)
+                values.add(""); // mass average (only for molecule precursors)
             }
             else if (precursor instanceof LibMoleculePrecursor)
             {

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateExporter.java
@@ -1,7 +1,7 @@
 package org.labkey.panoramapublic.chromlib;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.security.User;
@@ -93,7 +93,7 @@ public abstract class ChromLibStateExporter
         @Override
         List<String> headers()
         {
-            return ChromLibStateManager.PROTEIN_LIB_HEADERS;
+            return ChromLibStateManager.PROTEIN_LIB_COLS;
         }
 
         @Override
@@ -132,7 +132,7 @@ public abstract class ChromLibStateExporter
         @Override
         List<String> headers()
         {
-            return ChromLibStateManager.PEP_LIB_HEADERS;
+            return ChromLibStateManager.PEP_LIB_COLS;
         }
 
         @Override
@@ -161,7 +161,7 @@ public abstract class ChromLibStateExporter
         {
             // For each run / peptide group / precursor write the representative state
             // - run, run_state
-            // - peptidegroup_label, peptidegroup_sequenceid
+            // - peptidegroup_label, peptidegroup_sequenceid, peptidegroup_state
             // - precursor_mz, precursor_charge, precursor_state
             // - precursor_modified_sequence (for Precursors; empty for MoleculePrecursors)
             // - mol_precursor_custom_ion_name, mol_precursor_ion_formula, mol_precursor_mass_monoisotopic, mol_precursor_mass_average (for MoleculePrecursors; empty for Precursors)

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateImporter.java
@@ -60,17 +60,11 @@ public abstract class ChromLibStateImporter
     {
         TargetedMSService svc = TargetedMSService.get();
         TargetedMSService.FolderType folderType = svc.getFolderType(container);
-        if (TargetedMSService.FolderType.LibraryProtein.equals(folderType))
+        switch (folderType)
         {
-            new ProteinLibStateImporter(container, user, log, svc).importFromFile(libStateFile);
-        }
-        else if (TargetedMSService.FolderType.Library.equals(folderType))
-        {
-            new PeptideLibStateImporter(container, user, log, svc).importFromFile(libStateFile);
-        }
-        else
-        {
-            throw new ChromLibStateException(String.format("'%s' is not a chromatogram library folder.", container));
+            case LibraryProtein -> new ProteinLibStateImporter(container, user, log, svc).importFromFile(libStateFile);
+            case Library -> new PeptideLibStateImporter(container, user, log, svc).importFromFile(libStateFile);
+            default -> throw new ChromLibStateException(String.format("'%s' is not a chromatogram library folder.", container));
         }
     }
 
@@ -107,13 +101,13 @@ public abstract class ChromLibStateImporter
         _log.info("Done importing library state.");
     }
 
-    private void verifyLibColumns(ColumnDescriptor[] columns, List<String> expectedColulmns) throws ChromLibStateException
+    private void verifyLibColumns(ColumnDescriptor[] columns, List<String> expectedColumns) throws ChromLibStateException
     {
         var columnsInFile = Arrays.stream(columns).map(c -> c.name).collect(Collectors.toSet());
-        if (!columnsInFile.containsAll(expectedColulmns))
+        if (!columnsInFile.containsAll(expectedColumns))
         {
             throw new ChromLibStateException(String.format("Required column headers not found. Expected columns: %s.  Found columns: %s",
-                    StringUtils.join(expectedColulmns, ","), StringUtils.join(columnsInFile, ",")));
+                    StringUtils.join(expectedColumns, ","), StringUtils.join(columnsInFile, ",")));
         }
     }
 
@@ -395,8 +389,8 @@ public abstract class ChromLibStateImporter
             Long generalPrecursorId = _precursorKeyMap.get(precursor.getKey());
             if (generalPrecursorId == null)
             {
-                throw new IllegalStateException(String.format("Expected a row for precursor %s in the peptide group %s. Skyline document '%s'. Container '%s'.",
-                        precursor.getKey().toString(), peptideGroup.getLabel(), getSkyFile(row), _container));
+                throw new IllegalStateException(String.format("Expected a row for precursor %s in the peptide group '%s'. Skyline document '%s'. Folder '%s'.",
+                        precursor.getKey().toString(), peptideGroup.getLabel(), getSkyFile(row), _container.getPath()));
             }
             precursor.setId(generalPrecursorId);
 

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateImporter.java
@@ -1,0 +1,295 @@
+package org.labkey.panoramapublic.chromlib;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SqlExecutor;
+import org.labkey.api.data.Table;
+import org.labkey.api.iterator.CloseableIterator;
+import org.labkey.api.reader.ColumnDescriptor;
+import org.labkey.api.reader.TabLoader;
+import org.labkey.api.security.User;
+import org.labkey.api.targetedms.ITargetedMSRun;
+import org.labkey.api.targetedms.RepresentativeDataState;
+import org.labkey.api.targetedms.RunRepresentativeDataState;
+import org.labkey.api.targetedms.TargetedMSService;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PEP_GRP;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PEP_GRP_SEQ_ID;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PEP_GRP_STATE;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PEP_LIB_HEADERS;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_CHARGE;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_MOD_SEQ;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_MOL_CUSTOM_ION_NAME;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_MOL_ION_FORMULA;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_MOL_MASS_AVERAGE;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_MOL_MASS_MONOISOTOPIC;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_MZ;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PREC_STATE;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.PROTEIN_LIB_HEADERS;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.REPRESENTATIVEDATASTATE;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.RUN;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.RUN_STATE;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.getMoleculePrecursors;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.getPeptideGroups;
+import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.getPrecursors;
+
+
+public abstract class ChromLibStateImporter
+{
+    private ITargetedMSRun _currentRun;
+    private Map<LibPeptideGroup.LibPeptideGroupKey, Long> _pepGrpKeyMap;
+    private final Logger _log;
+
+    abstract List<String> getExpectedColumns() throws ChromLibStateException;
+    // abstract void onNewRunSeen(ITargetedMSRun run, TargetedMSService svc);
+
+    public ChromLibStateImporter(Logger log)
+    {
+        _log = log;
+    }
+
+    public static void importLibState(File libStateFile, Container container, User user, Logger log) throws ChromLibStateException
+    {
+        TargetedMSService svc = TargetedMSService.get();
+        TargetedMSService.FolderType folderType = svc.getFolderType(container);
+        if(TargetedMSService.FolderType.LibraryProtein.equals(folderType))
+        {
+            new ProteinLibStateImporter(log).importFromFile(container, user, libStateFile, svc);
+        }
+        else if (TargetedMSService.FolderType.Library.equals(folderType))
+        {
+            new PeptideLibStateImporter(log).importFromFile(container, user, libStateFile, svc);
+        }
+        else
+        {
+            throw new ChromLibStateException(String.format("'%s' is not a chromatogram library folder.", container));
+        }
+    }
+
+    void importFromFile(Container container, User user, File libStateFile, TargetedMSService svc) throws ChromLibStateException
+    {
+        try (TabLoader reader = new TabLoader(libStateFile, true))
+        {
+            CloseableIterator<Map<String, Object>> iterator = reader.iterator();
+            try
+            {
+                // Verify that we have the right column headers
+                verifyLibColumns(reader.getColumns(), getExpectedColumns());
+            }
+            catch (IOException e)
+            {
+                throw new ChromLibStateException(String.format("Error reading header columns from file '%s'.", libStateFile));
+            }
+            while(iterator.hasNext())
+            {
+                parseLibStateRow(iterator.next(), container, user, svc, _log);
+            }
+        }
+    }
+
+    private void verifyLibColumns(ColumnDescriptor[] columns, List<String> expectedColulmns) throws ChromLibStateException
+    {
+        var columnsInFile = Arrays.stream(columns).map(c -> c.name).collect(Collectors.toSet());
+        if(!columnsInFile.containsAll(expectedColulmns))
+        {
+            throw new ChromLibStateException(String.format("Required column headers not found. Expected columns: %s.  Found columns: %s",
+                    StringUtils.join(expectedColulmns, ","), StringUtils.join(columnsInFile, ",")));
+        }
+    }
+
+    void parseLibStateRow(Map<String, Object> row, Container container, User user, TargetedMSService svc, Logger log) throws ChromLibStateException
+    {
+        String skyFile = getSkyFile(row);
+        String runState = String.valueOf(row.get(RUN_STATE));
+        if(_currentRun == null || !StringUtils.equals(skyFile, _currentRun.getFileName()))
+        {
+            ITargetedMSRun run = svc.getRunByFileName(skyFile, container);
+            if(run == null)
+            {
+                throw new ChromLibStateException(String.format("Expected a row for Skyline document '%s' in the container '%s'.", skyFile, container));
+            }
+            _currentRun = run;
+            var map = new HashMap<String, RunRepresentativeDataState>();
+            map.put(REPRESENTATIVEDATASTATE, RunRepresentativeDataState.valueOf(runState));
+            Table.update(null, svc.getTableInfoRuns(), map, _currentRun.getId());
+
+            if(_pepGrpKeyMap != null)
+            {
+                _pepGrpKeyMap.clear();
+            }
+            else
+            {
+                _pepGrpKeyMap = new HashMap<>();
+            }
+
+            List<LibPeptideGroup> dbPepGrps = getPeptideGroups(run, svc);
+            dbPepGrps.forEach(p -> _pepGrpKeyMap.put(p.getKey(), p.getId()));
+        }
+    }
+
+    LibPeptideGroup parsePeptideGroup(Map<String, Object> row, long runId, Container container) throws ChromLibStateException
+    {
+        String peptideGrp = String.valueOf(row.get(PEP_GRP));
+        Integer seqId = null;
+        if(row.get(PEP_GRP_SEQ_ID) != null)
+        {
+            seqId = Integer.parseInt(String.valueOf(row.get(PEP_GRP_SEQ_ID)));
+        }
+        String pepGrpState = String.valueOf(row.get(PEP_GRP_STATE));
+        var pepGrp = new LibPeptideGroup(runId, peptideGrp, seqId, RepresentativeDataState.valueOf(pepGrpState));
+        LibPeptideGroup.LibPeptideGroupKey pepGrpKey = pepGrp.getKey();
+        Long dbId = _pepGrpKeyMap.get(pepGrpKey);
+        if(dbId == null)
+        {
+            throw new ChromLibStateException(String.format("Expected a row for peptide group %s in the Skyline document '%s'. Container '%s'.", pepGrp.getLabel(), getSkyFile(row), container));
+        }
+        pepGrp.setId(dbId);
+        return pepGrp;
+    }
+
+    String getSkyFile(Map<String, Object> row)
+    {
+        return String.valueOf(row.get(RUN));
+    }
+
+    ITargetedMSRun getCurrentRun()
+    {
+        return _currentRun;
+    }
+
+    private static class ProteinLibStateImporter extends ChromLibStateImporter
+    {
+        public ProteinLibStateImporter(Logger log)
+        {
+            super(log);
+        }
+
+        @Override
+        List<String> getExpectedColumns()
+        {
+            return PROTEIN_LIB_HEADERS;
+        }
+
+        @Override
+        void parseLibStateRow(Map<String, Object> row, Container container, User user, TargetedMSService svc, Logger log) throws ChromLibStateException
+        {
+            super.parseLibStateRow(row, container, user, svc, log);
+
+            LibPeptideGroup pepGrp = parsePeptideGroup(row, getCurrentRun().getId(), container);
+            var map = new HashMap<String, RepresentativeDataState>();
+            map.put(REPRESENTATIVEDATASTATE, pepGrp.getRepresentativeDataState());
+            Table.update(null, svc.getTableInfoPeptideGroup(), map, pepGrp.getId());
+            // Set the representative state for all the precursors to be the same as the state of the peptide group
+            updatePrecursorState(pepGrp, container, user, svc, log);
+        }
+
+        private void updatePrecursorState(LibPeptideGroup pepGrp, Container container, User user, TargetedMSService svc, Logger log)
+        {
+        /*
+        UPDATE targetedms.generalprecursor gp
+        SET representativedatastate = ?
+        FROM
+        targetedms.generalmolecule gm
+        INNER JOIN targetedms.peptidegroup pg ON pg.Id = gm.peptideGroupId
+        WHERE gm.Id = gp.generalMoleculeId  AND pg.Id = ?
+         */
+            SQLFragment sql = new SQLFragment(" UPDATE ")
+                    .append(svc.getTableInfoGeneralPrecursor(), "gp")
+                    .append(" SET ").append(REPRESENTATIVEDATASTATE).append(" = ? ").add(pepGrp.getRepresentativeDataState().ordinal())
+                    .append(" FROM ")
+                    .append(svc.getTableInfoGeneralMolecule(), "gm")
+                    .append(" INNER JOIN ")
+                    .append(svc.getTableInfoPeptideGroup(), "pg").append(" ON pg.Id = gm.peptideGroupId ")
+                    .append(" WHERE pg.Id = ?").add(pepGrp.getId())
+                    .append(" AND gm.Id = gp.generalMoleculeId ");
+
+            int updated = new SqlExecutor(svc.getUserSchema(user, container).getDbSchema()).execute(sql);
+            log.debug("UPDATED rows " + updated);
+        }
+    }
+
+    private static class PeptideLibStateImporter extends ProteinLibStateImporter
+    {
+        private LibPeptideGroup _currentPepGrp;
+        private Map<LibGeneralPrecursor.LibPrecursorKey, Long> _precursorKeyMap;
+
+        public PeptideLibStateImporter(Logger log)
+        {
+            super(log);
+        }
+
+        @Override
+        List<String> getExpectedColumns()
+        {
+            return PEP_LIB_HEADERS;
+        }
+
+        @Override
+        void parseLibStateRow(Map<String, Object> row, Container container, User user, TargetedMSService svc, Logger log) throws ChromLibStateException
+        {
+            super.parseLibStateRow(row, container, user, svc, log);
+
+            LibPeptideGroup pepGrp = parsePeptideGroup(row, getCurrentRun().getId(), container);
+            if(_currentPepGrp == null || !_currentPepGrp.getKey().equals(pepGrp.getKey()))
+            {
+                _currentPepGrp = pepGrp;
+
+                if(_precursorKeyMap != null)
+                {
+                    _precursorKeyMap.clear();
+                }
+                else
+                {
+                    _precursorKeyMap = new HashMap<>();
+                }
+
+                List<LibPrecursor> dbPrecursors = getPrecursors(_currentPepGrp, container, user, svc);
+                dbPrecursors.forEach(p -> _precursorKeyMap.put(p.getKey(), p.getId()));
+                List<LibMoleculePrecursor> dbMoleculePrecursors = getMoleculePrecursors(_currentPepGrp, container, user, svc);
+                dbMoleculePrecursors.forEach(p -> _precursorKeyMap.put(p.getKey(), p.getId()));
+            }
+
+            LibGeneralPrecursor precursor = parsePrecursor(row, _currentPepGrp.getId());
+            Long generalPrecursorId = _precursorKeyMap.get(precursor.getKey());
+            if(generalPrecursorId == null)
+            {
+                throw new IllegalStateException(String.format("Expected a row for precursor %s in the peptide group %s. Skyline document '%s'. Container '%s'.",
+                        precursor.getKey().toString(), pepGrp.getLabel(), getSkyFile(row), container));
+            }
+            var map = new HashMap<String, RepresentativeDataState>();
+            map.put(REPRESENTATIVEDATASTATE, precursor.getRepresentativeDataState());
+            Table.update(null, svc.getTableInfoGeneralPrecursor(), map, generalPrecursorId);
+        }
+
+        private LibGeneralPrecursor parsePrecursor(Map<String, Object> row, long peptideGroupId)
+        {
+            double precursorMz = Double.parseDouble(String.valueOf(row.get(PREC_MZ)));
+            int precursorCharge = Integer.parseInt(String.valueOf(row.get(PREC_CHARGE)));
+            String precursorState = String.valueOf(row.get(PREC_STATE));
+            String modifiedSeq = String.valueOf(row.get(PREC_MOD_SEQ));
+            if(!StringUtils.isBlank(modifiedSeq))
+            {
+                return new LibPrecursor(peptideGroupId, precursorMz, precursorCharge, RepresentativeDataState.valueOf(precursorState), modifiedSeq);
+            }
+            else
+            {
+                String customIonName = String.valueOf(row.get(PREC_MOL_CUSTOM_ION_NAME));
+                String ionFormula = String.valueOf(row.get(PREC_MOL_ION_FORMULA));
+                Double massMonoIsotopic = Double.parseDouble(String.valueOf(row.get(PREC_MOL_MASS_MONOISOTOPIC)));
+                Double massAverage = Double.parseDouble(String.valueOf(row.get(PREC_MOL_MASS_AVERAGE)));
+                return new LibMoleculePrecursor(peptideGroupId, precursorMz, precursorCharge, RepresentativeDataState.valueOf(precursorState),
+                        customIonName, ionFormula, massMonoIsotopic, massAverage);
+            }
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
@@ -1,22 +1,30 @@
 package org.labkey.panoramapublic.chromlib;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.targetedms.ITargetedMSRun;
+import org.labkey.api.targetedms.RepresentativeDataState;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.FileUtil;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ChromLibStateManager
 {
@@ -34,12 +42,64 @@ public class ChromLibStateManager
     static final String PREC_MOL_MASS_MONOISOTOPIC = "Precursor_Mol_Mass_Monoisotopic";
     static final String PREC_MOL_MASS_AVERAGE = "Precursor_Mol_Mass_Average";
 
-    static final List<String> PROTEIN_LIB_HEADERS = List.of(RUN, RUN_STATE, PEP_GRP, PEP_GRP_SEQ_ID, PEP_GRP_STATE);
-    static final List<String> PEP_LIB_HEADERS = List.of(RUN, RUN_STATE, PEP_GRP, PEP_GRP_SEQ_ID, PEP_GRP_STATE,
-            PREC_MZ, PREC_CHARGE, PREC_STATE,
-            PREC_MOD_SEQ, PREC_MOL_CUSTOM_ION_NAME, PREC_MOL_ION_FORMULA, PREC_MOL_MASS_MONOISOTOPIC, PREC_MOL_MASS_AVERAGE);
-
     static final String REPRESENTATIVEDATASTATE = "representativedatastate";
+
+    static final StringHeader H_RUN  = new StringHeader(RUN);
+    static final StringHeader H_RUN_STATE  = new StringHeader(RUN_STATE);
+    static final StringHeader H_PEP_GRP = new StringHeader(PEP_GRP);
+    static final IntegerHeader H_PEP_GRP_SEQ_ID = new IntegerHeader(PEP_GRP_SEQ_ID);
+    static final StringHeader H_PEP_GRP_STATE = new StringHeader(PEP_GRP_STATE);
+    static final DoubleHeader H_PREC_MZ = new DoubleHeader(PREC_MZ);
+    static final IntegerHeader H_PREC_CHARGE = new IntegerHeader(PREC_CHARGE);
+    static final StringHeader H_PREC_STATE = new StringHeader(PREC_STATE);
+    static final StringHeader H_PREC_MOD_SEQ = new StringHeader(PREC_MOD_SEQ);
+    static final StringHeader H_PREC_MOL_CUSTOM_ION_NAME = new StringHeader(PREC_MOL_CUSTOM_ION_NAME);
+    static final StringHeader H_PREC_MOL_ION_FORMULA = new StringHeader(PREC_MOL_ION_FORMULA);
+    static final DoubleHeader H_PREC_MOL_MASS_MONOISOTOPIC = new DoubleHeader(PREC_MOL_MASS_MONOISOTOPIC);
+    static final DoubleHeader H_PREC_MOL_MASS_AVERAGE = new DoubleHeader(PREC_MOL_MASS_AVERAGE);
+
+    static final List<Header<?>> PROTEIN_LIB_HEADERS = List.of(H_RUN, H_RUN_STATE, H_PEP_GRP, H_PEP_GRP_SEQ_ID, H_PEP_GRP_STATE);
+    static final List<String> PROTEIN_LIB_COLS = PROTEIN_LIB_HEADERS.stream().map(h -> h._name).collect(Collectors.toList());
+    static final List<Header<?>> PEP_LIB_HEADERS = List.of(H_RUN, H_RUN_STATE, H_PEP_GRP, H_PEP_GRP_SEQ_ID, H_PEP_GRP_STATE,
+            H_PREC_MZ, H_PREC_CHARGE, H_PREC_STATE,
+            H_PREC_MOD_SEQ, H_PREC_MOL_CUSTOM_ION_NAME, H_PREC_MOL_ION_FORMULA, H_PREC_MOL_MASS_MONOISOTOPIC, H_PREC_MOL_MASS_AVERAGE);
+    static final List<String> PEP_LIB_COLS = PEP_LIB_HEADERS.stream().map(h -> h._name).collect(Collectors.toList());
+
+    public static class Header<T>
+    {
+        final String _name;
+        final Class<T> _type;
+
+        private Header(String name, Class<T> type)
+        {
+            _name = name;
+            _type = type;
+        }
+    }
+
+    public final static class StringHeader extends Header<String>
+    {
+        private StringHeader(String name)
+        {
+            super(name, String.class);
+        }
+    }
+
+    public final static class IntegerHeader extends Header<Integer>
+    {
+        private IntegerHeader(String name)
+        {
+            super(name, Integer.class);
+        }
+    }
+
+    public final static class DoubleHeader extends Header<Double>
+    {
+        private DoubleHeader(String name)
+        {
+            super(name, Double.class);
+        }
+    }
 
     public void copyLibraryState(Container sourceContainer, Container targetContainer, Logger log, User user) throws ChromLibStateException
     {
@@ -79,14 +139,109 @@ public class ChromLibStateManager
 
     static List<LibMoleculePrecursor> getMoleculePrecursors(LibPeptideGroup pepGrp, Container c, User user, TargetedMSService svc)
     {
-        SQLFragment sql = new SQLFragment(" SELECT gp.Id, gp.mz, gp.charge, gp.representativedatastate, m.massMonoisotopic, m.massAverage, m.ionFormula, m.customIonName ")
+        SQLFragment sql = new SQLFragment(" SELECT gp.Id, gp.mz, gp.charge, gp.representativedatastate, mp.massMonoisotopic, mp.massAverage, mp.ionFormula, mp.customIonName ")
                 .append(" FROM ").append(svc.getTableInfoGeneralMolecule(), "gm")
                 .append(" INNER JOIN ").append(svc.getTableInfoGeneralPrecursor(), "gp")
                 .append(" ON gm.id = gp.generalmoleculeid ")
-                .append(" INNER JOIN ").append(svc.getTableInfoMolecule(), "m")
-                .append(" ON gm.id = m.id ")
+                .append(" INNER JOIN ").append(svc.getTableInfoMoleculePrecursor(), "mp")
+                .append(" ON gp.id = mp.id ")
                 .append(" WHERE gm.peptidegroupid = ?").add(pepGrp.getId());
 
         return new SqlSelector(svc.getUserSchema(user, c).getDbSchema(), sql).getArrayList(LibMoleculePrecursor.class);
+    }
+
+    public static void renameClibFileForContainer(Container container, TargetedMSService svc, Logger log) throws ChromLibStateException
+    {
+        Path chromLibDir = ChromLibStateManager.getChromLibDir(container);
+        if (Files.exists(chromLibDir))
+        {
+            try(Stream<Path> files = Files.list(chromLibDir).filter(p -> FileUtil.getFileName(p).endsWith(TargetedMSService.CHROM_LIB_FILE_EXT)))
+            {
+                for (Path libFile : files.collect(Collectors.toSet()))
+                {
+                    try
+                    {
+                        changeFileName(libFile, container, svc, log);
+                    }
+                    catch (IOException e)
+                    {
+                        throw new ChromLibStateException("Error changing chromatogram library file name", e);
+                    }
+                }
+            }
+            catch (IOException e)
+            {
+                throw new ChromLibStateException(String.format("Error listing chromatogram library files in folder '%s'.", chromLibDir), e);
+            }
+        }
+    }
+
+    private static void changeFileName(Path path, Container container, TargetedMSService svc, Logger log) throws IOException
+    {
+        Integer revision = svc.parseChromLibRevision(path.getFileName().toString());
+        if (revision != null)
+        {
+            String newFileName = svc.getChromLibFileName(container, revision);
+            Path targetFile = path.getParent().resolve(newFileName);
+
+            log.info(String.format("Changing chromatogram library file name from '%s' to '%s'.", path.getFileName().toString(), newFileName));
+            if (!Files.exists(targetFile))
+            {
+                FileUtils.moveFile(path.toFile(), targetFile.toFile());
+            }
+        }
+    }
+
+    // TODO: The existing methods in ConflictResultsManager in the targetedms module should be moved to the TargetedMS API
+    public static long getConflictCount(User user, Container container, TargetedMSService.FolderType folderType) {
+
+        long conflictCount = 0;
+
+        if(folderType == TargetedMSService.FolderType.LibraryProtein)
+        {
+            conflictCount = getProteinConflictCount(user, container);
+        }
+        else if(folderType == TargetedMSService.FolderType.Library)
+        {
+            conflictCount = getGeneralMoleculeConflictCount(container, user);
+        }
+
+        return conflictCount;
+    }
+
+    private static long getProteinConflictCount(User user, Container container)
+    {
+        TargetedMSService svc = TargetedMSService.get();
+        UserSchema schema = svc.getUserSchema(user, container);
+        TableInfo table = schema.getTable(svc.getTableInfoPeptideGroup().getName());
+        SimpleFilter filter = new SimpleFilter(FieldKey.fromParts(REPRESENTATIVEDATASTATE), RepresentativeDataState.Conflicted.ordinal());
+        return new TableSelector(table, filter, null).getRowCount();
+    }
+
+    private static long getGeneralMoleculeConflictCount(Container container, User user)
+    {
+        TargetedMSService svc = TargetedMSService.get();
+        SQLFragment sqlFragment = new SQLFragment();
+        sqlFragment.append("SELECT DISTINCT(gm.Id) FROM ");
+        sqlFragment.append(svc.getTableInfoGeneralMolecule(), "gm");
+        sqlFragment.append(", ");
+        sqlFragment.append(svc.getTableInfoRuns(), "r");
+        sqlFragment.append(", ");
+        sqlFragment.append(svc.getTableInfoPeptideGroup(), "pg");
+        sqlFragment.append(", ");
+        sqlFragment.append(svc.getTableInfoGeneralPrecursor(), "pc");
+        sqlFragment.append(" WHERE ");
+        sqlFragment.append("gm.PeptideGroupId = pg.Id AND ");
+        sqlFragment.append("pg.RunId = r.Id AND ");
+        sqlFragment.append("pc.GeneralMoleculeId = gm.Id  AND ");
+        sqlFragment.append("r.Deleted = ? AND r.Container = ? ");
+        sqlFragment.append("AND pc.RepresentativeDataState = ? ");
+
+        sqlFragment.add(false);
+        sqlFragment.add(container.getId());
+        sqlFragment.add(RepresentativeDataState.Conflicted.ordinal());
+
+        SqlSelector sqlSelector = new SqlSelector(svc.getUserSchema(user, container).getDbSchema(), sqlFragment);
+        return sqlSelector.getRowCount();
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
@@ -112,7 +112,6 @@ public class ChromLibStateManager
     public static Path getChromLibDir(Container container)
     {
         PipeRoot root = PipelineService.get().getPipelineRootSetting(container);
-        assert root != null;
         return root.getRootNioPath().resolve(TargetedMSService.CHROM_LIB_FILE_DIR);
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
@@ -1,0 +1,92 @@
+package org.labkey.panoramapublic.chromlib;
+
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineService;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.User;
+import org.labkey.api.targetedms.ITargetedMSRun;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.api.util.FileUtil;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+public class ChromLibStateManager
+{
+    static final String RUN = "Run";
+    static final String RUN_STATE = "Run_State";
+    static final String PEP_GRP = "Peptide_Group";
+    static final String PEP_GRP_SEQ_ID = "Peptide_Group_Seq_Id";
+    static final String PEP_GRP_STATE = "Peptide_Group_State";
+    static final String PREC_MZ = "Precursor_mz";
+    static final String PREC_CHARGE = "Precursor_Charge";
+    static final String PREC_STATE = "Precursor_State";
+    static final String PREC_MOD_SEQ = "Precursor_Modified_Sequence";
+    static final String PREC_MOL_CUSTOM_ION_NAME = "Precursor_Mol_Custom_Ion_Name";
+    static final String PREC_MOL_ION_FORMULA = "Precursor_Mol_Ion_Formula";
+    static final String PREC_MOL_MASS_MONOISOTOPIC = "Precursor_Mol_Mass_Monoisotopic";
+    static final String PREC_MOL_MASS_AVERAGE = "Precursor_Mol_Mass_Average";
+
+    static final List<String> PROTEIN_LIB_HEADERS = List.of(RUN, RUN_STATE, PEP_GRP, PEP_GRP_SEQ_ID, PEP_GRP_STATE);
+    static final List<String> PEP_LIB_HEADERS = List.of(RUN, RUN_STATE, PEP_GRP, PEP_GRP_SEQ_ID, PEP_GRP_STATE,
+            PREC_MZ, PREC_CHARGE, PREC_STATE,
+            PREC_MOD_SEQ, PREC_MOL_CUSTOM_ION_NAME, PREC_MOL_ION_FORMULA, PREC_MOL_MASS_MONOISOTOPIC, PREC_MOL_MASS_AVERAGE);
+
+    static final String REPRESENTATIVEDATASTATE = "representativedatastate";
+
+    public void copyLibraryState(Container sourceContainer, Container targetContainer, Logger log, User user) throws ChromLibStateException
+    {
+        Path chromLibDir = getChromLibDir(targetContainer);
+        Path chromLibExportFile = chromLibDir.resolve(FileUtil.makeFileNameWithTimestamp("chrom_lib_state_export_" + sourceContainer.getRowId(), "tsv"));
+        ChromLibStateExporter.exportLibState(chromLibExportFile.toFile(), sourceContainer, user, log);
+        ChromLibStateImporter.importLibState(chromLibExportFile.toFile(), targetContainer, user, log);
+    }
+
+    public static Path getChromLibDir(Container container)
+    {
+        PipeRoot root = PipelineService.get().getPipelineRootSetting(container);
+        assert root != null;
+        return root.getRootNioPath().resolve(TargetedMSService.CHROM_LIB_FILE_DIR);
+    }
+
+    static List<LibPeptideGroup> getPeptideGroups(ITargetedMSRun run, TargetedMSService svc)
+    {
+        return new TableSelector(svc.getTableInfoPeptideGroup(),
+                Set.of("id", "runId", "label", "sequenceId", "representativedatastate"),
+                new SimpleFilter(FieldKey.fromParts("runId"), run.getId()), null)
+                .getArrayList(LibPeptideGroup.class);
+    }
+
+    static List<LibPrecursor> getPrecursors(LibPeptideGroup pepGrp, Container c, User user, TargetedMSService svc)
+    {
+        SQLFragment sql = new SQLFragment(" SELECT gp.Id, gp.mz, gp.charge, gp.representativedatastate, p.modifiedsequence ")
+                .append(" FROM ").append(svc.getTableInfoGeneralMolecule(), "gm")
+                .append(" INNER JOIN ").append(svc.getTableInfoGeneralPrecursor(), "gp")
+                .append(" ON gm.id = gp.generalmoleculeid ")
+                .append(" INNER JOIN ").append(svc.getTableInfoPrecursor(), "p")
+                .append(" ON gp.id = p.id ")
+                .append(" WHERE gm.peptidegroupid = ?").add(pepGrp.getId());
+
+        return new SqlSelector(svc.getUserSchema(user, c).getDbSchema(), sql).getArrayList(LibPrecursor.class);
+    }
+
+    static List<LibMoleculePrecursor> getMoleculePrecursors(LibPeptideGroup pepGrp, Container c, User user, TargetedMSService svc)
+    {
+        SQLFragment sql = new SQLFragment(" SELECT gp.Id, gp.mz, gp.charge, gp.representativedatastate, m.massMonoisotopic, m.massAverage, m.ionFormula, m.customIonName ")
+                .append(" FROM ").append(svc.getTableInfoGeneralMolecule(), "gm")
+                .append(" INNER JOIN ").append(svc.getTableInfoGeneralPrecursor(), "gp")
+                .append(" ON gm.id = gp.generalmoleculeid ")
+                .append(" INNER JOIN ").append(svc.getTableInfoMolecule(), "m")
+                .append(" ON gm.id = m.id ")
+                .append(" WHERE gm.peptidegroupid = ?").add(pepGrp.getId());
+
+        return new SqlSelector(svc.getUserSchema(user, c).getDbSchema(), sql).getArrayList(LibMoleculePrecursor.class);
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
@@ -197,11 +197,11 @@ public class ChromLibStateManager
 
         long conflictCount = 0;
 
-        if(folderType == TargetedMSService.FolderType.LibraryProtein)
+        if (folderType == TargetedMSService.FolderType.LibraryProtein)
         {
             conflictCount = getProteinConflictCount(user, container);
         }
-        else if(folderType == TargetedMSService.FolderType.Library)
+        else if (folderType == TargetedMSService.FolderType.Library)
         {
             conflictCount = getGeneralMoleculeConflictCount(container, user);
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibGeneralPrecursor.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibGeneralPrecursor.java
@@ -1,0 +1,119 @@
+package org.labkey.panoramapublic.chromlib;
+
+import org.labkey.api.targetedms.RepresentativeDataState;
+
+import java.util.Objects;
+
+public abstract class LibGeneralPrecursor
+{
+    private long _peptideGroupId;
+
+    // Fields from the GeneralPrecursor table
+    private long _id;
+    private double _mz;
+    private int _charge;
+    private RepresentativeDataState _representativeDataState;
+
+    public LibGeneralPrecursor()
+    {
+    }
+
+    LibGeneralPrecursor(long peptideGroupId, double precursorMz, int charge, RepresentativeDataState state)
+    {
+        _peptideGroupId = peptideGroupId;
+        _mz = precursorMz;
+        _charge = charge;
+        _representativeDataState = state;
+    }
+
+    public long getId()
+    {
+        return _id;
+    }
+
+    public void setId(long id)
+    {
+        _id = id;
+    }
+
+    public double getMz()
+    {
+        return _mz;
+    }
+
+    public void setMz(double mz)
+    {
+        _mz = mz;
+    }
+
+    public int getCharge()
+    {
+        return _charge;
+    }
+
+    public void setCharge(int charge)
+    {
+        _charge = charge;
+    }
+
+    public RepresentativeDataState getRepresentativeDataState()
+    {
+        return _representativeDataState;
+    }
+
+    public void setRepresentativeDataState(RepresentativeDataState representativeDataState)
+    {
+        _representativeDataState = representativeDataState;
+    }
+
+    public long getPeptideGroupId()
+    {
+        return _peptideGroupId;
+    }
+
+    public void setPeptideGroupId(long peptideGroupId)
+    {
+        _peptideGroupId = peptideGroupId;
+    }
+
+    public abstract LibPrecursorKey getKey();
+
+    static class LibPrecursorKey
+    {
+        private final double _mz;
+        private final int _charge;
+        private final String _precursorKey;
+
+        public LibPrecursorKey(double mz, int charge, String precursorKey)
+        {
+            _mz = mz;
+            _charge = charge;
+            _precursorKey = precursorKey;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LibPrecursorKey that = (LibPrecursorKey) o;
+            return Double.compare(that._mz, _mz) == 0 && _charge == that._charge && Objects.equals(_precursorKey, that._precursorKey);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(_mz, _charge, _precursorKey);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "LibPrecursorKey{" +
+                    "_mz=" + _mz +
+                    ", _charge=" + _charge +
+                    ", _key='" + _precursorKey + '\'' +
+                    '}';
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibMoleculePrecursor.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibMoleculePrecursor.java
@@ -5,7 +5,7 @@ import org.labkey.api.targetedms.RepresentativeDataState;
 
 public class LibMoleculePrecursor extends LibGeneralPrecursor
 {
-    // Fields from the Molecule table
+    // Fields from the MoleculePrecursor table
     private String _customIonName;
     private String _ionFormula;
     private Double _massMonoisotopic; // not null

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibMoleculePrecursor.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibMoleculePrecursor.java
@@ -1,0 +1,74 @@
+package org.labkey.panoramapublic.chromlib;
+
+import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.targetedms.RepresentativeDataState;
+
+public class LibMoleculePrecursor extends LibGeneralPrecursor
+{
+    // Fields from the Molecule table
+    private String _customIonName;
+    private String _ionFormula;
+    private Double _massMonoisotopic; // not null
+    private Double _massAverage; // not null
+
+    public LibMoleculePrecursor()
+    {
+    }
+
+    LibMoleculePrecursor(long peptideGroupId, double precursorMz, int charge, RepresentativeDataState state,
+                         String customIonName, String ionFormula, Double massMonoisotopic, Double massAverage)
+    {
+        super(peptideGroupId, precursorMz, charge, state);
+        _customIonName = customIonName;
+        _ionFormula = ionFormula;
+        _massMonoisotopic = massMonoisotopic;
+        _massAverage = massAverage;
+    }
+
+    public String getIonFormula()
+    {
+        return _ionFormula;
+    }
+
+    public void setIonFormula(String ionFormula)
+    {
+        _ionFormula = ionFormula;
+    }
+
+    public Double getMassMonoisotopic()
+    {
+        return _massMonoisotopic;
+    }
+
+    public void setMassMonoisotopic(Double massMonoisotopic)
+    {
+        _massMonoisotopic = massMonoisotopic;
+    }
+
+    public Double getMassAverage()
+    {
+        return _massAverage;
+    }
+
+    public void setMassAverage(Double massAverage)
+    {
+        _massAverage = massAverage;
+    }
+
+    public String getCustomIonName()
+    {
+        return _customIonName;
+    }
+
+    public void setCustomIonName(String customIonName)
+    {
+        _customIonName = customIonName;
+    }
+
+    @Override
+    public LibPrecursorKey getKey()
+    {
+        return new LibPrecursorKey(getMz(), getCharge(),
+                StringUtils.join(new String[]{_customIonName, _ionFormula, String.valueOf(_massMonoisotopic), String.valueOf(_massAverage)}, ','));
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibPeptideGroup.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibPeptideGroup.java
@@ -1,0 +1,117 @@
+package org.labkey.panoramapublic.chromlib;
+
+import org.labkey.api.targetedms.RepresentativeDataState;
+
+import java.util.Objects;
+
+public class LibPeptideGroup
+{
+    private long _id;
+    private String _label;
+    private Integer _sequenceId;
+    private long _runId;
+    private RepresentativeDataState _representativeDataState;
+
+    public LibPeptideGroup()
+    {
+    }
+
+    LibPeptideGroup(long runId, String label, Integer sequenceId, RepresentativeDataState representativeDataState)
+    {
+        _runId = runId;
+        _label = label;
+        _sequenceId = sequenceId;
+        _representativeDataState = representativeDataState;
+    }
+
+    public long getId()
+    {
+        return _id;
+    }
+
+    public void setId(long id)
+    {
+        _id = id;
+    }
+
+    public String getLabel()
+    {
+        return _label;
+    }
+
+    public void setLabel(String label)
+    {
+        _label = label;
+    }
+
+    public Integer getSequenceId()
+    {
+        return _sequenceId;
+    }
+
+    public void setSequenceId(Integer sequenceId)
+    {
+        _sequenceId = sequenceId;
+    }
+
+    public long getRunId()
+    {
+        return _runId;
+    }
+
+    public void setRunId(long runId)
+    {
+        _runId = runId;
+    }
+
+    public RepresentativeDataState getRepresentativeDataState()
+    {
+        return _representativeDataState;
+    }
+
+    public void setRepresentativeDataState(RepresentativeDataState representativeDataState)
+    {
+        _representativeDataState = representativeDataState;
+    }
+
+    public LibPeptideGroupKey getKey()
+    {
+        return new LibPeptideGroupKey(_label, _sequenceId);
+    }
+
+    static class LibPeptideGroupKey
+    {
+        private final String _label;
+        private final Integer _seqId;
+
+        private LibPeptideGroupKey(String label, Integer seqId)
+        {
+            _label = label;
+            _seqId = seqId;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LibPeptideGroupKey that = (LibPeptideGroupKey) o;
+            return Objects.equals(_label, that._label) && Objects.equals(_seqId, that._seqId);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(_label, _seqId);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "LibPeptideGroupKey{" +
+                    "_label='" + _label + '\'' +
+                    ", _seqId=" + _seqId +
+                    '}';
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibPrecursor.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/LibPrecursor.java
@@ -1,0 +1,35 @@
+package org.labkey.panoramapublic.chromlib;
+
+import org.labkey.api.targetedms.RepresentativeDataState;
+
+public class LibPrecursor extends LibGeneralPrecursor
+{
+    // Fields from the Precursor table
+    private String _modifiedSequence;
+
+    public LibPrecursor()
+    {
+    }
+
+    LibPrecursor(long peptideGroupId, double precursorMz, int charge, RepresentativeDataState state, String modifiedSequence)
+    {
+        super(peptideGroupId, precursorMz, charge, state);
+        _modifiedSequence = modifiedSequence;
+    }
+
+    public String getModifiedSequence()
+    {
+        return _modifiedSequence;
+    }
+
+    public void setModifiedSequence(String modifiedSequence)
+    {
+        _modifiedSequence = modifiedSequence;
+    }
+
+    @Override
+    public LibPrecursorKey getKey()
+    {
+        return new LibPrecursorKey(getMz(), getCharge(), _modifiedSequence);
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/UpdateFolderTypeTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/UpdateFolderTypeTask.java
@@ -1,0 +1,230 @@
+package org.labkey.panoramapublic.pipeline;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DbScope;
+import org.labkey.api.data.PropertyManager;
+import org.labkey.api.exp.api.ExpExperiment;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.module.ModuleProperty;
+import org.labkey.api.pipeline.AbstractTaskFactory;
+import org.labkey.api.pipeline.AbstractTaskFactorySettings;
+import org.labkey.api.pipeline.PipelineJob;
+import org.labkey.api.pipeline.PipelineJobException;
+import org.labkey.api.pipeline.RecordedActionSet;
+import org.labkey.api.security.User;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.api.targetedms.TargetedMSService.FolderType;
+import org.labkey.api.util.FileType;
+import org.labkey.api.util.FileUtil;
+import org.labkey.panoramapublic.PanoramaPublicManager;
+import org.labkey.panoramapublic.chromlib.ChromLibStateException;
+import org.labkey.panoramapublic.chromlib.ChromLibStateManager;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.Experiment;
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.Library;
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.LibraryProtein;
+
+public class UpdateFolderTypeTask extends PipelineJob.Task<UpdateFolderTypeTask.Factory>
+{
+    private static final Module _targetedMSModule = ModuleLoader.getInstance().getModule(TargetedMSService.MODULE_NAME);
+    private static final ModuleProperty _folderTypeProp = _targetedMSModule.getModuleProperties().get(TargetedMSService.FOLDER_TYPE_PROP_NAME);
+
+    private UpdateFolderTypeTask(UpdateFolderTypeTask.Factory factory, PipelineJob job)
+    {
+        super(factory, job);
+    }
+
+    @Override
+    @NotNull
+    public RecordedActionSet run() throws PipelineJobException
+    {
+        PipelineJob job = getJob();
+        CopyExperimentJobSupport support = job.getJobSupport(CopyExperimentJobSupport.class);
+        try
+        {
+            job.getLogger().info("");
+            job.getLogger().info("Updating the folder type.");
+            updateFolderType(job, support);
+        }
+        catch (Throwable t)
+        {
+            throw new PipelineJobException(t);
+        }
+
+        return new RecordedActionSet();
+    }
+
+    private void updateFolderType(PipelineJob job, CopyExperimentJobSupport jobSupport) throws PipelineJobException
+    {
+        // Get the experiment that was just created in the target folder as part of the folder import.
+        var container = job.getContainer();
+        User user = job.getUser();
+        List<? extends ExpExperiment> experiments = ExperimentService.get().getExperiments(container, user, false, false);
+        if (experiments.size() == 0)
+        {
+            throw new PipelineJobException(String.format("No experiments found in the container '%s'.", container.getPath()));
+        }
+        else if (experiments.size() >  1)
+        {
+            throw new PipelineJobException(String.format("More than one experiment found in the container '%s'.", container.getPath()));
+        }
+        ExpExperiment experiment = experiments.get(0);
+
+        ExperimentAnnotations sourceExperiment = jobSupport.getExpAnnotations();
+        Logger log = job.getLogger();
+        try(DbScope.Transaction transaction = PanoramaPublicManager.getSchema().getScope().ensureTransaction())
+        {
+            Container target = experiment.getContainer();
+            TargetedMSService svc = TargetedMSService.get();
+            updateFolderType(target, sourceExperiment.getContainer(), user, svc, log);
+            transaction.commit();
+        }
+    }
+
+    private void updateFolderType(Container c, Container sourceContainer, User user, TargetedMSService svc, Logger log) throws PipelineJobException
+    {
+        doUpdate(c, sourceContainer, user, svc, log);
+
+        List<Container> children = ContainerManager.getChildren(c);
+        for (Container child: children)
+        {
+            Container source = ContainerManager.getChild(sourceContainer, child.getName());
+            if (source == null)
+            {
+               throw new PipelineJobException(String.format("Cannot update folder type. Could not find the source container for the subfolder '%s'.", child.getPath()));
+            }
+            updateFolderType(child, sourceContainer, user, svc, log);
+        }
+    }
+
+    private void doUpdate(Container c, Container sourceContainer, User user, TargetedMSService svc, Logger log) throws PipelineJobException
+    {
+        FolderType folderType = svc.getFolderType(sourceContainer);
+        if (Experiment.equals(folderType))
+        {
+            log.info(String.format("Setting the TargetedMS folder type to 'Experimental Data' for container '%s'.", c.getPath()));
+            _folderTypeProp.saveValue(user, c, Experiment.toString());
+        }
+        else if (Library.equals(folderType) || LibraryProtein.equals(folderType))
+        {
+            log.info(String.format("Updating the TargetedMS folder type to '%s' for container '%s'.",
+                    (LibraryProtein.equals(folderType) ? "Protein Library" : "Peptide Library"),
+                    c.getPath()));
+            makePanoramaLibraryFolder(c, sourceContainer, folderType, user, svc, log);
+        }
+    }
+
+    private static void makePanoramaLibraryFolder(Container container, Container sourceContainer, FolderType sourceFolderType,
+                                                  User user, TargetedMSService svc, Logger log) throws PipelineJobException
+    {
+        _folderTypeProp.saveValue(user, container, sourceFolderType.name());
+
+        PropertyManager.PropertyMap sourcePropMap = PropertyManager.getProperties(sourceContainer, TargetedMSService.MODULE_NAME);
+        String versionStr = sourcePropMap.get(TargetedMSService.PROP_CHROM_LIB_REVISION);
+        if (null != versionStr)
+        {
+            log.info(String.format("Setting the value of property '%s' to '%s'.", TargetedMSService.PROP_CHROM_LIB_REVISION, versionStr));
+            PropertyManager.PropertyMap targetPropMap = PropertyManager.getWritableProperties(container, TargetedMSService.MODULE_NAME, true);
+            targetPropMap.put(TargetedMSService.PROP_CHROM_LIB_REVISION, versionStr);
+            targetPropMap.save();
+
+            Path chromLibDir = ChromLibStateManager.getChromLibDir(container);
+            if (Files.exists(chromLibDir))
+            {
+                try(Stream<Path> files = Files.list(chromLibDir).filter(p -> FileUtil.getFileName(p).endsWith(TargetedMSService.CHROM_LIB_FILE_EXT)))
+                {
+                    for (Path libFile : files.collect(Collectors.toSet()))
+                    {
+                        try
+                        {
+                            changeFileName(libFile, container, svc, log);
+                        }
+                        catch (IOException e)
+                        {
+                            throw new PipelineJobException("Error changing chromatogram library file name", e);
+                        }
+                    }
+                }
+                catch (IOException e)
+                {
+                    throw new PipelineJobException(String.format("Error listing chromatogram library files in folder '%s'.", chromLibDir), e);
+                }
+            }
+
+            try
+            {
+                new ChromLibStateManager().copyLibraryState(sourceContainer, container, log, user);
+            }
+            catch (ChromLibStateException e)
+            {
+                throw new PipelineJobException(String.format("Error copying chromatogram library state from source folder '%s' to '%s'", sourceContainer, container), e);
+            }
+        }
+    }
+
+    private static void changeFileName(Path path, Container container, TargetedMSService svc, Logger log) throws IOException
+    {
+        Integer revision = svc.parseChromLibRevision(path.getFileName().toString());
+        if(revision != null)
+        {
+            String newFileName = svc.getChromLibFileName(container, revision);
+            Path targetFile = path.getParent().resolve(newFileName);
+
+            log.info(String.format("Changing chromatogram library file name from '%s' to '%s'.", path.getFileName().toString(), newFileName));
+            FileUtils.moveFile(path.toFile(), targetFile.toFile());
+        }
+    }
+
+    public static class Factory extends AbstractTaskFactory<AbstractTaskFactorySettings, UpdateFolderTypeTask.Factory>
+    {
+        public Factory()
+        {
+            super(UpdateFolderTypeTask.class);
+        }
+
+        @Override
+        public PipelineJob.Task createTask(PipelineJob job)
+        {
+            return new UpdateFolderTypeTask(this, job);
+        }
+
+        @Override
+        public List<FileType> getInputTypes()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public List<String> getProtocolActionNames()
+        {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getStatusName()
+        {
+            return "UPDATE FOLDER TYPE";
+        }
+
+        @Override
+        public boolean isJobComplete(PipelineJob job)
+        {
+            return false;
+        }
+    }
+}

--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentInsertPage.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentInsertPage.java
@@ -1,0 +1,42 @@
+package org.labkey.test.components.panoramapublic;
+
+import org.labkey.test.Locator;
+import org.labkey.test.pages.InsertPage;
+import org.labkey.test.tests.panoramapublic.PanoramaPublicTest;
+import org.openqa.selenium.WebDriver;
+
+public class TargetedMsExperimentInsertPage extends InsertPage
+{
+    private static final String DEFAULT_TITLE = "Targeted MS Experiment";
+
+    public TargetedMsExperimentInsertPage(WebDriver driver)
+    {
+        super(driver, DEFAULT_TITLE);
+    }
+
+    @Override
+    protected void waitForReady()
+    {
+        waitForElement(elements().expTitle);
+    }
+
+    public void insert(String experimentTitle)
+    {
+        Elements elements = elements();
+        setFormElement(elements.expTitle, experimentTitle);
+        setFormElement(elements.expAbstract, "This is a really short, 50 character long abstract");
+        clickAndWait(elements.submit);
+    }
+
+    @Override
+    protected Elements elements()
+    {
+        return new Elements();
+    }
+
+    private class Elements extends InsertPage.Elements
+    {
+        public Locator.XPathLocator expTitle = body.append(Locator.tagWithName("textarea", "title"));
+        public Locator.XPathLocator expAbstract = body.append(Locator.tagWithName("textarea", "abstract"));
+    }
+}

--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
@@ -1,0 +1,51 @@
+package org.labkey.test.components.panoramapublic;
+
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.components.BodyWebPart;
+import org.labkey.test.util.DataRegionTable;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TargetedMsExperimentWebPart extends BodyWebPart
+{
+    public static final String DEFAULT_TITLE = "Targeted MS Experiment";
+    private DataRegionTable _dataRegionTable;
+    private BaseWebDriverTest _test;
+
+    public TargetedMsExperimentWebPart(BaseWebDriverTest test)
+    {
+        this(test, 0);
+    }
+
+    public TargetedMsExperimentWebPart(BaseWebDriverTest test, int index)
+    {
+        super(test.getDriver(), DEFAULT_TITLE, index);
+        _test = test;
+    }
+
+    public DataRegionTable getDataRegion()
+    {
+        if (_dataRegionTable == null)
+            _dataRegionTable = DataRegionTable.DataRegion(_test.getDriver()).find(getComponentElement());
+        return _dataRegionTable;
+    }
+
+    public TargetedMsExperimentInsertPage startInsert()
+    {
+        findElement(Locator.linkContainingText("Create New Experiment")).click();
+        return new TargetedMsExperimentInsertPage(_test.getDriver());
+    }
+
+    public void clickSubmit()
+    {
+        getWrapper().clickAndWait(Locator.linkContainingText("Submit"));
+    }
+
+    public void clickResubmit()
+    {
+        Locator.XPathLocator resubmitLink = Locator.linkContainingText("Resubmit");
+        assertNotNull("Expected to see a \"Resubmit\" button", resubmitLink);
+        getWrapper().clickAndWait(resubmitLink);
+    }
+}

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/ChromLibTestHelper.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/ChromLibTestHelper.java
@@ -1,0 +1,379 @@
+package org.labkey.test.tests.panoramapublic;
+
+import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.util.Pair;
+import org.labkey.remoteapi.CommandException;
+import org.labkey.remoteapi.Connection;
+import org.labkey.remoteapi.query.Filter;
+import org.labkey.remoteapi.query.Row;
+import org.labkey.remoteapi.query.SelectRowsCommand;
+import org.labkey.remoteapi.query.SelectRowsResponse;
+import org.labkey.test.BaseWebDriverTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class ChromLibTestHelper
+{
+    private static final String TARGETEDMS = "targetedms";
+    private static final String ID = "id";
+    private static final String FILENAME = "filename";
+    private static final String RUNID = "runid";
+    private static final String SEQUENCEID = "sequenceid";
+    private static final String LABEL = "label";
+    private static final String MZ = "mz";
+    private static final String CHARGE = "charge";
+    private static final String MODIFIED_SEQ = "modifiedsequence";
+    private static final String MASS_MONO = "massmonoisotopic";
+    private static final String MASS_AVG = "massaverage";
+    private static final String CUSTOM_ION_NAME = "customionname";
+    private static final String ION_FORMULA = "ionformula";
+    static final String REPRESENTATIVEDATASTATE = "representativedatastate";
+
+    private final BaseWebDriverTest _test;
+
+    public ChromLibTestHelper(BaseWebDriverTest test)
+    {
+        _test = test;
+    }
+
+    public ChromLibState getLibState(String folderPath)
+    {
+        ChromLibState state = new ChromLibState();
+        state.setRuns(getRuns(folderPath));
+        return state;
+    }
+
+    private List<LibRun> getRuns(String folderPath)
+    {
+        List<LibRun> runs = new ArrayList<>();
+        try {
+            Connection conn = _test.createDefaultConnection();
+            SelectRowsCommand selectCmd = new SelectRowsCommand(TARGETEDMS, "runs");
+            selectCmd.setColumns(List.of(ID, FILENAME, REPRESENTATIVEDATASTATE));
+            SelectRowsResponse selectResp = selectCmd.execute(conn, folderPath);
+
+            for (Row row : selectResp.getRowset())
+            {
+                LibRun run = new LibRun();
+                run._id = (Integer)row.getValue(ID);
+                run._fileName = (String)row.getValue(FILENAME);
+                run._representativeDataState = (Integer)row.getValue(REPRESENTATIVEDATASTATE);
+                addPeptideGroups(run, folderPath);
+                runs.add(run);
+            }
+        }
+        catch (IOException | CommandException rethrow)
+        {
+            throw new RuntimeException(rethrow);
+        }
+        return runs;
+    }
+
+    private void addPeptideGroups(LibRun run, String folderPath)
+    {
+        try {
+            Connection conn = _test.createDefaultConnection();
+            SelectRowsCommand selectCmd = new SelectRowsCommand(TARGETEDMS, "peptidegroup");
+            selectCmd.addFilter(new Filter(RUNID, run._id));
+            selectCmd.setColumns(List.of(ID, RUNID, LABEL, SEQUENCEID, REPRESENTATIVEDATASTATE));
+            SelectRowsResponse selectResp = selectCmd.execute(conn, folderPath);
+
+            for (Row row : selectResp.getRowset())
+            {
+                LibPeptideGroup pepGrp = new LibPeptideGroup();
+                pepGrp._id = (Integer)row.getValue(ID);
+                pepGrp._sequenceId = (Integer)row.getValue(SEQUENCEID);
+                pepGrp._label = (String)row.getValue(LABEL);
+                pepGrp._representativeDataState = (Integer)row.getValue(REPRESENTATIVEDATASTATE);
+                addPrecursors(pepGrp, run, folderPath);
+                addMoleculePrecursors(pepGrp, run, folderPath);
+                run.addPeptideGroup(pepGrp);
+            }
+        }
+        catch (IOException | CommandException rethrow)
+        {
+            throw new RuntimeException(rethrow);
+        }
+    }
+
+    private void addPrecursors(LibPeptideGroup pepGrp, LibRun run, String folderPath)
+    {
+        try {
+            Connection conn = _test.createDefaultConnection();
+            SelectRowsCommand selectCmd = new SelectRowsCommand(TARGETEDMS, "precursor");
+            selectCmd.addFilter(new Filter("GeneralMoleculeId/PeptideGroupId", pepGrp._id));
+            selectCmd.setColumns(List.of(ID, MZ, CHARGE, MODIFIED_SEQ, REPRESENTATIVEDATASTATE));
+            SelectRowsResponse selectResp = selectCmd.execute(conn, folderPath);
+
+            for (Row row : selectResp.getRowset())
+            {
+                LibPrecursor precursor = new LibPrecursor();
+                precursor._id= (Integer)row.getValue(ID);
+                precursor._mz = (Double)row.getValue(MZ);
+                precursor._charge = (Integer)row.getValue(CHARGE);
+                precursor._representativeDataState = (Integer)row.getValue(REPRESENTATIVEDATASTATE);
+                precursor._modifiedSequence = (String)row.getValue(MODIFIED_SEQ);
+                pepGrp.addPrecursor(precursor, run);
+            }
+        }
+        catch (IOException | CommandException rethrow)
+        {
+            throw new RuntimeException(rethrow);
+        }
+    }
+
+    private void addMoleculePrecursors(LibPeptideGroup pepGrp, LibRun run, String folderPath)
+    {
+        try {
+            Connection conn = _test.createDefaultConnection();
+            SelectRowsCommand selectCmd = new SelectRowsCommand(TARGETEDMS, "moleculeprecursor");
+            selectCmd.addFilter(new Filter("GeneralMoleculeId/PeptideGroupId", pepGrp._id));
+            selectCmd.setColumns(List.of(ID, MZ, CHARGE, MASS_MONO, MASS_AVG, ION_FORMULA, CUSTOM_ION_NAME, REPRESENTATIVEDATASTATE));
+            SelectRowsResponse selectResp = selectCmd.execute(conn, folderPath);
+
+            for (Row row : selectResp.getRowset())
+            {
+                LibMoleculePrecursor precursor = new LibMoleculePrecursor();
+                precursor._id= (Integer)row.getValue(ID);
+                precursor._mz = (Double)row.getValue(MZ);
+                precursor._charge = (Integer)row.getValue(CHARGE);
+                precursor._representativeDataState = (Integer)row.getValue(REPRESENTATIVEDATASTATE);
+                precursor._massMonoisotopic = (Double)row.getValue(MASS_MONO);
+                precursor._massAverage = (Double)row.getValue(MASS_AVG);
+                precursor._ionFormula = (String)row.getValue(ION_FORMULA);
+                precursor._customIonName = (String)row.getValue(CUSTOM_ION_NAME);
+                pepGrp.addPrecursor(precursor, run);
+            }
+        }
+        catch (IOException | CommandException rethrow)
+        {
+            throw new RuntimeException(rethrow);
+        }
+    }
+
+    public static class ChromLibState
+    {
+//        private String _libType;
+//        private String _libVersion;
+        private List<LibRun> _runs = new ArrayList<>();
+
+        public List<LibRun> getRuns()
+        {
+            return _runs;
+        }
+
+        public void setRuns(List<LibRun> runs)
+        {
+            _runs = runs;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ChromLibState that = (ChromLibState) o;
+            return Objects.equals(getRuns(), that.getRuns());
+        }
+    }
+
+    private static class LibRun
+    {
+        private int _id;
+        private String _fileName;
+        private int _representativeDataState;
+        private final Map<LibPeptideGroupKey, Pair<Integer, Map<LibPrecursorKey, Integer>>>_peptideGroups;
+
+        private LibRun()
+        {
+            _peptideGroups = new HashMap<>();
+        }
+
+        public void addPeptideGroup(LibPeptideGroup group)
+        {
+            if(_peptideGroups.containsKey(group.getKey()))
+            {
+                throw new RuntimeException(String.format("Duplicate peptide group '%s' found for run %s.", group.getKey(), _fileName));
+            }
+            _peptideGroups.put(group.getKey(), new Pair<>(group._representativeDataState, group.getPrecursorStates()));
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LibRun libRun = (LibRun) o;
+            return _representativeDataState == libRun._representativeDataState && Objects.equals(_fileName, libRun._fileName)
+                    && Objects.equals(_peptideGroups, libRun._peptideGroups);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(_id, _fileName, _representativeDataState, _peptideGroups);
+        }
+    }
+
+    private static class LibPeptideGroup
+    {
+        private int _id;
+        private String _label;
+        private Integer _sequenceId;
+        private int _representativeDataState;
+        private final Map<LibPrecursorKey, Integer> _precursors;
+
+        public LibPeptideGroupKey getKey()
+        {
+            return new LibPeptideGroupKey(_label, _sequenceId);
+        }
+
+        private LibPeptideGroup()
+        {
+            _precursors = new HashMap<>();
+        }
+
+        public void addPrecursor(LibGeneralPrecursor precursor, LibRun run)
+        {
+            if(_precursors.containsKey(precursor.getKey()))
+            {
+                throw new RuntimeException(String.format("Duplicate precursor '%s' found for peptide group '%s' in run '%s'.", precursor.getKey(), getKey(), run._fileName));
+            }
+            _precursors.put(precursor.getKey(), precursor._representativeDataState);
+        }
+
+        public Map<LibPrecursorKey, Integer> getPrecursorStates()
+        {
+            return _precursors;
+        }
+    }
+
+    private static class LibPeptideGroupKey
+    {
+        private final String _label;
+        private final Integer _seqId;
+
+        private LibPeptideGroupKey(String label, Integer seqId)
+        {
+            _label = label;
+            _seqId = seqId;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LibPeptideGroupKey that = (LibPeptideGroupKey) o;
+            return Objects.equals(_label, that._label) && Objects.equals(_seqId, that._seqId);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(_label, _seqId);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "LibPeptideGroupKey{" +
+                    "_label='" + _label + '\'' +
+                    ", _seqId=" + _seqId +
+                    '}';
+        }
+    }
+
+    private static class LibPrecursorKey
+    {
+        private final double _mz;
+        private final int _charge;
+        private final String _precursorKey;
+
+        public LibPrecursorKey(double mz, int charge, String precursorKey)
+        {
+            _mz = mz;
+            _charge = charge;
+            _precursorKey = precursorKey;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            LibPrecursorKey that = (LibPrecursorKey) o;
+            return Double.compare(that._mz, _mz) == 0 && _charge == that._charge && Objects.equals(_precursorKey, that._precursorKey);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(_mz, _charge, _precursorKey);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "LibPrecursorKey{" +
+                    "_mz=" + _mz +
+                    ", _charge=" + _charge +
+                    ", _key='" + _precursorKey + '\'' +
+                    '}';
+        }
+    }
+
+    private static abstract class LibGeneralPrecursor
+    {
+        // Fields from the GeneralPrecursor table
+        protected int _id;
+        protected double _mz;
+        protected int _charge;
+        protected int _representativeDataState;
+
+        public abstract LibPrecursorKey getKey();
+    }
+
+    public static class LibMoleculePrecursor extends LibGeneralPrecursor
+    {
+        // Fields from the Molecule table
+        private String _customIonName;
+        private String _ionFormula;
+        private Double _massMonoisotopic;
+        private Double _massAverage;
+
+        @Override
+        public LibPrecursorKey getKey()
+        {
+            return new LibPrecursorKey(_mz, _charge,
+                    StringUtils.join(new String[]{_customIonName, _ionFormula, String.valueOf(_massMonoisotopic), String.valueOf(_massAverage)}, ','));
+        }
+    }
+
+    public static class LibPrecursor extends LibGeneralPrecursor
+    {
+        // Fields from the Precursor table
+        private String _modifiedSequence;
+
+        public String getModifiedSequence()
+        {
+            return _modifiedSequence;
+        }
+
+        public void setModifiedSequence(String modifiedSequence)
+        {
+            _modifiedSequence = modifiedSequence;
+        }
+
+        @Override
+        public LibPrecursorKey getKey()
+        {
+            return new LibPrecursorKey(_mz, _charge, _modifiedSequence);
+        }
+    }
+}

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -104,14 +104,9 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         setupSourceFolder(projectName, folderName, FolderType.Experiment, adminUsers);
     }
 
-    void setupProteinLibraryFolder(String projectName, String folderName, String ... adminUsers)
+    void setupLibraryFolder(String projectName, String folderName, FolderType folderType, String ... adminUsers)
     {
-        setupSourceFolder(projectName, folderName, FolderType.LibraryProtein, adminUsers);
-    }
-
-    void setupPeptideLibraryFolder(String projectName, String folderName, String ... adminUsers)
-    {
-        setupSourceFolder(projectName, folderName, FolderType.Library, adminUsers);
+        setupSourceFolder(projectName, folderName, folderType, adminUsers);
     }
 
     private void setupSourceFolder(String projectName, String folderName, FolderType folderType, String ... adminUsers)

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -1,0 +1,251 @@
+package org.labkey.test.tests.panoramapublic;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.labkey.test.Locator;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.components.SubfoldersWebPart;
+import org.labkey.test.components.panoramapublic.TargetedMsExperimentInsertPage;
+import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
+import org.labkey.test.tests.targetedms.TargetedMSTest;
+import org.labkey.test.util.APIContainerHelper;
+import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.Ext4Helper;
+import org.labkey.test.util.PermissionsHelper;
+import org.labkey.test.util.PortalHelper;
+import org.labkey.test.util.PostgresOnlyTest;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOnlyTest
+{
+    static String PANORAMA_PUBLIC = "Panorama Public " + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
+    static final String PANORAMA_PUBLIC_GROUP = "panoramapublictest";
+
+    static final String ADMIN_USER = "admin@panoramapublic.test";
+    static final String SUBMITTER = "submitter@panoramapublic.test";
+
+    static final String REVIEWER_PREFIX = "panoramapublictest_reviewer";
+
+    PortalHelper portalHelper = new PortalHelper(this);
+
+    @Override
+    protected String getProjectName()
+    {
+        String baseName = getClass().getSimpleName();
+        // The SQLite driver for the Chromatogram library code chokes on paths with certain characters on OSX. We don't have
+        // any real deployments on OSX, so just avoid using those characters on dev machines and rely on TeamCity
+        // to keep things happy on the platforms we actually use on production
+        String osName = System.getProperty("os.name").toLowerCase();
+        boolean isMacOs = osName.startsWith("mac os x");
+        if (isMacOs)
+        {
+            return baseName;
+        }
+        return baseName + " Project " + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
+    }
+
+    @BeforeClass
+    public static void initProject()
+    {
+        PanoramaPublicBaseTest init = (PanoramaPublicBaseTest)getCurrentTest();
+        init.createPanoramaPublicJournalProject();
+
+        // Create the test project
+        init.setupFolder(FolderType.Experiment);
+    }
+
+    private void createPanoramaPublicJournalProject()
+    {
+        // Create a "Panorama Public" project where we will copy data.
+        goToAdminConsole().goToSettingsSection();
+        clickAndWait(Locator.linkWithText("Panorama Public"));
+        clickAndWait(Locator.linkWithText("Create a new journal group"));
+        setFormElement(Locator.id("journalNameTextField"), PANORAMA_PUBLIC);
+        setFormElement(Locator.id("groupNameTextField"), PANORAMA_PUBLIC_GROUP);
+        setFormElement(Locator.id("projectNameTextField"), PANORAMA_PUBLIC);
+        clickButton("Submit", "Journal group details");
+
+        // Add an admin user to the security group associated with the Panorama Public project
+        _userHelper.createUser(ADMIN_USER);
+        ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
+        _permissionsHelper.addUserToProjGroup(ADMIN_USER, PANORAMA_PUBLIC, PANORAMA_PUBLIC_GROUP);
+
+        // Add the Messages webpart
+        goToProjectHome(PANORAMA_PUBLIC);
+        DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
+        assertEquals(0, expListTable.getDataRowCount()); // Table should be empty since we have not yet copied any experiments.
+        portalHelper.addWebPart("Messages");
+    }
+
+    @NotNull
+    TargetedMsExperimentWebPart createTargetedMsExperimentWebPart(String experimentTitle)
+    {
+        goToDashboard();
+        portalHelper.enterAdminMode();
+        portalHelper.addBodyWebPart("Targeted MS Experiment");
+
+        // Create a new experiment
+        TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
+        TargetedMsExperimentInsertPage insertPage = expWebPart.startInsert();
+        insertPage.insert(experimentTitle);
+        return expWebPart;
+    }
+
+    void setupSourceFolder(String projectName, String folderName, String ... adminUsers)
+    {
+        setupSourceFolder(projectName, folderName, FolderType.Experiment, adminUsers);
+    }
+
+    void setupProteinLibraryFolder(String projectName, String folderName, String ... adminUsers)
+    {
+        setupSourceFolder(projectName, folderName, FolderType.LibraryProtein, adminUsers);
+    }
+
+    void setupPeptideLibraryFolder(String projectName, String folderName, String ... adminUsers)
+    {
+        setupSourceFolder(projectName, folderName, FolderType.Library, adminUsers);
+    }
+
+    private void setupSourceFolder(String projectName, String folderName, FolderType folderType, String ... adminUsers)
+    {
+        setupSubfolder(projectName, folderName, folderType); // Create the subfolder
+
+        ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+        for(String user: adminUsers)
+        {
+            _userHelper.deleteUser(user);
+            _userHelper.createUser(user);
+            permissionsHelper.addMemberToRole(user, "Folder Administrator", PermissionsHelper.MemberType.user, projectName + "/" + folderName);
+        }
+    }
+
+    void updateSubmitterAccountInfo(String lastName)
+    {
+        goToMyAccount();
+        clickButton("Edit");
+        setFormElement(Locator.name("quf_FirstName"), "Submitter");
+        setFormElement(Locator.name("quf_LastName"), lastName);
+        clickButton("Submit");
+    }
+
+    void submitWithoutPXId()
+    {
+        clickContinueWithoutPxId();
+        _ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PanoramaPublicTest.PANORAMA_PUBLIC);
+        clickAndWait(Ext4Helper.Locators.ext4Button("Submit"));
+        clickAndWait(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+        clickAndWait(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
+    }
+
+    void clickContinueWithoutPxId()
+    {
+        // Expect to be on the missing information page
+        assertTextPresent("Missing Information in Submission Request");
+        clickAndWait(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
+    }
+
+    void copyExperimentAndVerify(String projectName, String folderName, String experimentTitle, boolean recopy, String destinationFolder)
+    {
+        copyExperimentAndVerify(projectName, folderName, null, experimentTitle, recopy, destinationFolder);
+    }
+
+    void copyExperimentAndVerify(String projectName, String folderName, @Nullable String subfolderName, String experimentTitle, boolean recopy, String destinationFolder)
+    {
+        if(isImpersonating())
+        {
+            stopImpersonating();
+        }
+        goToProjectHome(PANORAMA_PUBLIC);
+        impersonateGroup(PANORAMA_PUBLIC_GROUP, false);
+
+        clickAndWait(Locator.linkContainingText("/" + projectName + "/" + folderName));
+        Locator.XPathLocator copyLink = Locator.linkContainingText("Copy Link");
+        assertNotNull(copyLink);
+        clickAndWait(copyLink);
+
+        // In the copy form's folder tree view select the Panorama Public project as the destination.
+        Locator.tagWithClass("span", "x4-tree-node-text").withText(PANORAMA_PUBLIC).waitForElement(new WebDriverWait(getDriver(), 5)).click();
+        // Enter the name of the destination folder in the Panorama Public project
+        setFormElement(Locator.tagWithName("input", "destContainerName"), destinationFolder);
+        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Send Email to Submitter:"));
+        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Assign Digital Object Identifier:")); // Don't try to assign a DOI
+
+        if(recopy)
+        {
+            assertTextPresent("This experiment was last copied on");
+            Locator.XPathLocator deletePreviousCopyCb = Ext4Helper.Locators.checkbox(this, "Delete Previous Copy:");
+            assertNotNull("Expected to see \"Delete Previous Copy\" checkbox", deletePreviousCopyCb);
+            _ext4Helper.checkCheckbox(deletePreviousCopyCb);
+        }
+        else
+        {
+            setFormElement(Locator.tagWithName("input", "reviewerEmailPrefix"), REVIEWER_PREFIX);
+        }
+
+        // Locator.extButton("Begin Copy"); // Locator.extButton() does not work.
+        click(Ext4Helper.Locators.ext4Button("Begin Copy"));
+
+        // Wait for the pipeline job to finish
+        waitForText("Copying experiment");
+        waitForPipelineJobsToComplete(1, "Copying experiment: " + experimentTitle, false);
+
+        verifyCopy(experimentTitle, projectName, folderName, subfolderName, recopy);
+
+        stopImpersonating();
+    }
+
+    private void verifyCopy(String experimentTitle, String projectName, String folderName, String subfolderName, boolean recopy)
+    {
+        // Verify the copy
+        goToProjectHome(PANORAMA_PUBLIC);
+        DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
+        expListTable.ensureColumnPresent("Title");
+        expListTable.setFilter("Title", "Equals", experimentTitle);
+        // expListTable.setFilter("Share", "Is Not Blank");
+        assertEquals(1, expListTable.getDataRowCount()); // The table should have one row for the copied experiment.
+        expListTable.ensureColumnPresent("Runs");
+        expListTable.ensureColumnPresent("Public"); // Column to indicate if the data is public or not
+        expListTable.ensureColumnPresent("Data License");
+        Assert.assertTrue(expListTable.getDataAsText(0,"Title").contains(experimentTitle));
+        // assertEquals("1", expListTable.getDataAsText(0, "Runs"));
+        assertEquals("No", expListTable.getDataAsText(0, "Public"));
+        assertEquals("CC BY 4.0", expListTable.getDataAsText(0, "Data License"));
+        clickAndWait(expListTable.link(0, "Title"));
+        assertTextPresentInThisOrder("Targeted MS Experiment", // Webpart title
+                experimentTitle, // Title of the experiment
+                "Data License", "CC BY 4.0" // This is the default data license
+        );
+        if(subfolderName != null)
+        {
+            SubfoldersWebPart subfoldersWp = SubfoldersWebPart.getWebPart(getDriver());
+            assertNotNull(subfoldersWp);
+            List<String> subfolderNames = subfoldersWp.GetSubfolderNames();
+            assertEquals(1, subfolderNames.size());
+            assertEquals(subfolderName.toUpperCase(), subfolderNames.get(0));
+        }
+
+        // Verify that notifications got posted on message board
+        goToProjectHome(PANORAMA_PUBLIC);
+        clickAndWait(Locator.linkContainingText("/" + projectName + "/" + folderName));
+        assertTextPresent((recopy ? "RECOPIED": "COPIED") + ": Experiment ID ");
+        assertTextPresent("Email was not sent to submitter");
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        // these tests use the UIContainerHelper for project creation, but we can use the APIContainerHelper for deletion
+        APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
+        apiContainerHelper.deleteProject(PANORAMA_PUBLIC, afterTest);
+
+        super.doCleanup(afterTest);
+    }
+}

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
@@ -1,0 +1,73 @@
+package org.labkey.test.tests.panoramapublic;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.categories.External;
+import org.labkey.test.categories.MacCossLabModules;
+import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
+
+import static org.junit.Assert.assertEquals;
+
+@Category({External.class, MacCossLabModules.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
+public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
+{
+
+    private static final String SKY_FILE1 = "Stergachis-SupplementaryData_2_a.sky.zip";
+    private static final String SKY_FILE2 = "Stergachis-SupplementaryData_2_b.sky.zip";
+
+    @Test
+    public void testLibraryCopy()
+    {
+        // Set up our source folder. We will create an experiment here and submit it to our "Panorama Public" project.
+        String projectName = getProjectName();
+        String folderName = "Protein Library";
+        String experimentTitle = "This is a test experiment";
+        setupProteinLibraryFolder(projectName, folderName, SUBMITTER);
+
+        impersonate(SUBMITTER);
+        updateSubmitterAccountInfo("One");
+
+        importData(SKY_FILE1);
+        importData(SKY_FILE2, 2);
+        // TODO: try to submit a library folder in conflicted state
+        resolveConflicts();
+
+        // Read the state of the library in the source folder
+        ChromLibTestHelper libHelper = new ChromLibTestHelper(this);
+        ChromLibTestHelper.ChromLibState libStateSource = libHelper.getLibState(projectName + "/" + folderName);
+
+        // Add the "Targeted MS Experiment" webpart
+        TargetedMsExperimentWebPart expWebPart = createTargetedMsExperimentWebPart(experimentTitle);
+        submitExperiment(expWebPart);
+
+        // Copy the experiment to the Panorama Public project
+        var targetFolder = "Copy of " + folderName;
+        copyExperimentAndVerify(projectName, folderName, null, experimentTitle, false, targetFolder);
+
+        // Read the state of the library in the Panorama Public folder and compare the states
+        ChromLibTestHelper.ChromLibState libStateTarget = libHelper.getLibState(PANORAMA_PUBLIC + "/" + targetFolder);
+
+        assertEquals(libStateSource, libStateTarget);
+    }
+
+    private void resolveConflicts()
+    {
+        goToDashboard();
+        var resolveConflictsLink = Locator.tagWithClass("div", "labkey-download").descendant(Locator.linkWithText("RESOLVE CONFLICTS"));
+        assertElementPresent(resolveConflictsLink);
+        clickAndWait(resolveConflictsLink);
+        clickButton("Apply Changes");
+    }
+
+    private void submitExperiment(TargetedMsExperimentWebPart expWebPart)
+    {
+        goToDashboard();
+        expWebPart.clickSubmit();
+        submitWithoutPXId();
+        goToDashboard();
+        assertTextPresent("Copy Pending!");
+    }
+}

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
@@ -8,6 +8,9 @@ import org.labkey.test.categories.External;
 import org.labkey.test.categories.MacCossLabModules;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
@@ -15,15 +18,19 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
 
     private static final String SKY_FILE1 = "Stergachis-SupplementaryData_2_a.sky.zip";
     private static final String SKY_FILE2 = "Stergachis-SupplementaryData_2_b.sky.zip";
+    private static final String SMALL_MOL_FILE1 = "SmMolLibA.sky.zip";
+    private static final String SMALL_MOL_FILE2 = "SmMolLibB.sky.zip";
 
     @Test
     public void testProteinLibraryCopy()
     {
         testLibraryCopy("Protein Library", // Name of the source folder
                 FolderType.LibraryProtein, // Library folder type
+                List.of(SKY_FILE1, SKY_FILE2),
                 "Experiment to test Protein library copy", // TargetedMSExperiment title
                 10, // library protein count
                 91, // library peptide count
+                -1, // molecule count
                 597 // library transition count
                 );
     }
@@ -33,14 +40,17 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
     {
         testLibraryCopy("Peptide Library", // Name of the source folder
                 FolderType.Library, // Library folder type
+                List.of(SKY_FILE1, SKY_FILE2, SMALL_MOL_FILE1, SMALL_MOL_FILE2), // Include small molecule data as well
                 "Experiment to test Peptide library copy", // TargetedMSExperiment title
                 -1, // library protein count
                 93, // library peptide count
-                607 // library transition count
+                3, // -1, // molecule count
+                619 // 607 // library transition count
                 );
     }
 
-    private void testLibraryCopy(String folderName, FolderType folderType, String experimentTitle, int proteinCount, int peptideCount,
+    private void testLibraryCopy(String folderName, FolderType folderType, List<String> skyFiles,
+                                 String experimentTitle, int proteinCount, int peptideCount, int moleculeCount,
                                         int transitionCount)
     {
         // Set up our source folder. We will create an experiment here and submit it to our "Panorama Public" project.
@@ -50,19 +60,32 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         impersonate(SUBMITTER);
         updateSubmitterAccountInfo("One");
 
-        importData(SKY_FILE1);
-        importData(SKY_FILE2, 2);
-        // TODO: try to submit a library folder in conflicted state
-        resolveConflicts();
+        // Add the "Targeted MS Experiment" webpart
+        TargetedMsExperimentWebPart expWebPart = createTargetedMsExperimentWebPart(experimentTitle);
+
+        int count = 0;
+        int revision = 0;
+        for(var skyFile: skyFiles)
+        {
+            importData(skyFile, ++count);
+            revision++;
+            if(count == 2)
+            {
+                trySubmitWithConflicts(expWebPart);
+            }
+            if(count > 1 && resolveConflicts())
+            {
+                revision++;
+            };
+        }
         // Download link, library statistics and revision in the ChromatogramLibraryDownloadWebpart
-        verifyChromLibDownloadWebPart(folderType, proteinCount, peptideCount, transitionCount, 3);
+        verifyChromLibDownloadWebPart(folderType, proteinCount, peptideCount, moleculeCount, transitionCount, revision);
 
         // Read the state of the library in the source folder
         ChromLibTestHelper libHelper = new ChromLibTestHelper(this);
         ChromLibTestHelper.ChromLibState libStateSource = libHelper.getLibState(projectName + "/" + folderName);
 
-        // Add the "Targeted MS Experiment" webpart
-        TargetedMsExperimentWebPart expWebPart = createTargetedMsExperimentWebPart(experimentTitle);
+        // Submit the experiment
         submitExperiment(expWebPart);
 
         // Copy the experiment to the Panorama Public project
@@ -70,7 +93,7 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         copyExperimentAndVerify(projectName, folderName, null, experimentTitle, false, targetFolder);
         // Download link, library statistics and revision in the ChromatogramLibraryDownloadWebpart
         goToProjectFolder(PANORAMA_PUBLIC, targetFolder);
-        verifyChromLibDownloadWebPart(folderType, proteinCount, peptideCount, transitionCount, 3);
+        verifyChromLibDownloadWebPart(folderType, proteinCount, peptideCount, moleculeCount, transitionCount, revision);
 
         // Read the state of the library in the Panorama Public folder and compare the states
         ChromLibTestHelper.ChromLibState libStateTarget = libHelper.getLibState(PANORAMA_PUBLIC + "/" + targetFolder);
@@ -78,26 +101,25 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         ChromLibTestHelper.compareLibState(libStateSource, libStateTarget);
     }
 
-    private void verifyChromLibDownloadWebPart(FolderType folderType, int proteinCount, int peptideCount, int transitionCount, int libRevision)
-    {
-        if(folderType == FolderType.LibraryProtein)
-        {
-            verifyProteinChromLibDownloadWebPart(proteinCount, peptideCount, transitionCount, libRevision);
-        }
-
-        else
-        {
-            verifyPeptideChromLibDownloadWebPart(peptideCount, transitionCount, libRevision);
-        }
-    }
-
-    private void resolveConflicts()
+    private boolean resolveConflicts()
     {
         goToDashboard();
         var resolveConflictsLink = Locator.tagWithClass("div", "labkey-download").descendant(Locator.linkWithText("RESOLVE CONFLICTS"));
-        assertElementPresent(resolveConflictsLink);
-        clickAndWait(resolveConflictsLink);
-        clickButton("Apply Changes");
+        if(resolveConflictsLink.findElementOrNull(getDriver()) != null)
+        {
+            // assertElementPresent(resolveConflictsLink);
+            clickAndWait(resolveConflictsLink);
+            clickButton("Apply Changes");
+            return true;
+        }
+        return false;
+    }
+
+    private void trySubmitWithConflicts(TargetedMsExperimentWebPart expWebPart)
+    {
+        goToDashboard();
+        expWebPart.clickSubmit();
+        assertTextPresent("Please resolve the conflicts before submitting");
     }
 
     private void submitExperiment(TargetedMsExperimentWebPart expWebPart)
@@ -109,10 +131,22 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         assertTextPresent("Copy Pending!");
     }
 
+    private void verifyChromLibDownloadWebPart(FolderType folderType, int proteinCount, int peptideCount, int moleculeCount, int transitionCount, int libRevision)
+    {
+        if(folderType == FolderType.LibraryProtein)
+        {
+            verifyProteinChromLibDownloadWebPart(proteinCount, peptideCount, transitionCount, libRevision);
+        }
+
+        else
+        {
+            verifyPeptideChromLibDownloadWebPart(peptideCount, moleculeCount, transitionCount, libRevision);
+        }
+    }
+
     private void verifyProteinChromLibDownloadWebPart(int proteinCount, int peptideCount, int transitionCount, int revision)
     {
         goToDashboard();
-        // clickAndWait(Locator.linkContainingText("Panorama Dashboard"));
         assertElementPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
         assertTextPresent(
                 proteinCount + " proteins", peptideCount + " ranked peptides",
@@ -121,14 +155,15 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         assertTextPresent("Revision " + revision);
     }
 
-    private void verifyPeptideChromLibDownloadWebPart(int peptideCount, int transitionCount, int revision)
+    private void verifyPeptideChromLibDownloadWebPart(int peptideCount, int moleculeCount, int transitionCount, int revision)
     {
         goToDashboard();
-        // clickAndWait(Locator.linkContainingText("Panorama Dashboard"));
         assertElementPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
-        assertTextPresent(
-                peptideCount + " peptides",
-                transitionCount + " ranked transitions");
+        List<String> texts = new ArrayList<>();
+        if(peptideCount > 0) texts.add(peptideCount + " peptides");
+        if(moleculeCount > 0) texts.add(moleculeCount + " molecules");
+        texts.add(transitionCount + " ranked transitions");
+        assertTextPresent(texts);
         assertElementPresent(Locator.lkButton("Download"));
         assertTextPresent("Revision " + revision);
     }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
@@ -8,8 +8,6 @@ import org.labkey.test.categories.External;
 import org.labkey.test.categories.MacCossLabModules;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
 
-import static org.junit.Assert.assertEquals;
-
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
@@ -19,13 +17,35 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
     private static final String SKY_FILE2 = "Stergachis-SupplementaryData_2_b.sky.zip";
 
     @Test
-    public void testLibraryCopy()
+    public void testProteinLibraryCopy()
+    {
+        testLibraryCopy("Protein Library", // Name of the source folder
+                FolderType.LibraryProtein, // Library folder type
+                "Experiment to test Protein library copy", // TargetedMSExperiment title
+                10, // library protein count
+                91, // library peptide count
+                597 // library transition count
+                );
+    }
+
+    @Test
+    public void testPeptideLibraryCopy()
+    {
+        testLibraryCopy("Peptide Library", // Name of the source folder
+                FolderType.Library, // Library folder type
+                "Experiment to test Peptide library copy", // TargetedMSExperiment title
+                -1, // library protein count
+                93, // library peptide count
+                607 // library transition count
+                );
+    }
+
+    private void testLibraryCopy(String folderName, FolderType folderType, String experimentTitle, int proteinCount, int peptideCount,
+                                        int transitionCount)
     {
         // Set up our source folder. We will create an experiment here and submit it to our "Panorama Public" project.
         String projectName = getProjectName();
-        String folderName = "Protein Library";
-        String experimentTitle = "This is a test experiment";
-        setupProteinLibraryFolder(projectName, folderName, SUBMITTER);
+        setupLibraryFolder(projectName, folderName, folderType, SUBMITTER);
 
         impersonate(SUBMITTER);
         updateSubmitterAccountInfo("One");
@@ -34,6 +54,8 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         importData(SKY_FILE2, 2);
         // TODO: try to submit a library folder in conflicted state
         resolveConflicts();
+        // Download link, library statistics and revision in the ChromatogramLibraryDownloadWebpart
+        verifyChromLibDownloadWebPart(folderType, proteinCount, peptideCount, transitionCount, 3);
 
         // Read the state of the library in the source folder
         ChromLibTestHelper libHelper = new ChromLibTestHelper(this);
@@ -46,11 +68,27 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         // Copy the experiment to the Panorama Public project
         var targetFolder = "Copy of " + folderName;
         copyExperimentAndVerify(projectName, folderName, null, experimentTitle, false, targetFolder);
+        // Download link, library statistics and revision in the ChromatogramLibraryDownloadWebpart
+        goToProjectFolder(PANORAMA_PUBLIC, targetFolder);
+        verifyChromLibDownloadWebPart(folderType, proteinCount, peptideCount, transitionCount, 3);
 
         // Read the state of the library in the Panorama Public folder and compare the states
         ChromLibTestHelper.ChromLibState libStateTarget = libHelper.getLibState(PANORAMA_PUBLIC + "/" + targetFolder);
 
-        assertEquals(libStateSource, libStateTarget);
+        ChromLibTestHelper.compareLibState(libStateSource, libStateTarget);
+    }
+
+    private void verifyChromLibDownloadWebPart(FolderType folderType, int proteinCount, int peptideCount, int transitionCount, int libRevision)
+    {
+        if(folderType == FolderType.LibraryProtein)
+        {
+            verifyProteinChromLibDownloadWebPart(proteinCount, peptideCount, transitionCount, libRevision);
+        }
+
+        else
+        {
+            verifyPeptideChromLibDownloadWebPart(peptideCount, transitionCount, libRevision);
+        }
     }
 
     private void resolveConflicts()
@@ -69,5 +107,29 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         submitWithoutPXId();
         goToDashboard();
         assertTextPresent("Copy Pending!");
+    }
+
+    private void verifyProteinChromLibDownloadWebPart(int proteinCount, int peptideCount, int transitionCount, int revision)
+    {
+        goToDashboard();
+        // clickAndWait(Locator.linkContainingText("Panorama Dashboard"));
+        assertElementPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
+        assertTextPresent(
+                proteinCount + " proteins", peptideCount + " ranked peptides",
+                transitionCount + " ranked transitions");
+        assertElementPresent(Locator.lkButton("Download"));
+        assertTextPresent("Revision " + revision);
+    }
+
+    private void verifyPeptideChromLibDownloadWebPart(int peptideCount, int transitionCount, int revision)
+    {
+        goToDashboard();
+        // clickAndWait(Locator.linkContainingText("Panorama Dashboard"));
+        assertElementPresent(Locator.xpath("//img[contains(@src, 'graphLibraryStatistics.view')]"));
+        assertTextPresent(
+                peptideCount + " peptides",
+                transitionCount + " ranked transitions");
+        assertElementPresent(Locator.lkButton("Download"));
+        assertTextPresent("Revision " + revision);
     }
 }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicChromLibTest.java
@@ -44,8 +44,8 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
                 "Experiment to test Peptide library copy", // TargetedMSExperiment title
                 -1, // library protein count
                 93, // library peptide count
-                3, // -1, // molecule count
-                619 // 607 // library transition count
+                3, // molecule count
+                619 // library transition count
                 );
     }
 
@@ -71,12 +71,15 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
             revision++;
             if(count == 2)
             {
+                // After uploading the second Skyline document there should be a library conflict.  User should not be
+                // able to submit a library folder in a conflicted state.
                 trySubmitWithConflicts(expWebPart);
             }
             if(count > 1 && resolveConflicts())
             {
+                // Library revision is incremented after conflicts are resolved.
                 revision++;
-            };
+            }
         }
         // Download link, library statistics and revision in the ChromatogramLibraryDownloadWebpart
         verifyChromLibDownloadWebPart(folderType, proteinCount, peptideCount, moleculeCount, transitionCount, revision);
@@ -107,7 +110,6 @@ public class PanoramaPublicChromLibTest extends PanoramaPublicBaseTest
         var resolveConflictsLink = Locator.tagWithClass("div", "labkey-download").descendant(Locator.linkWithText("RESOLVE CONFLICTS"));
         if(resolveConflictsLink.findElementOrNull(getDriver()) != null)
         {
-            // assertElementPresent(resolveConflictsLink);
             clickAndWait(resolveConflictsLink);
             clickButton("Apply Changes");
             return true;

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -1,9 +1,5 @@
 package org.labkey.test.tests.panoramapublic;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
@@ -12,85 +8,28 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.categories.External;
 import org.labkey.test.categories.MacCossLabModules;
-import org.labkey.test.components.BodyWebPart;
-import org.labkey.test.components.SubfoldersWebPart;
-import org.labkey.test.pages.InsertPage;
-import org.labkey.test.tests.targetedms.TargetedMSTest;
-import org.labkey.test.util.APIContainerHelper;
+import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
 import org.labkey.test.util.ApiPermissionsHelper;
-import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PermissionsHelper;
 import org.labkey.test.util.PortalHelper;
-import org.labkey.test.util.PostgresOnlyTest;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.File;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
-public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTest
+public class PanoramaPublicTest extends PanoramaPublicBaseTest
 {
     private static final String SKY_FILE_1 = "Study9S_Site52_v1.sky.zip";
     private static final String RAW_FILE_WIFF = "Site52_041009_Study9S_Phase-I.wiff";
     private static final String RAW_FILE_WIFF_SCAN = RAW_FILE_WIFF + ".scan";
 
-    private static String PANORAMA_PUBLIC = "Panorama Public " + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
-    private static final String PANORAMA_PUBLIC_GROUP = "panoramapublictest";
-
-    private static final String ADMIN_USER = "admin@panoramapublic.test";
-    private static final String SUBMITTER = "submitter@panoramapublic.test";
     private static final String SUBMITTER_2 = "submitter_2@panoramapublic.test";
-    private static final String REVIEWER_PREFIX = "panoramapublictest_reviewer";
 
     private static final String INCLUDE_SUBFOLDERS_AND_SUBMIT = "Include Subfolders And Continue";
     private static final String EXCLUDE_SUBFOLDERS_AND_SUBMIT = "Skip Subfolders And Continue";
-
-    PortalHelper portalHelper = new PortalHelper(this);
-
-    @Override
-    protected String getProjectName()
-    {
-        return getClass().getSimpleName() + " Project " + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
-    }
-
-    @BeforeClass
-    public static void initProject()
-    {
-        PanoramaPublicTest init = (PanoramaPublicTest)getCurrentTest();
-        init.createPanoramaPublicJournalProject();
-
-        // Create the test project
-        init.setupFolder(FolderType.Experiment);
-    }
-
-    private void createPanoramaPublicJournalProject()
-    {
-        // Create a "Panorama Public" project where we will copy data.
-        goToAdminConsole().goToSettingsSection();
-        clickAndWait(Locator.linkWithText("Panorama Public"));
-        clickAndWait(Locator.linkWithText("Create a new journal group"));
-        setFormElement(Locator.id("journalNameTextField"), PANORAMA_PUBLIC);
-        setFormElement(Locator.id("groupNameTextField"), PANORAMA_PUBLIC_GROUP);
-        setFormElement(Locator.id("projectNameTextField"), PANORAMA_PUBLIC);
-        clickButton("Submit", "Journal group details");
-
-        // Add an admin user to the security group associated with the Panorama Public project
-        _userHelper.createUser(ADMIN_USER);
-        ApiPermissionsHelper _permissionsHelper = new ApiPermissionsHelper(this);
-        _permissionsHelper.addUserToProjGroup(ADMIN_USER, PANORAMA_PUBLIC, PANORAMA_PUBLIC_GROUP);
-
-        // Add the Messages webpart
-        goToProjectHome(PANORAMA_PUBLIC);
-        DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
-        assertEquals(0, expListTable.getDataRowCount()); // Table should be empty since we have not yet copied any experiments.
-        portalHelper.addWebPart("Messages");
-    }
 
     protected File getSampleDataPath(String file)
     {
@@ -189,107 +128,6 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         assertElementPresent(Locator.linkWithText("Exclude Subfolders"));
     }
 
-    @NotNull
-    private PanoramaPublicTest.TargetedMsExperimentWebPart createTargetedMsExperimentWebPart(String experimentTitle)
-    {
-        goToDashboard();
-        portalHelper.enterAdminMode();
-        portalHelper.addBodyWebPart("Targeted MS Experiment");
-
-        // Create a new experiment
-        TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
-        TargetedMsExperimentInsertPage insertPage = expWebPart.startInsert();
-        insertPage.insert(experimentTitle);
-        return expWebPart;
-    }
-
-    private void verifyCopy(String experimentTitle, String projectName, String folderName, String subfolderName, boolean recopy)
-    {
-        // Verify the copy
-        goToProjectHome(PANORAMA_PUBLIC);
-        DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
-        expListTable.ensureColumnPresent("Title");
-        expListTable.setFilter("Title", "Equals", experimentTitle);
-        // expListTable.setFilter("Share", "Is Not Blank");
-        assertEquals(1, expListTable.getDataRowCount()); // The table should have one row for the copied experiment.
-        expListTable.ensureColumnPresent("Runs");
-        expListTable.ensureColumnPresent("Public"); // Column to indicate if the data is public or not
-        expListTable.ensureColumnPresent("Data License");
-        Assert.assertTrue(expListTable.getDataAsText(0,"Title").contains(experimentTitle));
-        assertEquals("1", expListTable.getDataAsText(0, "Runs"));
-        assertEquals("No", expListTable.getDataAsText(0, "Public"));
-        assertEquals("CC BY 4.0", expListTable.getDataAsText(0, "Data License"));
-        clickAndWait(expListTable.link(0, "Title"));
-        assertTextPresentInThisOrder("Targeted MS Experiment", // Webpart title
-                experimentTitle, // Title of the experiment
-                "Data License", "CC BY 4.0" // This is the default data license
-        );
-        if(subfolderName != null)
-        {
-            SubfoldersWebPart subfoldersWp = SubfoldersWebPart.getWebPart(getDriver());
-            assertNotNull(subfoldersWp);
-            List<String> subfolderNames = subfoldersWp.GetSubfolderNames();
-            assertEquals(1, subfolderNames.size());
-            assertEquals(subfolderName.toUpperCase(), subfolderNames.get(0));
-        }
-
-        // Verify that notifications got posted on message board
-        goToProjectHome(PANORAMA_PUBLIC);
-        clickAndWait(Locator.linkContainingText("/" + projectName + "/" + folderName));
-        assertTextPresent((recopy ? "RECOPIED": "COPIED") + ": Experiment ID ");
-        assertTextPresent("Email was not sent to submitter");
-    }
-
-    private void copyExperimentAndVerify(String projectName, String folderName, String experimentTitle, boolean recopy, String destinationFolder)
-    {
-        copyExperimentAndVerify(projectName, folderName, null, experimentTitle, recopy, destinationFolder);
-    }
-
-    private void copyExperimentAndVerify(String projectName, String folderName, @Nullable String subfolderName, String experimentTitle, boolean recopy, String destinationFolder)
-    {
-        if(isImpersonating())
-        {
-            stopImpersonating();
-        }
-        goToProjectHome(PANORAMA_PUBLIC);
-        impersonateGroup(PANORAMA_PUBLIC_GROUP, false);
-
-        clickAndWait(Locator.linkContainingText("/" + projectName + "/" + folderName));
-        Locator.XPathLocator copyLink = Locator.linkContainingText("Copy Link");
-        assertNotNull(copyLink);
-        clickAndWait(copyLink);
-
-        // In the copy form's folder tree view select the Panorama Public project as the destination.
-        Locator.tagWithClass("span", "x4-tree-node-text").withText(PANORAMA_PUBLIC).waitForElement(new WebDriverWait(getDriver(), 5)).click();
-        // Enter the name of the destination folder in the Panorama Public project
-        setFormElement(Locator.tagWithName("input", "destContainerName"), destinationFolder);
-        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Send Email to Submitter:"));
-        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Assign Digital Object Identifier:")); // Don't try to assign a DOI
-
-        if(recopy)
-        {
-            assertTextPresent("This experiment was last copied on");
-            Locator.XPathLocator deletePreviousCopyCb = Ext4Helper.Locators.checkbox(this, "Delete Previous Copy:");
-            assertNotNull("Expected to see \"Delete Previous Copy\" checkbox", deletePreviousCopyCb);
-            _ext4Helper.checkCheckbox(deletePreviousCopyCb);
-        }
-        else
-        {
-            setFormElement(Locator.tagWithName("input", "reviewerEmailPrefix"), REVIEWER_PREFIX);
-        }
-
-        // Locator.extButton("Begin Copy"); // Locator.extButton() does not work.
-        click(Ext4Helper.Locators.ext4Button("Begin Copy"));
-
-        // Wait for the pipeline job to finish
-        waitForText("Copying experiment");
-        waitForPipelineJobsToComplete(1, "Copying experiment: " + experimentTitle, false);
-
-        verifyCopy(experimentTitle, projectName, folderName, subfolderName, recopy);
-
-        stopImpersonating();
-    }
-
     protected void setupSourceFolder(String projectName, String folderName, String ... adminUsers)
     {
         setupSubfolder(projectName, folderName, FolderType.Experiment); // Create the subfolder
@@ -308,15 +146,6 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         goToDashboard();
         expWebPart.clickSubmit();
         assertTextPresent("First and last names missing for data submitter: " + SUBMITTER);
-    }
-
-    private void updateSubmitterAccountInfo(String lastName)
-    {
-        goToMyAccount();
-        clickButton("Edit");
-        setFormElement(Locator.name("quf_FirstName"), "Submitter");
-        setFormElement(Locator.name("quf_LastName"), lastName);
-        clickButton("Submit");
     }
 
     private void testSubmitWithNoSkyDocs(TargetedMsExperimentWebPart expWebPart)
@@ -365,15 +194,6 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         assertTextPresent("Copy Pending!");
     }
 
-    public void submitWithoutPXId()
-    {
-        clickContinueWithoutPxId();
-        _ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithInputNamed("journalId"), PanoramaPublicTest.PANORAMA_PUBLIC);
-        clickAndWait(Ext4Helper.Locators.ext4Button("Submit"));
-        clickAndWait(Locator.lkButton("OK")); // Confirm to proceed with the submission.
-        clickAndWait(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
-    }
-
     public void resubmitWithoutPxd()
     {
         clickContinueWithoutPxId();
@@ -385,104 +205,14 @@ public class PanoramaPublicTest extends TargetedMSTest implements PostgresOnlyTe
         click(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
     }
 
-    private void clickContinueWithoutPxId()
-    {
-        // Expect to be on the missing information page
-        assertTextPresent("Missing Information in Submission Request");
-        clickAndWait(Locator.linkContainingText("Continue without a ProteomeXchange ID"));
-    }
-
     @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
-        // these tests use the UIContainerHelper for project creation, but we can use the APIContainerHelper for deletion
-        APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
-        apiContainerHelper.deleteProject(PANORAMA_PUBLIC, afterTest);
-
         _userHelper.deleteUsers(false,ADMIN_USER, SUBMITTER, SUBMITTER_2,
                 // Delete the two reviewer accounts created when experiments are copied to the Panorama Public project
                 REVIEWER_PREFIX + "@proteinms.net",
                 REVIEWER_PREFIX + "1@proteinms.net");
 
         super.doCleanup(afterTest);
-    }
-
-    private class TargetedMsExperimentWebPart extends BodyWebPart
-    {
-        public static final String DEFAULT_TITLE = "Targeted MS Experiment";
-        private DataRegionTable _dataRegionTable;
-        private BaseWebDriverTest _test;
-
-        public TargetedMsExperimentWebPart(BaseWebDriverTest test)
-        {
-            this(test, 0);
-        }
-
-        public TargetedMsExperimentWebPart(BaseWebDriverTest test, int index)
-        {
-            super(test.getDriver(), DEFAULT_TITLE, index);
-            _test = test;
-        }
-
-        public DataRegionTable getDataRegion()
-        {
-            if (_dataRegionTable == null)
-                _dataRegionTable = DataRegionTable.DataRegion(_test.getDriver()).find(getComponentElement());
-            return _dataRegionTable;
-        }
-
-        public TargetedMsExperimentInsertPage startInsert()
-        {
-            findElement(Locator.linkContainingText("Create New Experiment")).click();
-            return new TargetedMsExperimentInsertPage(_test.getDriver());
-        }
-
-        public void clickSubmit()
-        {
-            clickAndWait(Locator.linkContainingText("Submit"));
-        }
-
-        public void clickResubmit()
-        {
-            Locator.XPathLocator resubmitLink = Locator.linkContainingText("Resubmit");
-            assertNotNull("Expected to see a \"Resubmit\" button", resubmitLink);
-            clickAndWait(resubmitLink);
-        }
-    }
-
-    private static class TargetedMsExperimentInsertPage extends InsertPage
-    {
-        private static final String DEFAULT_TITLE = "Targeted MS Experiment";
-
-        public TargetedMsExperimentInsertPage(WebDriver driver)
-        {
-            super(driver, DEFAULT_TITLE);
-        }
-
-        @Override
-        protected void waitForReady()
-        {
-            waitForElement(elements().expTitle);
-        }
-
-        public void insert(String experimentTitle)
-        {
-            Elements elements = elements();
-            setFormElement(elements.expTitle, experimentTitle);
-            setFormElement(elements.expAbstract, "This is a really short, 50 character long abstract");
-            clickAndWait(elements.submit);
-        }
-
-        @Override
-        protected Elements elements()
-        {
-            return new Elements();
-        }
-
-        private class Elements extends InsertPage.Elements
-        {
-            public Locator.XPathLocator expTitle = body.append(Locator.tagWithName("textarea", "title"));
-            public Locator.XPathLocator expAbstract = body.append(Locator.tagWithName("textarea", "abstract"));
-        }
     }
 }

--- a/panoramapublic/webapp/WEB-INF/panoramapublic/panoramapublicContext.xml
+++ b/panoramapublic/webapp/WEB-INF/panoramapublic/panoramapublicContext.xml
@@ -12,6 +12,9 @@
                 <bean class="org.labkey.panoramapublic.pipeline.ExperimentImportTask$Factory">
                     <property name="location" value="webserver" />
                 </bean>
+                <bean class="org.labkey.panoramapublic.pipeline.UpdateFolderTypeTask$Factory">
+                    <property name="location" value="webserver" />
+                </bean>
                 <bean class="org.labkey.panoramapublic.pipeline.CopyExperimentFinalTask$Factory">
                     <property name="location" value="webserver" />
                 </bean>
@@ -29,6 +32,9 @@
                             </bean>
                             <bean id="importTask" class="org.labkey.api.pipeline.TaskId">
                                 <constructor-arg><value type="java.lang.Class">org.labkey.panoramapublic.pipeline.ExperimentImportTask</value></constructor-arg>
+                            </bean>
+                            <bean id="updateFolderTypeTask" class="org.labkey.api.pipeline.TaskId">
+                                <constructor-arg><value type="java.lang.Class">org.labkey.panoramapublic.pipeline.UpdateFolderTypeTask</value></constructor-arg>
                             </bean>
                             <bean id="finalTask" class="org.labkey.api.pipeline.TaskId">
                                 <constructor-arg><value type="java.lang.Class">org.labkey.panoramapublic.pipeline.CopyExperimentFinalTask</value></constructor-arg>


### PR DESCRIPTION
#### Rationale
Panorama Public currently only supports experimental data folders. Add support for submitting and copying chromatogram library folders.

#### Changes
- Added UpdateFolderTypeTask to the panoramapublic pipeline that will copy the library state of runs, peptide groups, and precursors from the source library folder.
- Library state of entities in the source folder is exported as a tab-separated file to '@files/targetedMSLib' in the target folder.  Library state of entities in the target folder are updated using this file
- Add a folder property in the target folder with the chromatogram library revision
- Rename the copied .clib files with the target container rowId so that they are recognized in the target container
- Added tests


