### PR TITLE
Copy ExpData comments (descriptions) to the Panorama Public copy 

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.panoramapublic.pipeline;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.FolderExportContext;
@@ -124,7 +123,10 @@ public class ExperimentExportTask extends PipelineJob.Task<ExperimentExportTask.
             throw new Exception("Could not create directory " + exportDir.getAbsolutePath());
         }
 
-        writer.write(source, ctx, new FileSystemFile(exportDir));
+        FileSystemFile vf = new FileSystemFile(exportDir);
+        writer.write(source, ctx, vf);
+        FilesMetadataWriter filesMetadataWriter = new FilesMetadataWriter();
+        filesMetadataWriter.write(exptAnnotations.getContainer(), exptAnnotations.isIncludeSubfolders(), vf, user, getJob().getLogger());
     }
 
     public static class Factory extends AbstractTaskFactory<AbstractTaskFactorySettings, Factory>

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentImportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentImportTask.java
@@ -96,6 +96,9 @@ public class ExperimentImportTask extends PipelineJob.Task<ExperimentImportTask.
 
         FolderImporterImpl importer = new FolderImporterImpl(job);
         importer.process(job, importCtx, importJobRoot);
+
+        FilesMetadataImporter filesMetadataImporter = new FilesMetadataImporter();
+        filesMetadataImporter.doImport(container, jobSupport.getExpAnnotations().isIncludeSubfolders(), importJobRoot, user, job.getLogger());
     }
 
     public static class Factory extends AbstractTaskFactory<AbstractTaskFactorySettings, Factory>

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataImporter.java
@@ -1,0 +1,108 @@
+package org.labkey.panoramapublic.pipeline;
+
+import org.apache.logging.log4j.Logger;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.files.FileContentService;
+import org.labkey.api.pipeline.PipelineJobException;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
+import org.labkey.api.writer.VirtualFile;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.List;
+
+public class FilesMetadataImporter
+{
+    public void doImport(Container container, boolean includeSubfolders, VirtualFile vf, User user, Logger log) throws PipelineJobException
+    {
+        log.info("Importing files metadata.");
+        FileContentService fcs = FileContentService.get();
+        ExperimentService expSvc = ExperimentService.get();
+        doImport(container, includeSubfolders, vf, fcs, expSvc, user, log);
+    }
+
+    private void doImport(Container container, boolean includeSubfolders, VirtualFile vf,
+                          FileContentService fcs, ExperimentService expSvc, User user, Logger log) throws PipelineJobException
+    {
+        readXmlAndImport(container, vf, fcs, expSvc, user, log);
+
+        if (includeSubfolders)
+        {
+            List<Container> children = ContainerManager.getChildren(container);
+            if (children.size() > 0)
+            {
+                var subfolders = vf.getDir("subfolders"); // TODO: Make SubfolderWriter.DIRECTORY_NAME public
+                for (Container child : children)
+                {
+                    doImport(child, true, subfolders.getDir(child.getName()), fcs, expSvc, user, log);
+                }
+            }
+        }
+    }
+
+    private void readXmlAndImport(Container container, VirtualFile vf, FileContentService fcs, ExperimentService expSvc, User user, Logger log) throws PipelineJobException
+    {
+        log.debug(String.format("[%s]  Reading files metadata from %s", container.getPath(), vf.getLocation()));
+
+        try (InputStream is = vf.getInputStream(FilesMetadataWriter.FILENAME))
+        {
+            if (is == null)
+            {
+                log.error(String.format("Could not find expected file %s in %s.", FilesMetadataWriter.FILENAME,  vf.getLocation()));
+                return;
+            }
+
+            Path fileRoot = fcs.getFileRootPath(container, FileContentService.ContentType.files);
+            if (fileRoot == null)
+            {
+                log.error("Could not get file root for " + container.getPath());
+                return;
+            }
+
+            Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(is));
+            NodeList nodes = document.getElementsByTagName(FilesMetadataWriter.FILE);
+            for(int i = 0; i < nodes.getLength(); i++)
+            {
+                Node node = nodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE)
+                {
+                    Element fileEl = (Element)node;
+                    String relPath = fileEl.getElementsByTagName(FilesMetadataWriter.RELATIVE_PATH).item(0).getTextContent();
+                    String comment = fileEl.getElementsByTagName(FilesMetadataWriter.COMMENT).item(0).getTextContent();
+                    if (relPath != null && comment != null)
+                    {
+                        ExpData data = expSvc.getExpDataByURL(fileRoot.resolve(relPath), container);
+                        if (data != null)
+                        {
+                            try
+                            {
+                                data.setComment(user, comment);
+                            }
+                            catch (ValidationException validationErrors)
+                            {
+                                log.error("Error setting comment on " + data.getFilePath(), validationErrors);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (IOException | ParserConfigurationException | SAXException e)
+        {
+            throw new PipelineJobException(String.format("Error reading %s in %s.", FilesMetadataWriter.FILENAME, vf.getLocation()), e);
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataWriter.java
@@ -1,0 +1,127 @@
+package org.labkey.panoramapublic.pipeline;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.admin.FolderExportPermission;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.exp.api.ExpData;
+import org.labkey.api.exp.api.ExperimentService;
+import org.labkey.api.files.FileContentService;
+import org.labkey.api.pipeline.PipelineJobException;
+import org.labkey.api.security.User;
+import org.labkey.api.writer.FileSystemFile;
+import org.labkey.api.writer.VirtualFile;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FilesMetadataWriter
+{
+    public static final String FILENAME = "files.xml";
+    public static final String FILES = "files";
+    public static final String FILE = "file";
+    public static final String RELATIVE_PATH = "relative_path";
+    public static final String COMMENT = "comment";
+
+    public void write(Container container, boolean includeSubfolders, FileSystemFile vf, User user, Logger log) throws PipelineJobException
+    {
+        log.info("Exporting files metadata.");
+        ExperimentService expSvc = ExperimentService.get();
+        FileContentService fcs = FileContentService.get();
+        writeFilesMetadata(vf, container, includeSubfolders, expSvc, fcs, user, log);
+    }
+
+    private void writeFilesMetadata(VirtualFile vf, Container container, boolean includeSubfolders,
+                                    ExperimentService expSvc, FileContentService fcs, User user, Logger log) throws PipelineJobException
+    {
+        log.debug(String.format("[%s]  Writing files metadata to %s", container.getPath(), vf.getLocation()));
+
+        try (PrintWriter writer = vf.getPrintWriter(FILENAME))
+        {
+            writeFilesXml(container, expSvc, fcs, writer, log);
+        }
+        catch (IOException | ParserConfigurationException | TransformerException e)
+        {
+            throw new PipelineJobException(String.format("Error writing %s in %s", FILENAME, vf.getLocation()));
+        }
+        if (includeSubfolders)
+        {
+            List<Container> children = ContainerManager.getChildren(container, user, FolderExportPermission.class);
+            if (children.size() > 0)
+            {
+                var subfolders = vf.getDir("subfolders"); // TODO: Make SubfolderWriter.DIRECTORY_NAME public
+                for (Container child : children)
+                {
+                    writeFilesMetadata(subfolders.getDir(child.getName()), child, true, expSvc, fcs, user, log);
+                }
+            }
+        }
+    }
+
+    private void writeFilesXml(Container container, ExperimentService expSvc, FileContentService fcs, PrintWriter writer, Logger log)
+            throws ParserConfigurationException, TransformerException
+    {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+
+        List<? extends ExpData> expDatasWithComments = getExpDatasWithComments(container, expSvc);
+
+        Path fileRoot = fcs.getFileRootPath(container, FileContentService.ContentType.files);
+        if (fileRoot == null)
+        {
+            log.error("Could not get file root for " + container.getPath());
+            return;
+        }
+
+        Element root = doc.createElement(FILES);
+        doc.appendChild(root);
+
+        for (ExpData data: expDatasWithComments)
+        {
+            Element fileEl = doc.createElement(FILE);
+            root.appendChild(fileEl);
+
+            Path dataPath = data.getFilePath();
+            if (dataPath != null)
+            {
+                // Write the path relative to the container file root
+                Path relFilePath = fileRoot.relativize(dataPath);
+                Element relPathNode = doc.createElement(RELATIVE_PATH);
+                relPathNode.appendChild(doc.createTextNode(relFilePath.toString()));
+
+                // Write the comment (description) for the ExpData
+                Element commentNode = doc.createElement(COMMENT);
+                commentNode.appendChild(doc.createTextNode(data.getComment()));
+
+                fileEl.appendChild(relPathNode);
+                fileEl.appendChild(commentNode);
+            }
+        }
+
+        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        DOMSource source = new DOMSource(doc);
+        StreamResult result = new StreamResult(writer);
+        transformer.transform(source, result);
+    }
+
+    @NotNull
+    private List<? extends ExpData> getExpDatasWithComments(Container container, ExperimentService expService)
+    {
+        return expService.getExpData(container).stream().filter(d -> !StringUtils.isBlank(d.getComment())).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
#### Rationale
FolderWriter / FolderImporter do not copy the comments (displayed in the Description column of the Files browser) entered by a user for files / folders.  

#### Changes
Added FilesMetadataWriter that gets called in ExperimentExportTask after the folder export is complete.  FilesMetadataWriter writes one files.xml for every exported folder (the root folder and any children if they are included in the export). This file contains, for each ExpData in the folder that has a comment, the path relative to the container file root and the comment.
FilesMetadataImporter is called at the end of ExperimentImportTask after FolderImporter is done. 

