### PR TITLE
Remove catch for exception that's no longer thrown

### DIFF
--- a/lincs/src/org/labkey/lincs/cromwell/CromwellGctTask.java
+++ b/lincs/src/org/labkey/lincs/cromwell/CromwellGctTask.java
@@ -82,10 +82,6 @@ public class CromwellGctTask extends PipelineJob.Task<CromwellGctTask.Factory>
             {
                 submitJob(cromwellConfig, assayType, run, session.getApiKey(), log);
             }
-            catch (IOException e)
-            {
-                throw new PipelineJobException(e);
-            }
         }
         else
         {


### PR DESCRIPTION
#### Rationale
Related PR is no longer declaring that an IOException is thrown

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2689

#### Changes
* Remove the catch