### PR TITLE
Allow users to make their data public

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.commons.validator.routines.UrlValidator;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -101,6 +100,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.security.roles.ProjectAdminRole;
+import org.labkey.api.security.roles.ReaderRole;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.Button;
 import org.labkey.api.util.DOM;
@@ -109,8 +109,10 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.util.Pair;
 import org.labkey.api.util.TestContext;
 import org.labkey.api.util.URLHelper;
+import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.*;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.panoramapublic.chromlib.ChromLibStateManager;
@@ -162,10 +164,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.labkey.api.targetedms.TargetedMSService.FolderType.*;
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.Experiment;
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.Library;
+import static org.labkey.api.targetedms.TargetedMSService.FolderType.LibraryProtein;
+import static org.labkey.api.targetedms.TargetedMSService.RAW_FILES_TAB;
 import static org.labkey.api.util.DOM.Attribute.action;
 import static org.labkey.api.util.DOM.Attribute.method;
 import static org.labkey.api.util.DOM.Attribute.name;
@@ -184,6 +190,7 @@ import static org.labkey.api.util.DOM.UL;
 import static org.labkey.api.util.DOM.at;
 import static org.labkey.api.util.DOM.cl;
 import static org.labkey.api.util.DOM.createHtmlFragment;
+import static org.labkey.panoramapublic.proteomexchange.NcbiUtils.PUBMED_ID;
 
 /**
  * User: vsharma
@@ -195,14 +202,14 @@ public class PanoramaPublicController extends SpringActionController
     private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(PanoramaPublicController.class);
     public static final String NAME = "panoramapublic";
     public static final String PANORAMA_REVIEWER_PREFIX = "panorama+reviewer";
-    public static final String PUBMED_ID = "^[0-9]{1,8}$"; // https://libguides.library.arizona.edu/c.php?g=406096&p=2779570
+
 
     public PanoramaPublicController()
     {
         setActionResolver(_actionResolver);
     }
 
-    private static final Logger LOG = LogManager.getLogger(PanoramaPublicController.class);
+    private static final Logger LOG = LogHelper.getLogger(PanoramaPublicController.class, "PanoramaPublicController requests");
 
     // ------------------------------------------------------------------------
     // BEGIN Actions for journal groups.
@@ -532,6 +539,12 @@ public class PanoramaPublicController extends SpringActionController
                 changeSupportContainerButton.setActionType(ActionButton.Action.GET);
                 changeSupportContainerButton.setPrimary(false);
                 buttonBar.add(changeSupportContainerButton);
+
+                ActionURL addPublicDataUserUrl = new ActionURL(AddPublicDataUserAction.class, getContainer());
+                ActionButton addPublicDataUserButton = new ActionButton(addPublicDataUserUrl, "Add Public Data User");
+                addPublicDataUserButton.setActionType(ActionButton.Action.GET);
+                addPublicDataUserButton.setPrimary(false);
+                buttonBar.add(addPublicDataUserButton);
             }
             journalDetails.setButtonBar(buttonBar);
 
@@ -722,6 +735,138 @@ public class PanoramaPublicController extends SpringActionController
                 return ContainerService.get().getForPath(_supportContainerPath);
             }
             return null;
+        }
+    }
+
+    /*
+    Set the user account that can be used to download public datasets on Panorama Public with a WebDAV client such as
+    Cyberduck, or by mapping a network drive in Windows. Anonymous downloads do not work with WebDAV.
+     */
+    @RequiresPermission(AdminOperationsPermission.class)
+    public static class AddPublicDataUserAction extends FormViewAction<PublicDataUseForm>
+    {
+        private Journal _journal;
+        @Override
+        public void validateCommand(PublicDataUseForm form, Errors errors)
+        {
+            _journal = form.lookupJournal();
+            if (_journal == null)
+            {
+                errors.reject(ERROR_MSG, "No journal found for journal Id " + form.getId());
+            }
+            if (StringUtils.isBlank(form.getUserEmail()))
+            {
+                errors.reject(ERROR_MSG, "User email cannot be blank");
+            }
+            if (StringUtils.isBlank(form.getUserPassword()))
+            {
+                errors.reject(ERROR_MSG, "User password cannot be blank");
+            }
+        }
+
+        @Override
+        public ModelAndView getView(PublicDataUseForm form, boolean reshow, BindException errors)
+        {
+            if (!reshow)
+            {
+                _journal = form.lookupJournal();
+                if (_journal == null)
+                {
+                    errors.reject(ERROR_MSG, "No journal found for journal Id " + form.getId());
+                    return new SimpleErrorView(errors);
+                }
+                JournalManager.PublicDataUser publicDataUser = JournalManager.getPublicDataUser(_journal);
+                if (publicDataUser != null)
+                {
+                    form.setUserEmail(publicDataUser.getEmail());
+                }
+            }
+
+            HtmlView view = new HtmlView(
+                    DIV(
+                            ERRORS(errors),
+                            "Enter the email address for the user account that can be used to download public datasets in a WebDAV client",
+                            FORM(at(method, "POST", action, new ActionURL(AddPublicDataUserAction.class, getContainer()).addParameter("id", _journal.getId())),
+                                    SPAN(cl("labkey-form-label"), "User Email Address"),
+                                    INPUT(at(type, "Text", name, "userEmail", value, form.getUserEmail())),
+                                    BR(),
+                                    SPAN(cl("labkey-form-label"), "User Password"),
+                                    INPUT(at(type, "Text", name, "userPassword", value, "")),
+                                    BR(),
+                                    new Button.ButtonBuilder("Save").submit(true).build(),
+                                    new Button.ButtonBuilder("Cancel").submit(false).href(getJournalGroupDetailsUrl(_journal.getId(), getContainer())).build()
+                            )
+                    )
+            );
+            view.setTitle("Add Public Data User");
+            view.setFrame(WebPartView.FrameType.PORTAL);
+            return view;
+        }
+
+        @Override
+        public boolean handlePost(PublicDataUseForm form, BindException errors)
+        {
+            ValidEmail validEmail;
+            try
+            {
+                validEmail = new ValidEmail(form.getUserEmail());
+            }
+            catch (ValidEmail.InvalidEmailException e)
+            {
+                errors.reject(ERROR_MSG, "Invalid email address");
+                return false;
+            }
+            User user = UserManager.getUser(validEmail);
+            if (user == null)
+            {
+                errors.reject(ERROR_MSG, "User with given email address does not exist");
+                return false;
+            }
+            if (!SecurityManager.matchPassword(form.getUserPassword(), SecurityManager.getPasswordHash(validEmail)))
+            {
+                errors.reject(ERROR_MSG, "Incorrect password for " + user.getEmail());
+                return false;
+            }
+            JournalManager.savePublicDataUser(_journal, user, form.getUserPassword());
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(PublicDataUseForm form)
+        {
+            return getJournalGroupDetailsUrl(form.getId(), getContainer());
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            root.addChild("Configure Public Data User");
+        }
+    }
+
+    public static class PublicDataUseForm extends JournalForm
+    {
+        private String _userEmail;
+        private String _userPassword;
+
+        public String getUserEmail()
+        {
+            return _userEmail;
+        }
+
+        public void setUserEmail(String userEmail)
+        {
+            _userEmail = userEmail;
+        }
+
+        public String getUserPassword()
+        {
+            return _userPassword;
+        }
+
+        public void setUserPassword(String userPassword)
+        {
+            _userPassword = userPassword;
         }
     }
 
@@ -4343,15 +4488,15 @@ public class PanoramaPublicController extends SpringActionController
 
     public static class ExperimentAnnotationsDetails
     {
-        private ExperimentAnnotations _experimentAnnotations;
+        private final ExperimentAnnotations _experimentAnnotations;
         private JournalSubmission _lastPublishedRecord;
-        private boolean _fullDetails = false;
-        private boolean _canPublish = false;
+        private final boolean _fullDetails;
+        private boolean _canPublish;
         private String _version;
-        private boolean _isCurrentVersion = false;
+        private boolean _isCurrentVersion;
         private ActionURL _versionsUrl;
+        private ExperimentAnnotations _journalCopy;
 
-        public ExperimentAnnotationsDetails(){}
         public ExperimentAnnotationsDetails(User user, ExperimentAnnotations exptAnnotations, boolean fullDetails)
         {
             _experimentAnnotations = exptAnnotations;
@@ -4368,6 +4513,11 @@ public class PanoramaPublicController extends SpringActionController
                 // 2. AND this is a NOT journal copy (i.e. a folder in the Panorama Public project)
                 // 3. AND if this experiment has been copied to Panorama Public, the copy is not final (paper published and data public).
                 _canPublish = c.hasPermission(user, AdminPermission.class) && (ExperimentAnnotationsManager.canSubmitExperiment(_experimentAnnotations, _lastPublishedRecord));
+                if (_lastPublishedRecord != null)
+                {
+                    Submission lastCopiedSubmission = _lastPublishedRecord.getLatestCopiedSubmission();
+                    _journalCopy = lastCopiedSubmission != null ? ExperimentAnnotationsManager.get(lastCopiedSubmission.getCopiedExperimentId()) : null;
+                }
             }
 
             if (_experimentAnnotations.isJournalCopy() && _experimentAnnotations.getSourceExperimentId() != null)
@@ -4399,19 +4549,9 @@ public class PanoramaPublicController extends SpringActionController
             return _experimentAnnotations;
         }
 
-        public void setExperimentAnnotations(ExperimentAnnotations experimentAnnotations)
-        {
-            _experimentAnnotations = experimentAnnotations;
-        }
-
         public boolean isFullDetails()
         {
             return _fullDetails;
-        }
-
-        public void setFullDetails(boolean fullDetails)
-        {
-            _fullDetails = fullDetails;
         }
 
         public boolean isCanPublish()
@@ -4419,19 +4559,9 @@ public class PanoramaPublicController extends SpringActionController
             return _canPublish;
         }
 
