### PR TITLE
Issue 44240: Use the correct source container when updating the folder type of child containers in the Panorama Public copy

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/UpdateFolderTypeTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/UpdateFolderTypeTask.java
@@ -99,7 +99,7 @@ public class UpdateFolderTypeTask extends PipelineJob.Task<UpdateFolderTypeTask.
             {
                throw new PipelineJobException(String.format("Cannot update folder type. Could not find the source container for the subfolder '%s'.", child.getPath()));
             }
-            updateFolderType(child, sourceContainer, user, svc, log);
+            updateFolderType(child, source, user, svc, log);
         }
     }
 


### PR DESCRIPTION
#### Rationale
Folder type (Experiment, Library) of folders copied to Panorama Public is matched to the corresponding container in the source container tree in the user's project. This was not working for child containers that were more than 1 level down from the top-level parent container.

