### PR TITLE
Auto-populate "Instrument" field; include first and last name in "Authors" column

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -4008,6 +4008,11 @@ public class PanoramaPublicController extends SpringActionController
             addExperimentViewDependencies(view);
             view.setTitle(TargetedMSExperimentWebPart.WEB_PART_NAME);
             view.setInitialValue(SUBMITTER, getUser().getUserId());
+            List<PsiInstrumentParser.PsiInstrument> instruments = ExperimentAnnotationsManager.getContainerInstruments(getContainer(), getUser());
+            if (instruments.size() > 0)
+            {
+                view.setInitialValue("instrument", StringUtils.join(instruments.stream().map(i -> i.getName()).collect(Collectors.toList()), ","));
+            }
             return view;
         }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -41,7 +41,10 @@ import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.UserIdForeignKey;
 import org.labkey.api.query.UserIdRenderer;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.Group;
+import org.labkey.api.security.MemberType;
 import org.labkey.api.security.RoleAssignment;
+import org.labkey.api.security.SecurityManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.UserManager;
 import org.labkey.api.security.UserPrincipal;
@@ -58,9 +61,9 @@ import org.labkey.api.util.UniqueID;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
+import org.labkey.panoramapublic.PanoramaPublicController;
 import org.labkey.panoramapublic.PanoramaPublicManager;
 import org.labkey.panoramapublic.PanoramaPublicSchema;
-import org.labkey.panoramapublic.PanoramaPublicController;
 import org.labkey.panoramapublic.model.DataLicense;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.view.publish.ShortUrlDisplayColumnFactory;
@@ -336,19 +339,23 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
 
     private ExprColumn getAuthorsColumn()
     {
-        // Concatenate the citation column with the display names of the submitter and the lab head associated with the experiment.
+        // Concatenate the citation column with the full name of the submitter and the lab head associated with the experiment.
+        // Users selected as submitter and lab head for experiments submitted to Panorama Public will always have a first and
+        // last name. Do not use the displayname since it may not always contain their first or last names.
         // This column will not be included in the list of default columns.  It is added only to enable expanded searches for author names
         // in the Panorama Public search form.
         SqlDialect dialect = PanoramaPublicSchema.getSchema().getSqlDialect();
-        SQLFragment usersSql = new SQLFragment(" SELECT DISTINCT displayname FROM ").append(CoreSchema.getInstance().getTableInfoUsersData(), "users")
+        SQLFragment usersSql = new SQLFragment(" SELECT ")
+                .append(dialect.concatenate(new SQLFragment(" COALESCE(firstname, '') "), new SQLFragment("' '"), new SQLFragment(" COALESCE(lastname, '') ")))
+                .append(" FROM ").append(CoreSchema.getInstance().getTableInfoUsersData(), "users")
                 .append(" WHERE ")
                 .append(" users.userid = ").append(ExprColumn.STR_TABLE_ALIAS).append(".submitter")
                 .append(" OR")
                 .append(" users.userid = ").append(ExprColumn.STR_TABLE_ALIAS).append(".labhead");
         SQLFragment authorsSql = dialect.concatenate(
-                new SQLFragment(" (COALESCE(").append(ExprColumn.STR_TABLE_ALIAS).append(".citation, '') "),
+                new SQLFragment(" (SELECT ").append(dialect.getSelectConcat(usersSql, ",")).append(") "),
                 new SQLFragment("','"),
-                new SQLFragment(" (SELECT ").append(dialect.getSelectConcat(usersSql, ",")).append(")) ")
+                new SQLFragment(" (COALESCE(").append(ExprColumn.STR_TABLE_ALIAS).append(".citation, '')) ")
                 );
         return new ExprColumn(this, "Authors", authorsSql, JdbcType.VARCHAR);
     }
@@ -443,6 +450,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
 
         private void addUsers(NamedObjectList objectList, Container container, Role adminRole)
         {
+            // CONSIDER:  Use this instead? SecurityManager.getUsersWithPermissions(container, Collections.singleton(AdminPermission.class));
             Set<RoleAssignment> roles = container.getPolicy().getAssignments();
             for(RoleAssignment role: roles)
             {
@@ -460,6 +468,20 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
             {
                 String displayName = getUserDisplayName(u);
                 objectList.put(new SimpleNamedObject(String.valueOf(u.getUserId()), displayName));
+            }
+            else
+            {
+                // This could be a permissions group.  Add the group members
+                Group group = SecurityManager.getGroup(userId);
+                if (group != null)
+                {
+                    // Members of the group and sub-groups (not including "All Site Users")
+                    Set<User> grpMembers = SecurityManager.getAllGroupMembers(group, MemberType.ACTIVE_USERS, false);
+                    for (User member: grpMembers)
+                    {
+                        objectList.put(new SimpleNamedObject(String.valueOf(member.getUserId()), getUserDisplayName(member)));
+                    }
+                }
             }
         }
     }
@@ -494,7 +516,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
         String displayName = u.getDisplayName(null);
         if(!StringUtils.isBlank(u.getFullName()))
         {
-            displayName = u.getFullName() + " (" + displayName + ")";
+            displayName = u.getFullName() + (!u.getFullName().equals(displayName) ? " (" + displayName + ")" : "");
         }
         return displayName;
     }
@@ -602,7 +624,11 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
         public void renderInputHtml(RenderContext ctx, Writer out, Object value) throws IOException
         {
             String name = getFormFieldName(ctx);
-            String valueString = value == null ? "" : value.toString();
+            String valueString = getStringValue(value, isDisabledInput(ctx));
+            if (valueString == null)
+            {
+                valueString = "";
+            }
 
             String renderId = "input-picker-div-" + UniqueID.getRequestScopedUID(HttpView.currentRequest());
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
- Auto populate the "Instrument" field in the new ExperimentAnnotations form.
  - Get the instrument names from the Skyline document metadata (targetedms.instrument table) in the container.
  - Instrument model names must match instruments in the PSI-MS CV. This should work for Thermo and SCIEX instrument but usually not for other instrument vendors.
- Look up members of groups with folder admin role in the container to populate the drop down menu for the "Submitter" and "Lab Head" fields in the form.
  This is in addition to users with folder admin roles.
- Include the first and last names of submitter and lab head instead of the display name in the "Authors" column (related to PR 131).