-        public void setCanPublish(boolean canPublish)
-        {
-            _canPublish = canPublish;
-        }
-
         public JournalSubmission getLastPublishedRecord()
         {
             return _lastPublishedRecord;
-        }
-
-        public void setLastPublishedRecord(JournalSubmission lastPublishedRecord)
-        {
-            _lastPublishedRecord = lastPublishedRecord;
         }
 
         public boolean hasVersion()
@@ -4457,6 +4587,26 @@ public class PanoramaPublicController extends SpringActionController
         public boolean isCurrentVersion()
         {
             return _isCurrentVersion;
+        }
+
+        public boolean canAddPublishLink(User user)
+        {
+           return _experimentAnnotations.getContainer().hasPermission(user, AdminPermission.class)
+                && _lastPublishedRecord != null && !_lastPublishedRecord.hasPendingSubmission() // There is no pending submission request
+                && _journalCopy != null // There exists a copy of the data on Panorama Public
+                && !(_journalCopy.isPublic() && _journalCopy.hasCompletePublicationInfo());  // The copy is not already public with a PubMed Id
+        }
+
+        public String getPublishButtonText()
+        {
+            if (_journalCopy != null)
+            {
+                return !_journalCopy.isPublic()       ? "Make Public" :
+                       !_journalCopy.isPublished()    ? "Add Publication" :
+                       !_journalCopy.isPeerReviewed() ? "Edit Publication" :
+                       !_journalCopy.hasPubmedId()    ? "Add PubMed ID" : "";
+            }
+            return "";
         }
     }
 
