### PR TITLE
Issue 43753: Removing '?' in LabKey URLs breaks organism auto completion

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -519,8 +519,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
         public AutoCompleteColumn(ColumnInfo col, ActionURL autocompletionUrl, boolean prefetch, String placeHolderText)
         {
             super(col);
-            _autoCompletionUrl = autocompletionUrl.getLocalURIString() + (!prefetch ? "token=%QUERY" : "");
-            _autoCompletionUrl = PageFlowUtil.jsString(_autoCompletionUrl);
+            _autoCompletionUrl = PageFlowUtil.jsString(prefetch ? autocompletionUrl: autocompletionUrl.addParameter("token", "__QUERY__"));
             _prefetch = prefetch;
             _placeholderText = placeHolderText;
         }

--- a/panoramapublic/webapp/PanoramaPublic/js/ExpAnnotAutoComplete.js
+++ b/panoramapublic/webapp/PanoramaPublic/js/ExpAnnotAutoComplete.js
@@ -60,7 +60,7 @@ function createStore(url, prefetch)
             local: localOrgStore,
             remote: {
                 url: url,
-                wildcard: '%QUERY',
+                wildcard: '__QUERY__',
                 transform: function (response) {
                     // console.log(response.completions);
                     return response.completions;


### PR DESCRIPTION
#### Rationale
Turning on the experimental feature 'No Question Marks in URLs' breaks the organism auto completion form field in the "Targeted MS Experiment" form.

#### Changes
Use ActionURL's addParameter() method instead of String concatenating the query parameter to the URL.