@@ -4987,6 +5137,464 @@ public class PanoramaPublicController extends SpringActionController
                     webPart.setProperty(FilesWebPart.FILE_ROOT_PROPERTY_NAME, fileRootString);
                 }
             }
+        }
+    }
+
+    /**
+     * Action class for making data submitted to Panorama Public public
+     * - A PubMed ID or publication link and citation can be added OR the data can be made public
+     *   without any publication information.
+     *   If a PubMed ID is provided, the citation in NLM format is determined using NCBI's Literature Citation Exporter.
+     * - The DOI associated with the data is made "findable".
+     * This action can be invoked by a folder administrator in the submitted folder in a user project.
+     */
+    @RequiresPermission(AdminPermission.class)
+    public static class MakePublicAction extends FormViewAction<PublicationDetailsForm>
+    {
+        private ExperimentAnnotations _expAnnot;
+        private ExperimentAnnotations _copiedExperiment;
+        private Journal _journal;
+        private JournalSubmission _journalSubmission;
+        private DataCiteException _doiError;
+        private boolean _madePublic;
+        private boolean _addedPublication;
+
+        private boolean validateExperiment(PublicationDetailsForm form, Errors errors)
+        {
+            _expAnnot = form.lookupExperiment();
+            if (_expAnnot == null)
+            {
+                errors.reject(ERROR_MSG, "Cannot find an experiment with Id " + form.getId());
+                return false;
+            }
+
+            ensureCorrectContainer(getContainer(), _expAnnot.getContainer(), getViewContext());
+            return true;
+        }
+
+        private ExperimentAnnotations getCopiedExperimentFor(ExperimentAnnotations expAnnot, Errors errors)
+        {
+            _journalSubmission = getJournalSubmissionFor(expAnnot, errors);
+            if (_journalSubmission != null)
+            {
+                _journal = JournalManager.getJournal(_journalSubmission.getJournalId());
+                if (_journal == null)
+                {
+                    errors.reject(ERROR_MSG, "Cannot find a journal with Id " + _journalSubmission.getJournalId());
+                    return null;
+                }
+
+                if (expAnnot.isJournalCopy())
+                {
+                    if (!_journalSubmission.isLatestExperimentCopy(_expAnnot.getId()))
+                    {
+                        errors.reject(ERROR_MSG, "Experiment Id " + _expAnnot.getId() + " is not the most recent copy of the data");
+                        return null;
+                    }
+                    return expAnnot;
+                }
+                else
+                {
+                    Submission submission = _journalSubmission.getLatestSubmission();
+                    ExperimentAnnotations copiedExperiment = submission != null ? ExperimentAnnotationsManager.get(submission.getCopiedExperimentId()) : null;
+                    if (copiedExperiment == null)
+                    {
+                        errors.reject(ERROR_MSG, String.format("Cannot find a copy of experiment Id %d on '%s'", expAnnot.getId(), _journal.getName()));
+                        return null;
+                    }
+                    return copiedExperiment;
+                }
+            }
+            return null;
+        }
+
+        private JournalSubmission getJournalSubmissionFor(ExperimentAnnotations expAnnot, Errors errors)
+        {
+            JournalSubmission js = expAnnot.isJournalCopy() ? SubmissionManager.getSubmissionForJournalCopy(expAnnot)
+                    : SubmissionManager.getNewestJournalSubmission(expAnnot);
+            if (js == null)
+            {
+                errors.reject(ERROR_MSG, "Unable to find a submission request for"
+                            + (expAnnot.isJournalCopy() ? " copied " : " ") +  "experiment Id " + expAnnot.getId());
+            }
+            return js;
+        }
+
+        @Override
+        public ModelAndView getView(PublicationDetailsForm form, boolean reshow, BindException errors)
+        {
+            if (reshow)
+            {
+                if (errors.hasErrors())
+                {
+                    return _copiedExperiment != null ? getPublicationDetailsView(form, errors)
+                            : new SimpleErrorView(errors, false);
+                }
+
+                return getConfirmView(form, errors);
+            }
+
+            if (!validateExperiment(form, errors))
+            {
+                return new SimpleErrorView(errors, false);
+            }
+
+            _copiedExperiment = getCopiedExperimentFor(_expAnnot, errors);
+            if (_copiedExperiment == null)
+            {
+                return new SimpleErrorView(errors);
+            }
+            if (!canUpdatePublicationDetails(errors))
+            {
+                return new SimpleErrorView(errors);
+            }
+
+            form.setPubmedId(_copiedExperiment.getPubmedId());
+            form.setLink(_copiedExperiment.getPublicationLink());
+            form.setCitation(_copiedExperiment.getCitation());
+            return getPublicationDetailsView(form, errors);
+        }
+
+        private ModelAndView getPublicationDetailsView(PublicationDetailsForm form, BindException errors)
+        {
+            PublicationDetailsBean bean = new PublicationDetailsBean(form, _copiedExperiment);
+            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/publicationDetails.jsp", bean, errors);
+            view.setTitle("Publication Details");
+            return view;
+        }
+
+        @NotNull
+        private ModelAndView getConfirmView(PublicationDetailsForm form, BindException errors)
+        {
+            PublicationDetailsBean bean = new PublicationDetailsBean(form, _copiedExperiment);
+            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/confirmPublish.jsp", bean, errors);
+            view.setTitle("Confirm Publication Details");
+            return view;
+        }
+
+        @Override
+        public void validateCommand(PublicationDetailsForm form, Errors errors)
+        {
+            if (!validateExperiment(form, errors))
+            {
+                return;
+            }
+            _copiedExperiment = getCopiedExperimentFor(_expAnnot, errors);
+            if (_copiedExperiment == null)
+            {
+                return;
+            }
+
+            if (!canUpdatePublicationDetails(errors))
+            {
+                return;
+            }
+
+            if (!form.isUnpublished())
+            {
+                // User did not check the "Unpublished" checkbox so we need the publication details
+                if (form.hasPubmedId())
+                {
+                    if(!form.getPubmedId().matches(PUBMED_ID))
+                    {
+                        errors.reject(ERROR_MSG, "PubMed ID should be a number with 1 to 8 digits");
+                        return;
+                    }
+                }
+                else
+                {
+                    if (!form.hasLinkAndCitation())
+                    {
+                        errors.reject(ERROR_MSG, "Please provide either a PubMed ID or both a publication link and citation for the paper");
+                        return;
+                    }
+                    UrlValidator urlValidator = new UrlValidator(new String[]{"http", "https"});
+                    if (!urlValidator.isValid(form.getLink()))
+                    {
+                        errors.reject(ERROR_MSG, "Publication Link is not valid");
+                        return;
+                    }
+                }
+                if (!form.hasNewPublicationDetails(_copiedExperiment))
+                {
+                    errors.reject(ERROR_MSG, String.format("Publication details are the same as the ones associated with the data on %s at %s",
+                            _journal.getName(), _copiedExperiment.getShortUrl().renderShortURL()));
+                    return;
+                }
+            }
+            else if (_copiedExperiment.isPublic())
+            {
+                // The "Unpublished" box was checked, but the data on Panorama Public is already public so nothing will change
+                // as a result of this action
+                errors.reject(ERROR_MSG, String.format("Data on %s at %s is already public",
+                        _journal.getName(), _copiedExperiment.getShortUrl().renderShortURL()));
+                return;
+            }
+        }
+
+        private boolean canUpdatePublicationDetails(Errors errors)
+        {
+            if (_copiedExperiment.isPublic() && _copiedExperiment.hasCompletePublicationInfo())
+            {
+                errors.reject(ERROR_MSG, String.format("Data on %s at %s is already public and has complete publication details, including a PubMed ID",
+                        _journal.getName(), _copiedExperiment.getShortUrl().renderShortURL()));
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public boolean handlePost(PublicationDetailsForm form, BindException errors)
+        {
+            if (!form.isConfirmed())
+            {
+                if (form.hasPubmedId())
+                {
+                    Pair<String, String> linkAndCitation = NcbiUtils.getLinkAndCitation(form.getPubmedId());
+                    if (linkAndCitation != null)
+                    {
+                        form.setLink(linkAndCitation.first);
+                        form.setCitation(linkAndCitation.second);
+                    }
+                    else
+                    {
+                        errors.reject(ERROR_MSG, "Unable to get a citation for PubMed ID: " + form.getPubmedId());
+                    }
+                }
+                return false;
+            }
+
+            if (!_copiedExperiment.isPublic())
+            {
+                JournalManager.PublicDataUser publicDataUser = JournalManager.getPublicDataUser(_journal);
+
+                makeFolderPublic(publicDataUser); // Make the folder public
+
+                // If the "Raw Data" tab is displayed, add the data download information webpart
+                if (publicDataUser != null)
+                {
+                    addDownloadDataWebpart(_copiedExperiment.getContainer());
+                }
+
+                // Publish the DOI, if one was assigned
+                publishDoi();
+
+                _madePublic = true;
+            }
+
+            if (!form.isUnpublished())
+            {
+                // Add the publication link and citation to the copied experiment
+                _copiedExperiment.setPublicationLink(form.getLink());
+                _copiedExperiment.setCitation(form.getCitation());
+                if (form.hasPubmedId())
+                {
+                    _copiedExperiment.setPubmedId(form.getPubmedId());
+                }
+                ExperimentAnnotationsManager.save(_copiedExperiment, getUser());
+
+                _addedPublication = true;
+            }
+
+
+            // TODO: announce to ProteomeXchange.  This will be added after updates to PX data validation process
+
+
+            // Post to the message thread associated with this submission
+            PanoramaPublicNotification.notifyDataPublished(_expAnnot, _copiedExperiment, _journal, _journalSubmission.getJournalExperiment(), _doiError, getUser());
+
+            return true;
+        }
+
+        private void makeFolderPublic(JournalManager.PublicDataUser publicDataUser)
+        {
+            Container container = _copiedExperiment.getContainer();
+            MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(container, container.getPolicy());
+            newPolicy.addRoleAssignment(SecurityManager.getGroup(Group.groupGuests), ReaderRole.class);
+            if (publicDataUser != null)
+            {
+                newPolicy.addRoleAssignment(publicDataUser.getUser(), ReaderRole.class);
+            }
+            SecurityPolicyManager.savePolicy(newPolicy);
+        }
+
+        private void addDownloadDataWebpart(Container container)
+        {
+            String webpartName = PanoramaPublicModule.DOWNLOAD_DATA_INFO_WP;
+            List<Portal.WebPart> parts = Portal.getParts(container, RAW_FILES_TAB);
+            if (parts.size() != 0)
+            {
+                if (!parts.stream().anyMatch(p -> webpartName.equals(p.getName())))
+                {
+                    WebPartFactory webPartFactory = Portal.getPortalPart(webpartName);
+                    if(webPartFactory != null)
+                    {
+                        Portal.addPart(container, RAW_FILES_TAB, webPartFactory, WebPartFactory.LOCATION_BODY);
+                    }
+                }
+            }
+        }
+
+        private void publishDoi()
+        {
+            try
+            {
+                DataCiteService.publishIfDraftDoi(_copiedExperiment);
+            }
+            catch (DataCiteException e)
+            {
+                _doiError = e;
+            }
+        }
+
+        @Override
+        public ModelAndView getSuccessView(PublicationDetailsForm form)
+        {
+            var shortUrl = _copiedExperiment.getShortUrl().renderShortURL();
+            var successMsg = _madePublic ? String.format("Data on %s at %s was made public%s",
+                                                               _journal.getName(),
+                                                               shortUrl,
+                                                               (_addedPublication ? " and publication details were added." : "."))
+                                   : _addedPublication ?  String.format("Publication details were updated for data on %s at %s.", _journal.getName(), shortUrl) : "";
+            Link viewDataLink = new Link.LinkBuilder("View Data")
+                    .href(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(_copiedExperiment.getContainer()))
+                    .target("_blank").build();
+            Button backToFolderBtn = new Button.ButtonBuilder("Back to Folder")
+                    .href(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(_expAnnot.getContainer())).build();
+
+            return new HtmlView(
+                    DIV(successMsg, SPAN(at(style, "margin-left:10px;"), viewDataLink),
+                            _copiedExperiment.getPxid() != null ?
+                                    DIV(at(style, "margin-top:10px;"),
+                                            String.format("Accession %s will be %s on ProteomeXchange by a %s administrator.",
+                                                    _copiedExperiment.getPxid(), _madePublic ? "made public" : "updated", _journal.getName()))
+                                    : "",
+                            DIV(at(style, "margin-top:10px;"), backToFolderBtn)
+                    )
+            );
+        }
+
+        @Override
+        public ActionURL getSuccessURL(PublicationDetailsForm form)
+        {
+            return null;
+        }
+
+        @Override
+        public void addNavTrail(NavTree root)
+        {
+            root.addChild("Publish Data");
+        }
+    }
+
+    public static class PublicationDetailsBean
+    {
+        private final PublicationDetailsForm _form;
+        private final String _accessUrl;
+        private final boolean _isPublic;
+        private final boolean _isPeerReviewed;
+
+        public PublicationDetailsBean(PublicationDetailsForm form, ExperimentAnnotations copiedExperiment)
+        {
+            _form = form;
+            _isPublic = copiedExperiment.isPublic();
+            _isPeerReviewed = copiedExperiment.isPeerReviewed();
+            _accessUrl = copiedExperiment.getShortUrl().renderShortURL();
+        }
+
+        public PublicationDetailsForm getForm()
+        {
+            return _form;
+        }
+
+        public boolean isPublic()
+        {
+            return _isPublic;
+        }
+
+        public boolean isPeerReviewed()
+        {
+            return _isPeerReviewed;
+        }
+
+        public String getAccessUrl()
+        {
+            return _accessUrl;
+        }
+    }
+    public static class PublicationDetailsForm extends ExperimentIdForm
+    {
+        private String _link;
+        private String _citation;
+        private String _pubmedId;
+        private boolean _unpublished;
+        private boolean _confirmed;
+
+        public String getLink()
+        {
+            return _link;
+        }
+
+        public void setLink(String link)
+        {
+            _link = link;
+        }
+
+        public String getCitation()
+        {
+            return _citation;
+        }
+
+        public void setCitation(String citation)
+        {
+            _citation = citation;
+        }
+
+        public String getPubmedId()
+        {
+            return _pubmedId;
+        }
+
+        public void setPubmedId(String pubmedId)
+        {
+            _pubmedId = pubmedId;
+        }
+
+        public boolean isUnpublished()
+        {
+            return _unpublished;
+        }
+
+        public void setUnpublished(boolean unpublished)
+        {
+            _unpublished = unpublished;
+        }
+
+        public boolean isConfirmed()
+        {
+            return _confirmed;
+        }
+
+        public void setConfirmed(boolean confirmed)
+        {
+            _confirmed = confirmed;
+        }
+
+        public boolean hasPubmedId()
+        {
+            return !StringUtils.isBlank(_pubmedId);
+        }
+
+        public boolean hasLinkAndCitation()
+        {
+            return !(StringUtils.isBlank(_link) || StringUtils.isBlank(_citation));
+        }
+
+        public boolean hasNewPublicationDetails(ExperimentAnnotations copiedExperiment)
+        {
+            return !(Objects.equals(_pubmedId, copiedExperiment.getPubmedId())
+                    && Objects.equals(_link, copiedExperiment.getPublicationLink())
+                    && Objects.equals(_citation, copiedExperiment.getCitation()));
         }
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.SQLFragment;
@@ -32,6 +31,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QuerySchema;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.User;
 import org.labkey.panoramapublic.query.ExperimentAnnotationsTableInfo;
 import org.labkey.panoramapublic.query.JournalExperimentTableInfo;
@@ -98,9 +98,9 @@ public class PanoramaPublicSchema extends UserSchema
             FilteredTable<PanoramaPublicSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf);
             result.wrapAllColumns(true);
             var projectCol = result.getMutableColumn(FieldKey.fromParts("Project"));
-            ContainerForeignKey.initColumn(projectCol, this);
+            projectCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
             var supportContainerCol = result.getMutableColumn(FieldKey.fromParts("SupportContainer"));
-            ContainerForeignKey.initColumn(supportContainerCol, this);
+            supportContainerCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
             return result;
         }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
@@ -98,6 +98,27 @@ public class DataCiteService
         }
     }
 
+    public static void publishIfDraftDoi(@NotNull ExperimentAnnotations expAnnot) throws DataCiteException
+    {
+        if (!StringUtils.isBlank(expAnnot.getDoi()) && !isPublished(expAnnot.getDoi()))
+        {
+            publish(expAnnot);
+        }
+    }
+
+    private static boolean isPublished (@NotNull String experimentDoi) throws DataCiteException
+    {
+        // curl --request GET --url https://api.test.datacite.org/dois/id --header 'Accept: application/vnd.api+json'
+        METHOD method = METHOD.GET;
+        DataCiteResponse response = doRequest(getDataCiteConfig(experimentDoi), null, method);
+        if(!response.success(method))
+        {
+            throw new DataCiteException("Request to get DOI status failed", response);
+        }
+        Doi doi = response.getDoi();
+        return (doi != null && doi.getDoi() != null && doi.isFindable());
+    }
+
     private static DataCiteResponse doRequest(DataCiteConfig config, @Nullable JSONObject json, METHOD method) throws DataCiteException
     {
         String auth = Base64.getEncoder().encodeToString((config.getName() + ":" + config.getPassword()).getBytes(StandardCharsets.UTF_8));

--- a/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
@@ -514,6 +514,11 @@ public class ExperimentAnnotations
         return Experiment.equals(folderType) && isPublic() && isPublished();
     }
 
+    public boolean hasCompletePublicationInfo()
+    {
+        return isPeerReviewed() && hasPubmedId();
+    }
+
     public String getDoi()
     {
         return _doi;

--- a/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
@@ -294,6 +294,8 @@ public class SubmissionManager
                 ShortURLRecord accessUrlRecord = JournalManager.saveShortURL(fullAccessUrl, newShortAccessUrl, journal, user);
                 je.setShortAccessUrl(accessUrlRecord);
 
+                updateJournalExperiment(je, user); // Save with the new URL before deleting the old short URL
+
                 // Delete the old one
                 shortURLService.deleteShortURL(oldAccessUrl, user);
             }
@@ -305,11 +307,11 @@ public class SubmissionManager
                 ShortURLRecord copyUrlRecord = JournalManager.saveShortURL(fullCopyUrl, newShortCopyUrl, null, user);
                 je.setShortCopyUrl(copyUrlRecord);
 
+                updateJournalExperiment(je, user); // Save with the new URL before deleting the old short URL
+
                 // Delete the old one
                 shortURLService.deleteShortURL(oldCopyUrl, user);
             }
-
-            updateJournalExperiment(je, user);
 
             transaction.commit();
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/TargetedMSExperimentWebPart.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/TargetedMSExperimentWebPart.java
@@ -17,6 +17,7 @@ package org.labkey.panoramapublic.view.expannotations;
 
 import org.labkey.api.data.Container;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
+import org.labkey.api.util.Link;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.JspView;
@@ -26,6 +27,10 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.panoramapublic.PanoramaPublicController;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
+
+import static org.labkey.api.util.DOM.Attribute.style;
+import static org.labkey.api.util.DOM.DIV;
+import static org.labkey.api.util.DOM.at;
 
 /**
  * User: vsharma
@@ -50,12 +55,12 @@ public class TargetedMSExperimentWebPart extends VBox
         {
             // There is no experiment defined in this container, or in a parent container that is configured
             // to include subfolders.
-            StringBuilder html = new StringBuilder("<div>This folder does not contain an experiment.</div>");
-            ActionURL url = new ActionURL(PanoramaPublicController.ShowNewExperimentAnnotationFormAction.class, container);
-            html.append("<div style=\"margin-top: 20px;\">");
-            html.append("<a href=\"").append(url).append("\">Create New Experiment</a>");
-            html.append("</div>");
-            HtmlView view = new HtmlView(html.toString());
+            HtmlView view = new HtmlView(DIV(
+                    DIV("This folder does not contain an experiment."),
+                    DIV(at(style, "margin-top:20px;"),
+                            new Link.LinkBuilder("Create New Experiment")
+                                    .href(new ActionURL(PanoramaPublicController.ShowNewExperimentAnnotationFormAction.class, container))
+                                    .build())));
             addView(view);
         }
         else if(expAnnotations.getContainer().equals(container))
@@ -71,18 +76,20 @@ public class TargetedMSExperimentWebPart extends VBox
                 NavTree navTree = new NavTree();
                 navTree.addChild("ProteomeXchange", new ActionURL(PanoramaPublicController.GetPxActionsAction.class, container).addParameter("id", expAnnotations.getId()));
                 navTree.addChild("DOI", new ActionURL(PanoramaPublicController.DoiOptionsAction.class, container).addParameter("id", expAnnotations.getId()));
+                navTree.addChild("Make Data Public", new ActionURL(PanoramaPublicController.MakePublicAction.class, container).addParameter("id", expAnnotations.getId()));
                 setNavMenu(navTree);
             }
         }
         else
         {
             // There is an experiment defined in a parent container that is configured to include subfolders.
-            StringBuilder html = new StringBuilder("<div>A parent folder contains an experiment that includes data in this folder.</div>");
-            ActionURL url = PanoramaPublicController.getViewExperimentDetailsURL(expAnnotations.getId(), container);
-            html.append("<div style=\"margin-top: 20px;\">");
-            html.append("<a href=\"").append(url.getEncodedLocalURIString()).append("\">View Experiment Details</a>");
-            html.append("</div>");
-            HtmlView view = new HtmlView(html.toString());
+            HtmlView view = new HtmlView(DIV(
+                    DIV("A parent folder contains an experiment that includes data in this folder."),
+                    DIV(at(style, "margin-top: 20px;"),
+                            new Link.LinkBuilder("View Experiment Details")
+                                    .href(PanoramaPublicController.getViewExperimentDetailsURL(expAnnotations.getId(), container))
+                                    .build() )
+            ));
             addView(view);
         }
         setTitle("Targeted MS Experiment");

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -17,7 +17,6 @@
 %>
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.labkey.api.data.Container" %>
-<%@ page import="org.labkey.api.security.permissions.InsertPermission" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
@@ -33,6 +32,7 @@
 <%@ page import="java.text.SimpleDateFormat" %>
 <%@ page import="org.labkey.panoramapublic.model.Submission" %>
 <%@ page import="org.labkey.panoramapublic.model.JournalSubmission" %>
+<%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%!
@@ -59,7 +59,7 @@
 
     ActionURL publishUrl = PanoramaPublicController.getPublishExperimentURL(annot.getId(), getContainer(), true, true);
     Container experimentContainer = annot.getContainer();
-    final boolean canEdit = (!annot.isJournalCopy() || getUser().hasSiteAdminPermission()) && experimentContainer.hasPermission(getUser(), InsertPermission.class);
+    final boolean canEdit = (!annot.isJournalCopy() || getUser().hasSiteAdminPermission()) && experimentContainer.hasPermission(getUser(), AdminPermission.class);
     // User needs to be the folder admin to publish an experiment.
     final boolean canPublish = annotDetails.isCanPublish();
     final boolean showingFullDetails = annotDetails.isFullDetails();
@@ -187,6 +187,12 @@
     <%if(canPublish && !journalCopyPending){%>
         <a class="button-small button-small-red" style="float:left; margin:0px 5px 0px 2px;" href="<%=h(publishUrl)%>"><%=h(publishButtonText)%></a>
     <%}%>
+    <% if (annotDetails.canAddPublishLink(getUser())) { %>
+        <%=link(annotDetails.getPublishButtonText(), new ActionURL(PanoramaPublicController.MakePublicAction.class,getContainer())
+                .addParameter("id", annot.getId()))
+                .clearClasses().addClass("button-small button-small-red")
+                .style("margin:0px 5px 0px 2px;")%>
+    <% } %>
     <%if(canEdit){%>
     <a style="margin-top:2px; margin-left:2px;" href="<%=h(editUrl)%>">[Edit]</a>
     <a style="margin-top:2px; margin-left:2px;" href="<%=h(deleteUrl)%>">[Delete]</a>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
@@ -1,0 +1,118 @@
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.api.portal.ProjectUrls" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("Ext4");
+    }
+%>
+
+<labkey:errors/>
+<%
+    JspView<PanoramaPublicController.PublicationDetailsBean> me = (JspView<PanoramaPublicController.PublicationDetailsBean>) HttpView.currentView();
+    var bean = me.getModelBean();
+    var form = bean.getForm();
+%>
+
+<div id="publishDataDetails"></div>
+<div id="publishDataForm"></div>
+
+<script type="text/javascript">
+
+    Ext4.onReady(function(){
+
+        var items = [];
+        if (<%=!bean.isPublic()%>) {
+            items.push({xtype: 'component', style: 'margin: 5px 0 5px 0', html: 'Data at ' + <%=qh(bean.getAccessUrl())%> + ' will be made public.'});
+        }
+        if (<%=form.hasPubmedId()%>) {
+            items.push({xtype: 'component', html: '<b>PubMed ID:</b> ' + <%=qh(form.getPubmedId())%>});
+        }
+        if (<%=form.hasLinkAndCitation()%>) {
+            items.push({xtype: 'component', html: '<b>Link:</b> ' + <%=qh(form.getLink())%>});
+            items.push({xtype: 'component', html: '<b>Citation:</b> <i>' + <%=qh(form.getCitation())%> + '</i>'});
+        }
+        else {
+            items.push({xtype: 'component', html: 'Publication details were not entered.'});
+        }
+        Ext4.create('Ext.Panel', {
+            renderTo: 'publishDataDetails',
+            border: false,
+            frame: false,
+            margin: '0 0 10 0',
+            items: items
+        });
+
+        var form = Ext4.create('Ext.form.Panel', {
+            renderTo: "publishDataForm",
+            standardSubmit: true,
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 150,
+                width: 600,
+                labelStyle: 'background-color: #E0E6EA; padding: 5px;'
+            },
+            items: [
+                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
+                {
+                    xtype: 'hidden',
+                    name: 'id',
+                    value: <%=form.getId()%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'pubmedId',
+                    value: <%=q(form.getPubmedId())%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'link',
+                    value: <%=q(form.getLink())%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'citation',
+                    value: <%=q(form.getCitation())%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'unpublished',
+                    value: <%=form.isUnpublished()%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'confirmed',
+                    value: true
+                }
+            ],
+            buttonAlign: 'left',
+            buttons: [
+                {
+                    text: "OK",
+                    cls: 'labkey-button primary',
+                    handler: function(button) {
+                        button.setDisabled(true);
+                        form.submit({
+                            url: <%=q(urlFor(PanoramaPublicController.MakePublicAction.class))%>,
+                            method: 'POST'
+                        });
+                    }
+                },
+                {
+                    text: 'Cancel',
+                    cls: 'labkey-button',
+                    hrefTarget: '_self',
+                    href: <%=q(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(getContainer()))%>
+                }]
+        });
+    });
+</script>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
@@ -1,0 +1,32 @@
+<%@ page import="org.labkey.panoramapublic.query.JournalManager" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page import="org.labkey.api.settings.AppProps" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<labkey:errors/>
+<%
+    JspView<JournalManager.PublicDataUser> me = (JspView<JournalManager.PublicDataUser>) HttpView.currentView();
+    var publicDataUser = me.getModelBean();
+    // NOTE: This is a link to the data download documentation page on PanoramaWeb.  It will not work on any other server.
+    var downloadDataDocHref = "/wiki/home/page.view?name=download_public_data";
+    // WebDAV URL to the RawFiles folder in the file root
+    var webdavUrl = AppProps.getInstance().getBaseServerUrl() + PageFlowUtil.encodePath("_webdav" + getContainer().getPath() + "/@files/RawFiles/");
+%>
+<p>
+    Select one or more files or folders in the browser above and click the download icon ( <span class="fa fa-download"></span> ).
+    Data can also be downloaded by mapping this folder as a network drive in Windows Explorer, or by using a
+    <%=link("WebDAV").href("https://en.wikipedia.org/wiki/WebDAV").clearClasses()%>
+    client such as <span class="nobr"><%=link("CyberDuck").href("https://cyberduck.io").clearClasses()%></span>
+    or <span class="nobr"><%=link("WinSCP").href("https://winscp.net/eng/docs/introduction").clearClasses()%></span>.
+    For details look at <%=link("Download data from Panorama Public").href(downloadDataDocHref).clearClasses()%>.
+    Use the following URL, login email and password to connect to this folder:
+    <br/>
+    <br/>
+    URL: <b class="bold"><span class="nobr" id="webdav_url_link"><%=h(webdavUrl)%></span></b>
+    <br/>
+    Login email: <b class="bold"><%=h(publicDataUser.getEmail())%></b>
+    <br/>
+    Password: <b class="bold"><%=h(publicDataUser.getPassword())%></b>
+</p>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
@@ -10,7 +10,7 @@
     JspView<JournalManager.PublicDataUser> me = (JspView<JournalManager.PublicDataUser>) HttpView.currentView();
     var publicDataUser = me.getModelBean();
     // NOTE: This is a link to the data download documentation page on PanoramaWeb.  It will not work on any other server.
-    var downloadDataDocHref = "/wiki/home/page.view?name=download_public_data";
+    var downloadDataDocHref = "/home/wiki-page.view?name=download_public_data";
     // WebDAV URL to the RawFiles folder in the file root
     var webdavUrl = AppProps.getInstance().getBaseServerUrl() + PageFlowUtil.encodePath("_webdav" + getContainer().getPath() + "/@files/RawFiles/");
 %>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publicationDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publicationDetails.jsp
@@ -1,0 +1,120 @@
+<%@ page import="org.labkey.api.util.PageFlowUtil" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.api.portal.ProjectUrls" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("Ext4");
+    }
+%>
+
+<labkey:errors/>
+<%
+    JspView<PanoramaPublicController.PublicationDetailsBean> me = (JspView<PanoramaPublicController.PublicationDetailsBean>) HttpView.currentView();
+    var bean = me.getModelBean();
+    var form = bean.getForm();
+%>
+
+<div id="publishDataForm"></div>
+
+<script type="text/javascript">
+
+    Ext4.onReady(function(){
+
+        var form = Ext4.create('Ext.form.Panel', {
+            renderTo: "publishDataForm",
+            standardSubmit: true,
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 150,
+                width: 600,
+                labelStyle: 'background-color: #E0E6EA; padding: 5px;'
+            },
+            items: [
+                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
+                {
+                    xtype: 'hidden',
+                    name: 'id',
+                    value: <%=form.getId()%>
+                },
+                {
+                    xtype: 'textfield',
+                    name: 'pubmedId',
+                    fieldLabel: "PubMed ID",
+                    value: <%=q(form.getPubmedId())%>
+                },
+                {
+                    xtype: 'component',
+                    hidden: <%=bean.isPeerReviewed()%>,
+                    html: '<div style="color:red;">Publication link and citation are not required if a PubMed ID is provided</div>'
+                },
+                {
+                    xtype: 'label',
+                    hidden: <%=bean.isPeerReviewed()%>,
+                    text: '------------------------------------------------- OR -------------------------------------------------',
+                    style: {'text-align': 'center', 'margin': '10px 0 10px 0'}
+                },
+                {
+                    xtype: 'textfield',
+                    hidden: <%=bean.isPeerReviewed()%>,
+                    name: 'link',
+                    fieldLabel: "Publication Link",
+                    value: <%=q(form.getLink())%>
+                },
+                {
+                    xtype: 'textarea',
+                    hidden: <%=bean.isPeerReviewed()%>,
+                    name: 'citation',
+                    fieldLabel: "Citation",
+                    value: <%=q(form.getCitation())%>
+                },
+                {
+                    xtype: 'label',
+                    hidden: <%=bean.isPublic()%>,
+                    text: '------------------------------------------------- OR -------------------------------------------------',
+                    style: {'text-align': 'center', 'margin': '10px 0 10px 0'}
+                },
+                {
+                    xtype: 'checkbox',
+                    hidden: <%=bean.isPublic()%>,
+                    name: 'unpublished',
+                    fieldLabel: "Unpublished",
+                    checked: <%=form.isUnpublished()%>,
+                    boxLabel: 'Check this box if a manuscript for the data is not yet published, or if the manuscript has been ' +
+                            'accepted for publication but the publication link is not yet available',
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'detailsConfirmed',
+                    value: <%=form.isConfirmed()%>,
+                }
+            ],
+            buttonAlign: 'left',
+            buttons: [{
+                text: "Continue",
+                cls: 'labkey-button primary',
+                handler: function(button) {
+                    button.setDisabled(true);
+                    form.submit({
+                        url: <%=q(urlFor(PanoramaPublicController.MakePublicAction.class))%>,
+                        method: 'POST'
+                    });
+                }
+            },
+                {
+                    text: 'Cancel',
+                    cls: 'labkey-button',
+                    hrefTarget: '_self',
+                    href: <%=q(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(getContainer()))%>
+                }]
+        });
+    });
+</script>


### PR DESCRIPTION
- Add a "Make Public" button to the TargetedMSExperiment webpart that will let users make their data on Panorama Public public.  This button will be displayed in the user's copy of the data, in their project. This will:
  - Display a form where the user can fill the publication details (PubMed ID or link and citation)
  - Assign Reader role to Site:Guests and the user account that can be used to download files in a WebDAV client
  - Add a "Download Data" webpart to the "Raw Data" tab.  This webpart has the WebDAV URL for the "RawFiles" folder in the file root along with the user email and password that can be used to connect to the folder in a WebDAV client
  - If a PubMed ID was entered, we will get the citation in NLM format through PubMed's Literature Citation Exporter
  - Set the publication details on the ExperimentAnnotations in the Panorama Public folder for the data
  - Make the DOI "findable" if one was assigned
- AddPublicDataUserAction class was added to let site admins set the user account that should be used for WebDAV downloads:  (Admin Console > Panorama Public > Add Public Data User)

 Changes are described here: https://docs.google.com/document/d/1cjLH-OBc77jHBn_DN4u9munUl7EA_e2RwYfIqWjPcFM/edit
