### PR TITLE
Collect spectral library information for Panorama Public submissions

### DIFF
--- a/panoramapublic/build.gradle
+++ b/panoramapublic/build.gradle
@@ -37,5 +37,6 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"), depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:targetedms", depProjectConfig: "published", depExtension: "module")
 }

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.query.xml
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.query.xml
@@ -1,10 +1,22 @@
 <query xmlns="http://labkey.org/data/xml/query">
     <metadata>
         <tables xmlns="http://labkey.org/data/xml">
-            <table tableName="SpectralLibraries" tableDbType="TABLE">
+            <table tableName="SpectralLibraries" tableDbType="NOT_IN_DB">
                 <columns>
                     <column columnName="FileNameHint">
                         <columnTitle>File Name</columnTitle>
+                    </column>
+                    <column columnName="SpecLibInfoId/SourceType/Value">
+                        <columnTitle>Library Source</columnTitle>
+                    </column>
+                    <column columnName="SpecLibInfoId/SourceUrl">
+                        <columnTitle>Library URL</columnTitle>
+                    </column>
+                    <column columnName="SpecLibInfoId/SourceAccession">
+                        <columnTitle>External Accession</columnTitle>
+                    </column>
+                    <column columnName="SpecLibInfoId/DependencyType/Value">
+                        <columnTitle>Library Dependency</columnTitle>
                     </column>
                     <column columnName="SkylineDocLibraries">
                         <columnTitle>Skyline Documents With Library</columnTitle>

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.query.xml
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.query.xml
@@ -1,0 +1,36 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="SpectralLibraries" tableDbType="TABLE">
+                <columns>
+                    <column columnName="FileNameHint">
+                        <columnTitle>File Name</columnTitle>
+                    </column>
+                    <column columnName="SkylineDocLibraries">
+                        <columnTitle>Skyline Documents With Library</columnTitle>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.speclib.LibraryDocsDisplayColumnFactory</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="Details">
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.speclib.EditLibraryDisplayColumnFactory</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="SpecLibId">
+                        <fk>
+                            <fkDbSchema>targetedms</fkDbSchema>
+                            <fkTable>SpectrumLibrary</fkTable>
+                        </fk>
+                    </column>
+                    <column columnName="SpecLibInfoId">
+                        <fk>
+                            <fkDbSchema>panoramapublic</fkDbSchema>
+                            <fkTable>SpecLibInfo</fkTable>
+                        </fk>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.query.xml
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.query.xml
@@ -24,9 +24,9 @@
                             <className>org.labkey.panoramapublic.query.speclib.LibraryDocsDisplayColumnFactory</className>
                         </displayColumnFactory>
                     </column>
-                    <column columnName="Details">
+                    <column columnName="LibraryInfo">
                         <displayColumnFactory>
-                            <className>org.labkey.panoramapublic.query.speclib.EditLibraryDisplayColumnFactory</className>
+                            <className>org.labkey.panoramapublic.query.speclib.EditLibInfoDisplayColumnFactory</className>
                         </displayColumnFactory>
                     </column>
                     <column columnName="SpecLibId">

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.sql
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.sql
@@ -8,14 +8,14 @@ FROM
         filenamehint,
         skylinelibraryid,
         revision,
-        GROUP_CONCAT(DISTINCT Id, ',') AS SpecLibIds, -- Other libraries, in other Skyline documents, with the same values
-        MAX(Id) AS SpecLibId -- One spectral library that we can use as the example
+        GROUP_CONCAT(Id, ',') AS SpecLibIds, -- other libraries with the same values
+        MAX(Id) AS SpecLibId -- one library that we can use as the example
  FROM targetedms.spectrumlibrary
  GROUP BY librarytype, name, filenamehint, skylinelibraryid, revision
 ) lib
 LEFT OUTER JOIN panoramapublic.speclibinfo libInfo ON
-libInfo.librarytype = lib.librarytype
-AND libInfo.name = lib.name
+libInfo.librarytype = lib.librarytype -- librarytype is not nullable
+AND libInfo.name = lib.name -- name is not nullable
 AND ((libInfo.filenamehint IS NULL AND lib.filenamehint IS NULL) OR (libInfo.filenamehint = lib.filenamehint))
 AND ((libinfo.skylinelibraryid IS NULL AND lib.skylinelibraryid IS NULL) OR libinfo.skylinelibraryid = lib.skylinelibraryid)
 AND ((libinfo.revision IS NULL AND lib.revision IS NULL) OR libinfo.revision = lib.revision)

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.sql
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.sql
@@ -1,6 +1,6 @@
 SELECT lib.*,
        lib.SpecLibIds AS SkylineDocLibraries,
-       lib.SpecLibId AS Details,
+       lib.SpecLibId AS LibraryInfo,
        libinfo.id AS specLibInfoId
 FROM
 (SELECT librarytype,

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.sql
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries.sql
@@ -1,0 +1,21 @@
+SELECT lib.*,
+       lib.SpecLibIds AS SkylineDocLibraries,
+       lib.SpecLibId AS Details,
+       libinfo.id AS specLibInfoId
+FROM
+(SELECT librarytype,
+        name,
+        filenamehint,
+        skylinelibraryid,
+        revision,
+        GROUP_CONCAT(DISTINCT Id, ',') AS SpecLibIds, -- Other libraries, in other Skyline documents, with the same values
+        MAX(Id) AS SpecLibId -- One spectral library that we can use as the example
+ FROM targetedms.spectrumlibrary
+ GROUP BY librarytype, name, filenamehint, skylinelibraryid, revision
+) lib
+LEFT OUTER JOIN panoramapublic.speclibinfo libInfo ON
+libInfo.librarytype = lib.librarytype
+AND libInfo.name = lib.name
+AND ((libInfo.filenamehint IS NULL AND lib.filenamehint IS NULL) OR (libInfo.filenamehint = lib.filenamehint))
+AND ((libinfo.skylinelibraryid IS NULL AND lib.skylinelibraryid IS NULL) OR libinfo.skylinelibraryid = lib.skylinelibraryid)
+AND ((libinfo.revision IS NULL AND lib.revision IS NULL) OR libinfo.revision = lib.revision)

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/.qview.xml
@@ -1,0 +1,8 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <columns>
+        <column name="Name" />
+        <column name="FileNameHint">
+        </column>
+        <column name="SkylineDocLibraries" />
+    </columns>
+</customView>

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/.qview.xml
@@ -1,8 +1,7 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <columns>
         <column name="Name" />
-        <column name="FileNameHint">
-        </column>
+        <column name="FileNameHint" />
         <column name="SkylineDocLibraries" />
     </columns>
 </customView>

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/SpectralLibrariesInfo.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/SpectralLibrariesInfo.qview.xml
@@ -1,0 +1,31 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <columns>
+        <column name="Name" />
+        <column name="FileNameHint">
+            <properties>
+                <property name="columnTitle" value="File Name" />
+            </properties>
+        </column>
+        <column name="SkylineDocLibraries" />
+        <column name="SpecLibInfoId/SourceType/Value">
+            <properties>
+                <property name="columnTitle" value="Library Source" />
+            </properties>
+        </column>
+        <column name="SpecLibInfoId/SourceUrl">
+            <properties>
+                <property name="columnTitle" value="Library URL" />
+            </properties>
+        </column>
+        <column name="SpecLibInfoId/SourceAccession">
+            <properties>
+                <property name="columnTitle" value="External Accession" />
+            </properties>
+        </column>
+        <column name="SpecLibInfoId/DependencyType/Value">
+            <properties>
+                <property name="columnTitle" value="Library Dependency" />
+            </properties>
+        </column>
+    </columns>
+</customView>

--- a/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/SpectralLibrariesInfo.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/SpectralLibraries/SpectralLibrariesInfo.qview.xml
@@ -1,31 +1,11 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <columns>
         <column name="Name" />
-        <column name="FileNameHint">
-            <properties>
-                <property name="columnTitle" value="File Name" />
-            </properties>
-        </column>
+        <column name="FileNameHint" />
         <column name="SkylineDocLibraries" />
-        <column name="SpecLibInfoId/SourceType/Value">
-            <properties>
-                <property name="columnTitle" value="Library Source" />
-            </properties>
-        </column>
-        <column name="SpecLibInfoId/SourceUrl">
-            <properties>
-                <property name="columnTitle" value="Library URL" />
-            </properties>
-        </column>
-        <column name="SpecLibInfoId/SourceAccession">
-            <properties>
-                <property name="columnTitle" value="External Accession" />
-            </properties>
-        </column>
-        <column name="SpecLibInfoId/DependencyType/Value">
-            <properties>
-                <property name="columnTitle" value="Library Dependency" />
-            </properties>
-        </column>
+        <column name="SpecLibInfoId/SourceType/Value" />
+        <column name="SpecLibInfoId/SourceUrl" />
+        <column name="SpecLibInfoId/SourceAccession" />
+        <column name="SpecLibInfoId/DependencyType/Value" />
     </columns>
 </customView>

--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-21.001-21.002.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-21.001-21.002.sql
@@ -26,7 +26,7 @@ CREATE TABLE panoramapublic.speclibinfo
 
     -- Columns from the targetedms.spectrumlibrary table. The same spectral library can be used in more than one
     -- document. We assume that libraries with identical values for these columns are the same library.
-    -- The VARCHAR column in the targetedms schema have a limit.  Here they are defined without a limit in case
+    -- The VARCHAR columns in the targetedms schema have a limit.  Here they are defined without a limit in case
     -- the column definitions for name, filenamehint and skylinelibraryid change in the targetedms schema.
     librarytype               VARCHAR(20)  NOT NULL,
     name                      VARCHAR NOT NULL, -- VARCHAR(400) NOT NULL,

--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-21.001-21.002.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-21.001-21.002.sql
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CREATE TABLE panoramapublic.speclibinfo
+(
+    _ts               TIMESTAMP,
+    Id                SERIAL NOT NULL,
+    CreatedBy         USERID,
+    Created           TIMESTAMP,
+    ModifiedBy        USERID,
+    Modified          TIMESTAMP,
+
+    experimentAnnotationsId   INT NOT NULL,
+
+    -- Columns from the targetedms.spectrumlibrary table. The same spectral library can be used in more than one
+    -- document. We assume that libraries with identical values for these columns are the same library.
+    -- The VARCHAR column in the targetedms schema have a limit.  Here they are defined without a limit in case
+    -- the column definitions for name, filenamehint and skylinelibraryid change in the targetedms schema.
+    librarytype               VARCHAR(20)  NOT NULL,
+    name                      VARCHAR NOT NULL, -- VARCHAR(400) NOT NULL,
+    filenamehint              VARCHAR, -- VARCHAR(300),
+    skylinelibraryid          VARCHAR, -- VARCHAR(200),
+    revision                  VARCHAR(10),
+
+    SourceType                INT NOT NULL,
+    SourceUrl                 VARCHAR,
+    SourceAccession           VARCHAR(100),
+    SourceUsername            VARCHAR(100),
+    SourcePassword            VARCHAR(100),
+    DependencyType            INT NOT NULL,
+
+    CONSTRAINT PK_SpecLibInfo PRIMARY KEY (Id),
+    CONSTRAINT FK_SpecLibInfo_ExperimentAnnotations FOREIGN KEY (experimentAnnotationsId) REFERENCES panoramapublic.ExperimentAnnotations(Id)
+);
+CREATE INDEX IX_SpecLibInfo_ExperimentAnnotations ON panoramapublic.SpecLibInfo(experimentAnnotationsId);
+

--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -354,4 +354,58 @@
         </columns>
     </table>
 
+    <table tableName="SpecLibInfo" tableDbType="TABLE">
+        <columns>
+            <column columnName="_ts">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Created">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="CreatedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Modified">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="ModifiedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Id"/>
+            <column columnName="librarytype">
+                <nullable>false</nullable>
+            </column>
+            <column columnName="name">
+                <nullable>false</nullable>
+            </column>
+            <column columnName="filenamehint"/>
+            <column columnName="skylinelibraryid"/>
+            <column columnName="revision"/>
+            <column columnName="experimentAnnotationsId">
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>panoramapublic</fkDbSchema>
+                    <fkTable>ExperimentAnnotations</fkTable>
+                </fk>
+            </column>
+            <column columnName="SourceType"/>
+            <column columnName="SourceUrl"/>
+            <column columnName="SourceAccession"/>
+            <column columnName="SourceUsername"/>
+            <column columnName="SourcePassword">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="DependencyType"/>
+        </columns>
+    </table>
 </tables>

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -6080,7 +6080,7 @@ public class PanoramaPublicController extends SpringActionController
             List<DOM.Renderable> rows = new ArrayList<>();
             rows.add(getSummaryRow("Name:", library.getName()));
             rows.add(getSummaryRow("File Name: ", SPAN(library.getFileNameHint(),
-                    SPAN(at(style, "margin-left:5px;"), library.getDownloadLink(getUser())))));
+                    SPAN(at(style, "margin-left:5px; white-space: nowrap;"), library.getDownloadLink(getUser())))));
             rows.add(getSummaryRow("Skyline Document: ",  new Link.LinkBuilder(run.getFileName())
                     .href(PageFlowUtil.urlProvider(TargetedMSUrls.class).getShowRunUrl(run.getContainer(), run.getId()))
                     .clearClasses().build()));
@@ -6165,14 +6165,14 @@ public class PanoramaPublicController extends SpringActionController
             Path libPath = specLib.getLibPath(getUser());
             if (libPath == null)
             {
-                view.addView(new HtmlView(DIV(at(style, "color:red; font-weight:bold;"), "Library file is missing from the Skyline document")));
+                view.addView(new HtmlView(DIV(cl("labkey-error"), "Library file is missing from the Skyline document")));
             }
             else
             {
                 SpecLibReader reader = SpecLibReader.getReader(specLib);
                 if (reader == null)
                 {
-                    view.addView(new HtmlView(DIV(at(style, "color:red; font-weight:bold;"), "Unsupported library. Could not read library source file names.")));
+                    view.addView(new HtmlView(DIV(cl("labkey-error"), "Unsupported library. Could not read library source file names.")));
                 }
                 else
                 {
@@ -6181,7 +6181,7 @@ public class PanoramaPublicController extends SpringActionController
                         List<LibSourceFile> libSourceFiles = reader.readLibSourceFiles(run, specLib);
                         if (libSourceFiles == null || libSourceFiles.size() == 0)
                         {
-                            view.addView(new HtmlView(DIV(at(style, "color:red; font-weight:bold;"), "No library source file names were found.")));
+                            view.addView(new HtmlView(DIV(cl("labkey-error"), "No library source file names were found.")));
                         }
                         else
                         {
@@ -6198,7 +6198,7 @@ public class PanoramaPublicController extends SpringActionController
                     }
                     catch (SpecLibReaderException e)
                     {
-                        view.addView(new HtmlView(DIV(DIV(at(style, "color:red; font-weight:bold;"), "Error reading library source files."),
+                        view.addView(new HtmlView(DIV(DIV(cl("labkey-error"), "Error reading library source files."),
                                 DIV(ExceptionUtil.renderException(e)))));
                     }
                 }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
@@ -17,23 +17,14 @@
 package org.labkey.panoramapublic;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.data.TableSelector;
 import org.labkey.api.portal.ProjectUrls;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class PanoramaPublicManager
 {
@@ -51,7 +42,7 @@ public class PanoramaPublicManager
 
     public static DbSchema getSchema()
     {
-        return DbSchema.get(PanoramaPublicSchema.SCHEMA_NAME);
+        return DbSchema.get(PanoramaPublicSchema.SCHEMA_NAME, DbSchemaType.Module);
     }
 
     public static TableInfo getTableInfoExperimentAnnotations()

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
@@ -17,13 +17,23 @@
 package org.labkey.panoramapublic;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
 import org.labkey.api.portal.ProjectUrls;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PanoramaPublicManager
 {
@@ -72,6 +82,11 @@ public class PanoramaPublicManager
     public static ITargetedMSRun getRunByLsid(String lsid, Container container)
     {
         return TargetedMSService.get().getRunByLsid(lsid, container);
+    }
+
+    public static TableInfo getTableInfoSpecLibInfo()
+    {
+        return getSchema().getTable(PanoramaPublicSchema.TABLE_SPEC_LIB_INFO);
     }
 
     public static ActionURL getRawDataTabUrl(Container container)

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -40,6 +40,7 @@ import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.view.WebPartView;
 import org.labkey.panoramapublic.model.Journal;
+import org.labkey.panoramapublic.model.speclib.SpecLibKey;
 import org.labkey.panoramapublic.pipeline.CopyExperimentPipelineProvider;
 import org.labkey.panoramapublic.proteomexchange.SkylineVersion;
 import org.labkey.panoramapublic.proteomexchange.SubmissionDataValidator;
@@ -313,6 +314,7 @@ public class PanoramaPublicModule extends SpringModule
         set.add(SubmissionDataValidator.TestCase.class);
         set.add(PanoramaPublicNotification.TestCase.class);
         set.add(SkylineVersion.TestCase.class);
+        set.add(SpecLibKey.TestCase.class);
         return set;
 
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -45,6 +45,7 @@ import org.labkey.panoramapublic.proteomexchange.SkylineVersion;
 import org.labkey.panoramapublic.proteomexchange.SubmissionDataValidator;
 import org.labkey.panoramapublic.query.ExperimentTitleDisplayColumn;
 import org.labkey.panoramapublic.query.JournalManager;
+import org.labkey.panoramapublic.query.speclib.SpecLibView;
 import org.labkey.panoramapublic.security.CopyTargetedMSExperimentRole;
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentWebPart;
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentsWebPart;
@@ -210,12 +211,22 @@ public class PanoramaPublicModule extends SpringModule
             }
         };
 
+        BaseWebPartFactory spectralLibrariesFactory = new BaseWebPartFactory("Spectral Libraries")
+        {
+            @Override
+            public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+            {
+                return new SpecLibView(portalCtx);
+            }
+        };
+
         List<WebPartFactory> webpartFactoryList = new ArrayList<>();
         webpartFactoryList.add(experimentAnnotationsListFactory);
         webpartFactoryList.add(containerExperimentFactory);
         webpartFactoryList.add(proteinSearchFactory);
         webpartFactoryList.add(peptideSearchFactory);
         webpartFactoryList.add(dataDownloadInfoFactory);
+        webpartFactoryList.add(spectralLibrariesFactory);
         return webpartFactoryList;
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -73,7 +73,7 @@ public class PanoramaPublicModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.001;
+        return 21.002;
     }
 
     @Override

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -111,10 +111,8 @@ public class PanoramaPublicSchema extends UserSchema
             FilteredTable<PanoramaPublicSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf);
             result.wrapAllColumns(true);
             var projectCol = result.getMutableColumn(FieldKey.fromParts("Project"));
-            // projectCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
             projectCol.setFk(new ContainerForeignKey(result.getUserSchema()));
             var supportContainerCol = result.getMutableColumn(FieldKey.fromParts("SupportContainer"));
-            // supportContainerCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
             supportContainerCol.setFk(new ContainerForeignKey(result.getUserSchema()));
             return result;
         }
@@ -192,45 +190,6 @@ public class PanoramaPublicSchema extends UserSchema
 
                     sql.append(" WHERE ");
                     sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("exp.Container"), getContainer()));
-                }
-                sql.append(") ");
-                sql.append(alias);
-
-                return sql;
-            }
-        };
-        result.wrapAllColumns(true);
-        return result;
-    }
-
-    @NotNull
-    private TableInfo getFilteredSpecLibInfoTable(String name, ContainerFilter cf)
-    {
-        FilteredTable<PanoramaPublicSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf)
-        {
-            @Override
-            protected void applyContainerFilter(ContainerFilter filter)
-            {
-                // Don't apply the container filter normally, let us apply it in our wrapper around the normally generated SQL
-            }
-
-            @Override
-            public SQLFragment getFromSQL(String alias)
-            {
-                // This table does not have a Container column so we will join it to the JournalExperiment and ExperimentAnnotations
-                // tables to filter by the Container of the copied experiment.
-                SQLFragment sql = new SQLFragment("(SELECT X.* FROM ");
-                sql.append(super.getFromSQL("X"));
-                sql.append(" ");
-
-                if (getContainerFilter() != ContainerFilter.EVERYTHING)
-                {
-                    SQLFragment joinToExpAnnotSql = new SQLFragment("INNER JOIN ");
-                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
-                    joinToExpAnnotSql.append(" ON (exp.id = experimentannotationsid) ");
-                    sql.append(joinToExpAnnotSql);
-                    sql.append(" WHERE ");
-                    sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("exp.Container")));
                 }
                 sql.append(") ");
                 sql.append(alias);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -17,11 +17,14 @@
 package org.labkey.panoramapublic;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.data.EnumTableInfo;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
@@ -30,12 +33,18 @@ import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryView;
 import org.labkey.api.query.UserSchema;
-import org.labkey.api.query.column.BuiltInColumnTypes;
 import org.labkey.api.security.User;
+import org.labkey.api.view.ViewContext;
+import org.labkey.panoramapublic.model.speclib.SpecLibDependencyType;
+import org.labkey.panoramapublic.model.speclib.SpecLibSourceType;
 import org.labkey.panoramapublic.query.ExperimentAnnotationsTableInfo;
 import org.labkey.panoramapublic.query.JournalExperimentTableInfo;
 import org.labkey.panoramapublic.query.SubmissionTableInfo;
+import org.labkey.panoramapublic.query.speclib.SpecLibInfoTableInfo;
+import org.springframework.validation.BindException;
 
 import java.util.Set;
 
@@ -49,6 +58,10 @@ public class PanoramaPublicSchema extends UserSchema
     public static final String TABLE_SUBMISSION = "Submission";
     public static final String TABLE_EXPERIMENT_ANNOTATIONS = "ExperimentAnnotations";
     public static final String TABLE_PX_XML = "PxXml";
+    public static final String TABLE_SPEC_LIB_INFO = "SpecLibInfo";
+
+    public static final String TABLE_LIB_DEPENDENCY_TYPE = "SpecLibDependencyType";
+    public static final String TABLE_LIB_SOURCE_TYPE = "SpecLibSourceType";
 
     public PanoramaPublicSchema(User user, Container container)
     {
@@ -98,15 +111,50 @@ public class PanoramaPublicSchema extends UserSchema
             FilteredTable<PanoramaPublicSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf);
             result.wrapAllColumns(true);
             var projectCol = result.getMutableColumn(FieldKey.fromParts("Project"));
-            projectCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
+            // projectCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
+            projectCol.setFk(new ContainerForeignKey(result.getUserSchema()));
             var supportContainerCol = result.getMutableColumn(FieldKey.fromParts("SupportContainer"));
-            supportContainerCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
+            // supportContainerCol.setConceptURI(BuiltInColumnTypes.CONTAINERID_CONCEPT_URI);
+            supportContainerCol.setFk(new ContainerForeignKey(result.getUserSchema()));
             return result;
         }
 
         if(TABLE_PX_XML.equalsIgnoreCase(name))
         {
             return getFilteredPxXmlTable(name, cf);
+        }
+
+        if (TABLE_SPEC_LIB_INFO.equalsIgnoreCase(name))
+        {
+            return new SpecLibInfoTableInfo(this, cf);
+        }
+
+        if (TABLE_LIB_DEPENDENCY_TYPE.equalsIgnoreCase(name))
+        {
+            EnumTableInfo<SpecLibDependencyType> tableInfo = new EnumTableInfo<>(
+                    SpecLibDependencyType.class,
+                    this,
+                    SpecLibDependencyType::getLabel,
+                    true,
+                    "Types of dependencies on a spectral library");
+
+            var viewColumn = tableInfo.getMutableColumn("Value");
+            viewColumn.setLabel("Dependency Type");
+            return tableInfo;
+        }
+
+        if (TABLE_LIB_SOURCE_TYPE.equalsIgnoreCase(name))
+        {
+            EnumTableInfo<SpecLibSourceType> tableInfo = new EnumTableInfo<>(
+                    SpecLibSourceType.class,
+                    this,
+                    SpecLibSourceType::getLabel,
+                    true,
+                    "Spectral library source types");
+
+            var viewColumn = tableInfo.getMutableColumn("Value");
+            viewColumn.setLabel("Library Source");
+            return tableInfo;
         }
         return null;
     }
@@ -155,6 +203,55 @@ public class PanoramaPublicSchema extends UserSchema
         return result;
     }
 
+    @NotNull
+    private TableInfo getFilteredSpecLibInfoTable(String name, ContainerFilter cf)
+    {
+        FilteredTable<PanoramaPublicSchema> result = new FilteredTable<>(getSchema().getTable(name), this, cf)
+        {
+            @Override
+            protected void applyContainerFilter(ContainerFilter filter)
+            {
+                // Don't apply the container filter normally, let us apply it in our wrapper around the normally generated SQL
+            }
+
+            @Override
+            public SQLFragment getFromSQL(String alias)
+            {
+                // This table does not have a Container column so we will join it to the JournalExperiment and ExperimentAnnotations
+                // tables to filter by the Container of the copied experiment.
+                SQLFragment sql = new SQLFragment("(SELECT X.* FROM ");
+                sql.append(super.getFromSQL("X"));
+                sql.append(" ");
+
+                if (getContainerFilter() != ContainerFilter.EVERYTHING)
+                {
+                    SQLFragment joinToExpAnnotSql = new SQLFragment("INNER JOIN ");
+                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
+                    joinToExpAnnotSql.append(" ON (exp.id = experimentannotationsid) ");
+                    sql.append(joinToExpAnnotSql);
+                    sql.append(" WHERE ");
+                    sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("exp.Container")));
+                }
+                sql.append(") ");
+                sql.append(alias);
+
+                return sql;
+            }
+        };
+        result.wrapAllColumns(true);
+        return result;
+    }
+
+    @Override
+    public @NotNull QueryView createView(ViewContext context, @NotNull QuerySettings settings, @Nullable BindException errors)
+    {
+        if (TABLE_SPEC_LIB_INFO.equalsIgnoreCase(settings.getQueryName()))
+        {
+            return new SpecLibInfoTableInfo.UserSchemaView(this, settings, errors);
+        }
+        return super.createView(context, settings, errors);
+    }
+
     @Override
     public Set<String> getTableNames()
     {
@@ -164,6 +261,7 @@ public class PanoramaPublicSchema extends UserSchema
         hs.add(TABLE_SUBMISSION);
         hs.add(TABLE_EXPERIMENT_ANNOTATIONS);
         hs.add(TABLE_PX_XML);
+        hs.add(TABLE_SPEC_LIB_INFO);
 
         return hs;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibDependencyType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibDependencyType.java
@@ -1,0 +1,37 @@
+package org.labkey.panoramapublic.model.speclib;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.SafeToRenderEnum;
+
+public enum SpecLibDependencyType implements SafeToRenderEnum
+{
+    STATISTICALLY_DEPENDENT("Statistically dependent results"),
+    TARGETS_AND_FRAGMENTS("Used for choosing targets and fragments"),
+    TARGETS_ONLY("Used for choosing targets only"),
+    SUPPORTING_INFO("Used only as supporting information"),
+    IRRELEVANT("Irrelevant to results");
+
+    private final String _label;
+
+    SpecLibDependencyType(String label)
+    {
+        _label = label;
+    }
+
+    public String getLabel()
+    {
+        return _label;
+    }
+
+    public static @Nullable SpecLibDependencyType getFromName(String name)
+    {
+        try
+        {
+            return name != null ? valueOf(name) : null;
+        }
+        catch(IllegalArgumentException e)
+        {
+            return null;
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibInfo.java
@@ -1,0 +1,223 @@
+package org.labkey.panoramapublic.model.speclib;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SpecLibInfo
+{
+    private int _id;
+    private int _createdBy;
+    private Date _created;
+    private int _modifiedBy;
+    private Date _modified;
+
+    private int _experimentAnnotationsId;
+
+    private String _name;
+    private String _fileNameHint;
+    private String _skylineLibraryId;
+    private String _libraryType;
+    private String _revision;
+
+    private SpecLibSourceType _sourceType;
+    private String _sourceUrl;
+    private String _sourceAccession;
+    private String _sourceUsername;
+    private String _sourcePassword;
+
+    private SpecLibDependencyType _dependencyType;
+
+
+    public SpecLibInfo() {}
+
+    public SpecLibKey getLibraryKey()
+    {
+        return new SpecLibKey(_name, _fileNameHint, _skylineLibraryId, _libraryType, _revision);
+    }
+
+    public String getStringKey()
+    {
+        return getLibraryKey().getStringKey();
+    }
+
+    public static Map<SpecLibKey, SpecLibInfo> toMap(SpecLibInfo[] specLibInfos)
+    {
+        Map<SpecLibKey, SpecLibInfo> m = new HashMap<>();
+        for (SpecLibInfo specLibInfo : specLibInfos)
+        {
+            m.put(specLibInfo.getLibraryKey(), specLibInfo);
+        }
+        return m;
+    }
+
+    public int getId()
+    {
+        return _id;
+    }
+
+    public void setId(int id)
+    {
+        _id = id;
+    }
+
+    public int getExperimentAnnotationsId()
+    {
+        return _experimentAnnotationsId;
+    }
+
+    public void setExperimentAnnotationsId(int experimentAnnotationsId)
+    {
+        _experimentAnnotationsId = experimentAnnotationsId;
+    }
+
+    public int getCreatedBy()
+    {
+        return _createdBy;
+    }
+
+    public void setCreatedBy(int createdBy)
+    {
+        _createdBy = createdBy;
+    }
+
+    public Date getCreated()
+    {
+        return _created;
+    }
+
+    public void setCreated(Date created)
+    {
+        _created = created;
+    }
+
+    public int getModifiedBy()
+    {
+        return _modifiedBy;
+    }
+
+    public void setModifiedBy(int modifiedBy)
+    {
+        _modifiedBy = modifiedBy;
+    }
+
+    public Date getModified()
+    {
+        return _modified;
+    }
+
+    public void setModified(Date modified)
+    {
+        _modified = modified;
+    }
+
+    public String getName()
+    {
+        return _name;
+    }
+
+    public void setName(String name)
+    {
+        _name = name;
+    }
+
+    public String getFileNameHint()
+    {
+        return _fileNameHint;
+    }
+
+    public void setFileNameHint(String fileNameHint)
+    {
+        _fileNameHint = fileNameHint;
+    }
+
+    public String getSkylineLibraryId()
+    {
+        return _skylineLibraryId;
+    }
+
+    public void setSkylineLibraryId(String skylineLibraryId)
+    {
+        _skylineLibraryId = skylineLibraryId;
+    }
+
+    public String getRevision()
+    {
+        return _revision;
+    }
+
+    public void setRevision(String revision)
+    {
+        _revision = revision;
+    }
+
+    public String getLibraryType()
+    {
+        return _libraryType;
+    }
+
+    public void setLibraryType(String libraryType)
+    {
+        _libraryType = libraryType;
+    }
+
+    public String getSourceUrl()
+    {
+        return _sourceUrl;
+    }
+
+    public void setSourceUrl(String sourceUrl)
+    {
+        _sourceUrl = sourceUrl;
+    }
+
+    public SpecLibDependencyType getDependencyType()
+    {
+        return _dependencyType;
+    }
+
+    public void setSourceType(SpecLibSourceType sourceType)
+    {
+        _sourceType = sourceType;
+    }
+
+    public String getSourceAccession()
+    {
+        return _sourceAccession;
+    }
+
+    public void setSourceAccession(String sourceAccession)
+    {
+        _sourceAccession = sourceAccession;
+    }
+
+    public String getSourceUsername()
+    {
+        return _sourceUsername;
+    }
+
+    public void setSourceUsername(String sourceUsername)
+    {
+        _sourceUsername = sourceUsername;
+    }
+
+    public String getSourcePassword()
+    {
+        return _sourcePassword;
+    }
+
+    public void setSourcePassword(String sourcePassword)
+    {
+        _sourcePassword = sourcePassword;
+    }
+
+    public void setDependencyType(SpecLibDependencyType dependencyType)
+    {
+        _dependencyType = dependencyType;
+    }
+
+    public SpecLibSourceType getSourceType()
+    {
+        return _sourceType;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibInfo.java
@@ -1,6 +1,6 @@
 package org.labkey.panoramapublic.model.speclib;
 
-import java.util.Date;;
+import java.util.Date;
 
 public class SpecLibInfo
 {

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibInfo.java
@@ -1,8 +1,6 @@
 package org.labkey.panoramapublic.model.speclib;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Date;;
 
 public class SpecLibInfo
 {
@@ -33,22 +31,7 @@ public class SpecLibInfo
 
     public SpecLibKey getLibraryKey()
     {
-        return new SpecLibKey(_name, _fileNameHint, _skylineLibraryId, _libraryType, _revision);
-    }
-
-    public String getStringKey()
-    {
-        return getLibraryKey().getStringKey();
-    }
-
-    public static Map<SpecLibKey, SpecLibInfo> toMap(SpecLibInfo[] specLibInfos)
-    {
-        Map<SpecLibKey, SpecLibInfo> m = new HashMap<>();
-        for (SpecLibInfo specLibInfo : specLibInfos)
-        {
-            m.put(specLibInfo.getLibraryKey(), specLibInfo);
-        }
-        return m;
+        return new SpecLibKey(_name, _fileNameHint, _skylineLibraryId, _revision, _libraryType);
     }
 
     public int getId()

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibKey.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibKey.java
@@ -1,0 +1,48 @@
+package org.labkey.panoramapublic.model.speclib;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.panoramapublic.speclib.LibraryType;
+
+public class SpecLibKey
+{
+    private final String _name;
+    private final String _fileNameHint;
+    private final String _skylineLibraryId;
+    private final String _libraryType;
+    private final String _revision;
+
+    private static final String SEP = "__&&__";
+
+    public SpecLibKey(@NotNull String name, @NotNull String fileNameHint, String skylineLibraryId, String libraryType, String revision)
+    {
+        _name = name;
+        _fileNameHint = fileNameHint;
+        _skylineLibraryId = skylineLibraryId;
+        _libraryType = libraryType;
+        _revision = revision;
+    }
+
+    public String getStringKey()
+    {
+        return String.format("%s%s%s%s%s", _name, SEP, _libraryType,
+                (_fileNameHint != null ? SEP + _fileNameHint : ""),
+                (_skylineLibraryId != null ? SEP + _skylineLibraryId : ""),
+                (_revision != null ? SEP + _revision : ""));
+
+    }
+
+    public static SpecLibKey from(String key)
+    {
+        String[] parts = key.split(SEP);
+        if (parts.length > 1)
+        {
+            String name = parts[0];
+            String libraryType = parts[1];
+            String fileNameHint = parts.length > 2 ? parts[2] : null;
+            String skylineLibId = parts.length > 3 ? parts[3] : null;
+            String revision = parts.length > 4 ? parts[4] : null;
+            return new SpecLibKey(name, fileNameHint, skylineLibId, libraryType, revision);
+        }
+        return null;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibKey.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibKey.java
@@ -1,6 +1,11 @@
 package org.labkey.panoramapublic.model.speclib;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
+import org.labkey.panoramapublic.speclib.LibraryType;
+
 import java.util.Objects;
 
 public class SpecLibKey
@@ -31,17 +36,20 @@ public class SpecLibKey
 
     }
 
-    public static SpecLibKey from(String key)
+    public static @Nullable SpecLibKey from(String key)
     {
-        var parts = key.split(SEP);
-        if (parts.length > 1)
+        if (key != null)
         {
-            var libraryType = parts[0];
-            var name = parts[1];
-            var fileNameHint = parts.length > 2 ? parts[2] : null;
-            var skylineLibId = parts.length > 3 ? parts[3] : null;
-            var revision = parts.length > 4 ? parts[4] : null;
-            return new SpecLibKey(name, fileNameHint, skylineLibId, revision, libraryType);
+            var parts = key.split(SEP);
+            if (parts.length > 1)
+            {
+                var libraryType = parts[0];
+                var name = parts[1];
+                var fileNameHint = parts.length > 2 ? parts[2] : null;
+                var skylineLibId = parts.length > 3 ? parts[3] : null;
+                var revision = parts.length > 4 ? parts[4] : null;
+                return new SpecLibKey(name, fileNameHint, skylineLibId, revision, libraryType);
+            }
         }
         return null;
     }
@@ -63,5 +71,34 @@ public class SpecLibKey
     public int hashCode()
     {
         return Objects.hash(_name, _fileNameHint, _skylineLibraryId, _libraryType, _revision);
+    }
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void testSpecLibKey()
+        {
+            var key = new SpecLibKey("BSA Library", null, null, null, LibraryType.nist.getName());
+            var keyString =  LibraryType.nist.getName() + SEP + "BSA Library";
+            assertEquals(keyString, key.toString());
+            assertEquals(SpecLibKey.from(keyString), key);
+
+            key = new SpecLibKey("1593Lumos_1229",
+                    "CFP10_MRM.blib",
+                    "urn:lsid:proteome.gs.washington.edu:spectral_library:bibliospec:nr:CFP10_MRM", "1",
+                    LibraryType.bibliospec_lite.getName());
+            keyString = String.format("%s%s%s%s%s%s%s%s%s",
+                    LibraryType.bibliospec_lite.getName(), SEP,
+                    "1593Lumos_1229", SEP,
+                    "CFP10_MRM.blib", SEP,
+                    "urn:lsid:proteome.gs.washington.edu:spectral_library:bibliospec:nr:CFP10_MRM", SEP,
+                    "1");
+            assertEquals(keyString, key.toString());
+            assertEquals(SpecLibKey.from(keyString), key);
+
+            assertNull(SpecLibKey.from(null));
+            assertNull(SpecLibKey.from("BSA Library"));
+            assertNull(SpecLibKey.from("BSA Library" + SEP));
+        }
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibKey.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibKey.java
@@ -1,7 +1,7 @@
 package org.labkey.panoramapublic.model.speclib;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.panoramapublic.speclib.LibraryType;
+import java.util.Objects;
 
 public class SpecLibKey
 {
@@ -13,18 +13,18 @@ public class SpecLibKey
 
     private static final String SEP = "__&&__";
 
-    public SpecLibKey(@NotNull String name, @NotNull String fileNameHint, String skylineLibraryId, String libraryType, String revision)
+    public SpecLibKey(@NotNull String name, String fileNameHint, String skylineLibraryId, String revision, @NotNull String libraryType)
     {
         _name = name;
         _fileNameHint = fileNameHint;
         _skylineLibraryId = skylineLibraryId;
-        _libraryType = libraryType;
         _revision = revision;
+        _libraryType = libraryType;
     }
 
-    public String getStringKey()
+    public String toString()
     {
-        return String.format("%s%s%s%s%s", _name, SEP, _libraryType,
+        return String.format("%s%s%s%s%s%s", _libraryType, SEP, _name,
                 (_fileNameHint != null ? SEP + _fileNameHint : ""),
                 (_skylineLibraryId != null ? SEP + _skylineLibraryId : ""),
                 (_revision != null ? SEP + _revision : ""));
@@ -33,16 +33,35 @@ public class SpecLibKey
 
     public static SpecLibKey from(String key)
     {
-        String[] parts = key.split(SEP);
+        var parts = key.split(SEP);
         if (parts.length > 1)
         {
-            String name = parts[0];
-            String libraryType = parts[1];
-            String fileNameHint = parts.length > 2 ? parts[2] : null;
-            String skylineLibId = parts.length > 3 ? parts[3] : null;
-            String revision = parts.length > 4 ? parts[4] : null;
-            return new SpecLibKey(name, fileNameHint, skylineLibId, libraryType, revision);
+            var libraryType = parts[0];
+            var name = parts[1];
+            var fileNameHint = parts.length > 2 ? parts[2] : null;
+            var skylineLibId = parts.length > 3 ? parts[3] : null;
+            var revision = parts.length > 4 ? parts[4] : null;
+            return new SpecLibKey(name, fileNameHint, skylineLibId, revision, libraryType);
         }
         return null;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpecLibKey that = (SpecLibKey) o;
+        return _name.equals(that._name)
+                && _libraryType.equals(that._libraryType)
+                && Objects.equals(_fileNameHint, that._fileNameHint)
+                && Objects.equals(_skylineLibraryId, that._skylineLibraryId)
+                && Objects.equals(_revision, that._revision);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(_name, _fileNameHint, _skylineLibraryId, _libraryType, _revision);
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibSourceType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibSourceType.java
@@ -34,7 +34,7 @@ public enum SpecLibSourceType implements SafeToRenderEnum
         }
     }
 
-    public static SpecLibSourceType[] valuesForLibrary(SpectrumLibrary library)
+    public static SpecLibSourceType[] valuesForLibrary(SpectralLibrary library)
     {
         if (library.isSupported())
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibSourceType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpecLibSourceType.java
@@ -1,0 +1,45 @@
+package org.labkey.panoramapublic.model.speclib;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.util.SafeToRenderEnum;
+
+public enum SpecLibSourceType implements SafeToRenderEnum
+{
+    LOCAL("Uploaded to project"),
+    PUBLIC_LIBRARY("Public library"),
+    OTHER_REPOSITORY("Source files in external repository"),
+    UNAVAILABLE("Source files unavailable");
+
+    private final String _label;
+
+    SpecLibSourceType(String label)
+    {
+        _label = label;
+    }
+
+    public String getLabel()
+    {
+        return _label;
+    }
+
+    public static @Nullable SpecLibSourceType getForName(String name)
+    {
+        try
+        {
+            return name != null ? valueOf(name) : null;
+        }
+        catch(IllegalArgumentException e)
+        {
+            return null;
+        }
+    }
+
+    public static SpecLibSourceType[] valuesForLibrary(SpectrumLibrary library)
+    {
+        if (library.isSupported())
+        {
+            return values();
+        }
+        return new SpecLibSourceType[]{PUBLIC_LIBRARY};
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpectralLibrary.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpectralLibrary.java
@@ -30,6 +30,7 @@ import static org.labkey.api.util.DOM.Attribute.style;
 import static org.labkey.api.util.DOM.EM;
 import static org.labkey.api.util.DOM.SPAN;
 import static org.labkey.api.util.DOM.at;
+import static org.labkey.api.util.DOM.cl;
 
 public class SpectralLibrary implements ISpectrumLibrary
 {
@@ -166,7 +167,7 @@ public class SpectralLibrary implements ISpectrumLibrary
         initRun(user);
         if (_run == null)
         {
-            return SPAN(at(style, "color:red;"), "Run not found");
+            return SPAN(cl("labkey-error"), "Run not found");
         }
         var runUrl = PageFlowUtil.urlProvider(TargetedMSUrls.class).getShowRunUrl(_run.getContainer(), _run.getId());
         return new Link.LinkBuilder(_run.getFileName()).href(runUrl).clearClasses().build();
@@ -174,7 +175,7 @@ public class SpectralLibrary implements ISpectrumLibrary
 
     public @NotNull DOM.Renderable getViewLibInfoAndDownloadLink(@NotNull User user, @NotNull Map<String, String> viewSpecLibParams)
     {
-        return SPAN(getViewLibInfoLink(viewSpecLibParams), getDownloadLink(user));
+        return SPAN(at(style, "white-space: nowrap;"), getViewLibInfoLink(viewSpecLibParams), getDownloadLink(user));
     }
 
     @NotNull
@@ -215,19 +216,18 @@ public class SpectralLibrary implements ISpectrumLibrary
             }
             return missingLibrary("Library not included in the Skyline document zip file");
         }
-        return SPAN(at(style, "color:red;"), "Run not found");
+        return SPAN(cl("labkey-error"), "Run not found");
     }
 
     @NotNull
     private DOM.Renderable missingLibrary(String popupText)
     {
-        return EM(at(style, "color:red;",
-                DOM.Attribute.title, popupText),
-                "(Missing Library)");
+        return SPAN(cl("labkey-error"), EM(at(DOM.Attribute.title, popupText), "(Missing Library)"));
     }
 
     private @Nullable String getWebdavUrl(@NotNull Container container, @NotNull Path file)
     {
+        // NOTE: There are no exp.data rows for spectral library files. Otherwise we could use ExpData.getWebDavURL()
         var fcs = FileContentService.get();
         if (fcs != null)
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpectralLibrary.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpectralLibrary.java
@@ -130,6 +130,12 @@ public class SpectralLibrary implements ISpectrumLibrary
         }
     }
 
+    public @Nullable Path getLibPath(User user)
+    {
+        initLibPath(user);
+        return _libFilePath;
+    }
+
     private void initLibPath(User user)
     {
         if (_libFilePath == null && !_pathInitialized)
@@ -163,7 +169,6 @@ public class SpectralLibrary implements ISpectrumLibrary
             return SPAN(at(style, "color:red;"), "Run not found");
         }
         var runUrl = PageFlowUtil.urlProvider(TargetedMSUrls.class).getShowRunUrl(_run.getContainer(), _run.getId());
-
         return new Link.LinkBuilder(_run.getFileName()).href(runUrl).clearClasses().build();
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpectrumLibrary.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/speclib/SpectrumLibrary.java
@@ -1,0 +1,250 @@
+package org.labkey.panoramapublic.model.speclib;
+
+import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.files.FileContentService;
+import org.labkey.api.security.User;
+import org.labkey.api.settings.AppProps;
+import org.labkey.api.targetedms.ISpectrumLibrary;
+import org.labkey.api.targetedms.ITargetedMSRun;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.api.targetedms.TargetedMSUrls;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.FileUtil;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.Link;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.ActionURL;
+import org.labkey.api.webdav.WebdavService;
+import org.labkey.panoramapublic.PanoramaPublicController;
+import org.labkey.panoramapublic.speclib.LibraryType;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.labkey.api.util.DOM.Attribute.style;
+import static org.labkey.api.util.DOM.EM;
+import static org.labkey.api.util.DOM.SPAN;
+import static org.labkey.api.util.DOM.at;
+
+public class SpectrumLibrary implements ISpectrumLibrary
+{
+    private final long _id;
+    private final long _runId;
+    private final String _name;
+    private final String _fileNameHint;
+    private final String _skylineLibraryId;  // lsid in <bibliospec_lite_library> element, id in others
+    private final String _revision;
+    private final String _libraryType;
+
+    private ITargetedMSRun _run;
+    private boolean _runInitialized;
+    private Path _libFilePath;
+    private boolean _pathInitialized;
+    private long _fileSize = 0L;
+
+    public SpectrumLibrary(@NotNull ISpectrumLibrary library)
+    {
+        _id = library.getId();
+        _runId = library.getRunId();
+        _libraryType = library.getLibraryType();
+        _name = library.getName();
+        _fileNameHint = library.getFileNameHint();
+        _skylineLibraryId = library.getSkylineLibraryId();
+        _revision = library.getRevision();
+    }
+
+    @Override
+    public long getId()
+    {
+        return _id;
+    }
+
+    @Override
+    public long getRunId()
+    {
+        return _runId;
+    }
+
+    @Override
+    public String getName()
+    {
+        return _name;
+    }
+
+    @Override
+    public String getFileNameHint()
+    {
+        return _fileNameHint;
+    }
+
+    @Override
+    public String getSkylineLibraryId()
+    {
+        return _skylineLibraryId;
+    }
+
+    @Override
+    public String getRevision()
+    {
+        return _revision;
+    }
+
+    @Override
+    public String getLibraryType()
+    {
+        return _libraryType;
+    }
+
+    public SpecLibKey getKey()
+    {
+        return new SpecLibKey(getName(), getFileNameHint(), getSkylineLibraryId(), getLibraryType(), getRevision());
+    }
+
+    public LibraryType getType()
+    {
+        return getLibraryType() != null ? LibraryType.getType(getLibraryType()) : LibraryType.unknown;
+    }
+
+    public boolean isSupported()
+    {
+        return getType().isSupported();
+    }
+
+    public ITargetedMSRun getRun(User user)
+    {
+        initRun(user);
+        return _run;
+    }
+
+    private void initRun(User user)
+    {
+        if (_run == null && !_runInitialized)
+        {
+            _run = TargetedMSService.get().getRun(getRunId(), user);
+            _runInitialized = true;
+        }
+    }
+
+    public Path getLibFilePath(User user)
+    {
+        initLibPath(user);
+        return _libFilePath;
+    }
+
+    private void initLibPath(User user)
+    {
+        if (_libFilePath == null && !_pathInitialized)
+        {
+            initRun(user);
+            if (_run != null)
+            {
+                Path path = TargetedMSService.get().getLibraryFilePath(_run, this);
+                _pathInitialized = true;
+                if (path != null && FileUtil.isFileAndExists(path))
+                {
+                    _libFilePath = path;
+                    try { _fileSize = Files.size(_libFilePath); } catch (IOException ignored) {}
+                }
+            }
+        }
+    }
+
+    public @NotNull DOM.Renderable getRunLibraryLink(@NotNull User user, @NotNull Map<String, String> viewSpecLibParams)
+    {
+        return SPAN(getRunLink(user),
+                HtmlString.NBSP,
+                SPAN(at(style, "margin-left:5px;"), getViewLibInfoLink(viewSpecLibParams)));
+    }
+
+    public @NotNull DOM.Renderable getRunLink(@NotNull User user)
+    {
+        initRun(user);
+        if (_run == null)
+        {
+            return SPAN(at(style, "color:red;"), "Run not found");
+        }
+        ActionURL runUrl = PageFlowUtil.urlProvider(TargetedMSUrls.class).getShowRunUrl(_run.getContainer(), _run.getId());
+
+        return new Link.LinkBuilder(_run.getFileName()).href(runUrl).clearClasses().build();
+    }
+
+    @NotNull
+    public DOM.Renderable getViewLibInfoAndDownloadLink(@NotNull User user, @NotNull Map<String, String> viewSpecLibParams)
+    {
+        return SPAN(getViewLibInfoLink(viewSpecLibParams), getDownloadLink(user));
+    }
+
+    @NotNull
+    private DOM.Renderable getViewLibInfoLink(@NotNull Map<String, String> viewSpecLibParams)
+    {
+        ActionURL viewSpecLibAction = new ActionURL(PanoramaPublicController.ViewSpecLibAction.class, _run.getContainer());
+        viewSpecLibAction.addParameter("specLibId", getId());
+        for (Map.Entry<String, String> param : viewSpecLibParams.entrySet())
+        {
+            viewSpecLibAction.replaceParameter(param.getKey(), param.getValue());
+        }
+        return new Link.LinkBuilder("Library").href(viewSpecLibAction).tooltip("View library details").build();
+    }
+
+    @NotNull
+    public DOM.Renderable getDownloadLink(@NotNull User user)
+    {
+        initRun(user);
+        if (_run != null)
+        {
+            initLibPath(user);
+            if (_libFilePath != null)
+            {
+                var webdavUrl = getWebdavUrl(_run.getContainer(), _libFilePath);
+                if (webdavUrl != null)
+                {
+                    var displaySize = FileUtils.byteCountToDisplaySize(_fileSize);
+                    return SPAN(
+                            new Link.LinkBuilder().href(webdavUrl).iconCls("fa fa-download").build(),
+                            HtmlString.NBSP,
+                            new Link.LinkBuilder(displaySize).href(webdavUrl).tooltip("Download library file included in the Skyline document").clearClasses().build()
+                    );
+                }
+                else
+                {
+                    return missingLibrary("Cannot build WebDAV URL");
+                }
+            }
+            return missingLibrary("Library file not included in the Skyline document zip file");
+        }
+        return SPAN(at(style, "color:red;"), "Run not found");
+    }
+
+    @NotNull
+    private DOM.Renderable missingLibrary(String popupText)
+    {
+        return EM(at(style, "color:red;",
+                DOM.Attribute.title, popupText),
+                "(Missing Library)");
+    }
+
+    private @Nullable String getWebdavUrl(@NotNull Container container, @NotNull Path file)
+    {
+        FileContentService fcs = FileContentService.get();
+        if (fcs != null)
+        {
+            var fileRootPath = fcs.getFileRootPath(container, FileContentService.ContentType.files);
+            if (fileRootPath != null)
+            {
+                var relPath = fileRootPath.relativize(file);
+                var path = WebdavService.getPath()
+                        .append(container.getParsedPath())
+                        .append(FileContentService.FILES_LINK)
+                        .append(new org.labkey.api.util.Path(relPath));
+                return AppProps.getInstance().getBaseServerUrl() + AppProps.getInstance().getContextPath() + path.encode();
+            }
+        }
+        return null;
+    }
+}
+

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
@@ -315,7 +315,7 @@ public class ExperimentAnnotationsManager
         Container leaf = container;
         while(container != null && !container.isRoot())
         {
-            ExperimentAnnotations expAnnotations = ExperimentAnnotationsManager.getInContainer(container);
+            ExperimentAnnotations expAnnotations = ExperimentAnnotationsManager.getExperimentInContainer(container);
             if(expAnnotations == null)
             {
                 container = container.getParent();
@@ -337,7 +337,7 @@ public class ExperimentAnnotationsManager
         return null;
     }
 
-    public static ExperimentAnnotations getInContainer(Container container)
+    public static ExperimentAnnotations getExperimentInContainer(Container container)
     {
         SimpleFilter filter = container != null ? SimpleFilter.createContainerFilter(container) : null;
         List<ExperimentAnnotations> expAnnotations = new TableSelector(PanoramaPublicManager.getTableInfoExperimentAnnotations(),

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
@@ -279,6 +279,10 @@ public class ExperimentAnnotationsManager
             SubmissionManager.beforeCopiedExperimentDeleted(expAnnotations, user);
         }
 
+        // Delete any rows in the panoramapublic.speclibinfo table associated with this experiment
+        Table.delete(PanoramaPublicManager.getTableInfoSpecLibInfo(),
+                new SimpleFilter().addCondition(FieldKey.fromParts("ExperimentAnnotationsId"), expAnnotations.getId()));
+
         Table.delete(PanoramaPublicManager.getTableInfoExperimentAnnotations(), expAnnotations.getId());
 
         if(expAnnotations.isJournalCopy() && expAnnotations.getShortUrl() != null)
@@ -311,7 +315,7 @@ public class ExperimentAnnotationsManager
         Container leaf = container;
         while(container != null && !container.isRoot())
         {
-            ExperimentAnnotations expAnnotations = ExperimentAnnotationsManager.get(container);
+            ExperimentAnnotations expAnnotations = ExperimentAnnotationsManager.getInContainer(container);
             if(expAnnotations == null)
             {
                 container = container.getParent();
@@ -333,7 +337,7 @@ public class ExperimentAnnotationsManager
         return null;
     }
 
-    private static ExperimentAnnotations get(Container container)
+    public static ExperimentAnnotations getInContainer(Container container)
     {
         SimpleFilter filter = container != null ? SimpleFilter.createContainerFilter(container) : null;
         List<ExperimentAnnotations> expAnnotations = new TableSelector(PanoramaPublicManager.getTableInfoExperimentAnnotations(),

--- a/panoramapublic/src/org/labkey/panoramapublic/query/PanoramaPublicTable.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/PanoramaPublicTable.java
@@ -1,0 +1,49 @@
+package org.labkey.panoramapublic.query;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.FilteredTable;
+import org.labkey.panoramapublic.PanoramaPublicSchema;
+
+public class PanoramaPublicTable extends FilteredTable<PanoramaPublicSchema>
+{
+    private final SQLFragment _joinSql;
+    private final SQLFragment _containerSql;
+
+    public PanoramaPublicTable(TableInfo table, PanoramaPublicSchema schema, ContainerFilter cf, SQLFragment joinSql,  SQLFragment containerSql)
+    {
+        super(table, schema, cf);
+        _joinSql = joinSql;
+        _containerSql = containerSql;
+        wrapAllColumns(true);
+    }
+
+    @Override
+    protected void applyContainerFilter(ContainerFilter filter)
+    {
+        // Don't apply the container filter normally, let us apply it in our wrapper around the normally generated SQL
+    }
+
+    @Override
+    @NotNull
+    public SQLFragment getFromSQL(String alias)
+    {
+        SQLFragment sql = new SQLFragment("(SELECT X.* FROM ");
+        sql.append(super.getFromSQL("X"));
+        sql.append(" ");
+
+        if (getContainerFilter() != ContainerFilter.EVERYTHING)
+        {
+            sql.append(_joinSql != null ? _joinSql.getSQL() : "");
+
+            sql.append(" WHERE ");
+            sql.append(getContainerFilter().getSQLFragment(getSchema(), _containerSql));
+        }
+        sql.append(") ");
+        sql.append(alias);
+
+        return sql;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/SpecLibInfoManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/SpecLibInfoManager.java
@@ -1,0 +1,75 @@
+package org.labkey.panoramapublic.query;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.User;
+import org.labkey.api.targetedms.ISpectrumLibrary;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.panoramapublic.PanoramaPublicManager;
+import org.labkey.panoramapublic.model.speclib.SpecLibInfo;
+import org.labkey.panoramapublic.model.speclib.SpectrumLibrary;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class SpecLibInfoManager
+{
+    private SpecLibInfoManager() {}
+
+    public static SpecLibInfo get(int id, Container container)
+    {
+        SQLFragment sql = new SQLFragment("SELECT slib.* FROM ")
+                .append(PanoramaPublicManager.getTableInfoSpecLibInfo(), "slib")
+                .append(" INNER JOIN ")
+                .append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp")
+                .append(" ON exp.Id = slib.experimentAnnotationsId ")
+                .append(" WHERE slib.Id = ? ").add(id)
+                .append(" AND exp.Container = ?").add(container);
+         return new SqlSelector(PanoramaPublicManager.getSchema(), sql).getObject(SpecLibInfo.class);
+    }
+
+    public static SpecLibInfo save(SpecLibInfo specLibInfo, User user)
+    {
+        return Table.insert(user, PanoramaPublicManager.getTableInfoSpecLibInfo(), specLibInfo);
+    }
+
+    public static SpecLibInfo update(SpecLibInfo specLibInfo, User user)
+    {
+        return Table.update(user, PanoramaPublicManager.getTableInfoSpecLibInfo(), specLibInfo, specLibInfo.getId());
+    }
+
+    public static List<SpecLibInfo> getForExperiment(int experimentAnnotationsId, Container container)
+    {
+        var expAnnotations = ExperimentAnnotationsManager.get(experimentAnnotationsId);
+        if (expAnnotations != null && expAnnotations.getContainer().equals(container))
+        {
+            var filter = new SimpleFilter().addCondition(FieldKey.fromParts("experimentAnnotationsId"), experimentAnnotationsId);
+            return new TableSelector(PanoramaPublicManager.getTableInfoSpecLibInfo(), filter, null).getArrayList(SpecLibInfo.class);
+        }
+        return Collections.emptyList();
+    }
+
+    public static @Nullable SpectrumLibrary getSpectrumLibrary(long specLibId, @Nullable Container container, User user)
+    {
+        ISpectrumLibrary library = TargetedMSService.get().getLibrary(specLibId, container, user);
+        return library != null ? new SpectrumLibrary(library) : null;
+    }
+
+    public static List<SpectrumLibrary> getLibraries(Collection<Long> specLibIds, User user)
+    {
+        List<ISpectrumLibrary> libraries = new ArrayList<>();
+        TargetedMSService svc = TargetedMSService.get();
+        specLibIds.forEach(id -> libraries.add(svc.getLibrary(id, null, user)));
+        return libraries.stream().filter(Objects::nonNull).map(SpectrumLibrary::new).collect(Collectors.toList());
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/SpecLibInfoManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/SpecLibInfoManager.java
@@ -13,7 +13,7 @@ import org.labkey.api.targetedms.ISpectrumLibrary;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.panoramapublic.PanoramaPublicManager;
 import org.labkey.panoramapublic.model.speclib.SpecLibInfo;
-import org.labkey.panoramapublic.model.speclib.SpectrumLibrary;
+import org.labkey.panoramapublic.model.speclib.SpectralLibrary;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -28,7 +28,7 @@ public class SpecLibInfoManager
 
     public static SpecLibInfo get(int id, Container container)
     {
-        SQLFragment sql = new SQLFragment("SELECT slib.* FROM ")
+        var sql = new SQLFragment("SELECT slib.* FROM ")
                 .append(PanoramaPublicManager.getTableInfoSpecLibInfo(), "slib")
                 .append(" INNER JOIN ")
                 .append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp")
@@ -59,17 +59,17 @@ public class SpecLibInfoManager
         return Collections.emptyList();
     }
 
-    public static @Nullable SpectrumLibrary getSpectrumLibrary(long specLibId, @Nullable Container container, User user)
+    public static @Nullable SpectralLibrary getSpectralLibrary(long specLibId, @Nullable Container container, User user)
     {
-        ISpectrumLibrary library = TargetedMSService.get().getLibrary(specLibId, container, user);
-        return library != null ? new SpectrumLibrary(library) : null;
+        var library = TargetedMSService.get().getLibrary(specLibId, container, user);
+        return library != null ? new SpectralLibrary(library) : null;
     }
 
-    public static List<SpectrumLibrary> getLibraries(Collection<Long> specLibIds, User user)
+    public static List<SpectralLibrary> getLibraries(Collection<Long> specLibIds, User user)
     {
-        List<ISpectrumLibrary> libraries = new ArrayList<>();
-        TargetedMSService svc = TargetedMSService.get();
+        var libraries = new ArrayList<ISpectrumLibrary>();
+        var svc = TargetedMSService.get();
         specLibIds.forEach(id -> libraries.add(svc.getLibrary(id, null, user)));
-        return libraries.stream().filter(Objects::nonNull).map(SpectrumLibrary::new).collect(Collectors.toList());
+        return libraries.stream().filter(Objects::nonNull).map(SpectralLibrary::new).collect(Collectors.toList());
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibInfoDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibInfoDisplayColumnFactory.java
@@ -17,12 +17,12 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Set;
 
-public class EditLibraryDisplayColumnFactory implements DisplayColumnFactory
+public class EditLibInfoDisplayColumnFactory implements DisplayColumnFactory
 {
     private static final FieldKey SPECLIB_INFO_ID = FieldKey.fromParts("specLibInfoId");
     private static final FieldKey EXPT_ANNOT_ID = FieldKey.fromParts("specLibInfoId", "experimentAnnotationsId");
 
-    public EditLibraryDisplayColumnFactory() {}
+    public EditLibInfoDisplayColumnFactory() {}
 
     @Override
     public DisplayColumn createRenderer(ColumnInfo colInfo)

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibraryDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibraryDisplayColumnFactory.java
@@ -1,0 +1,71 @@
+package org.labkey.panoramapublic.query.speclib;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.ActionURL;
+import org.labkey.panoramapublic.PanoramaPublicController;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Set;
+
+public class EditLibraryDisplayColumnFactory implements DisplayColumnFactory
+{
+    private static final FieldKey SPECLIB_INFO_ID = FieldKey.fromParts("specLibInfoId");
+    private static final FieldKey EXPT_ANNOT_ID = FieldKey.fromParts("specLibInfoId", "experimentAnnotationsId");
+
+    public EditLibraryDisplayColumnFactory() {}
+
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new DataColumn(colInfo)
+        {
+            @Override
+            public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
+            {
+                // Show the link only to users that have have admin permissions in the container
+                if (ctx.getContainer().hasPermission(ctx.getViewContext().getUser(), AdminPermission.class))
+                {
+                    Long specLibId = ctx.get(colInfo.getFieldKey(), Long.class);
+                    Integer specLibInfoId = ctx.get(SPECLIB_INFO_ID, Integer.class);
+                    int experimentAnnotationsId;
+                    if (specLibInfoId != null)
+                    {
+                        experimentAnnotationsId = ctx.get(EXPT_ANNOT_ID, Integer.class);
+                    }
+                    else
+                    {
+                        ExperimentAnnotations exptAnnotations = ExperimentAnnotationsManager.getInContainer(ctx.getContainer());
+                        experimentAnnotationsId = exptAnnotations != null ? exptAnnotations.getId() : 0;
+                    }
+                    if (experimentAnnotationsId != 0)
+                    {
+                        ActionURL editUrl = PanoramaPublicController.getEditSpecLibInfoURL(experimentAnnotationsId, specLibId, specLibInfoId, ctx.getContainer());
+                        editUrl.addReturnURL(ctx.getViewContext().getActionURL());
+                        out.write(PageFlowUtil.link(specLibInfoId != null ? "Edit" : "Add").href(editUrl).toString());
+                        return;
+                    }
+
+                }
+                out.write("<em>Not Editable</em>");
+            }
+
+            @Override
+            public void addQueryFieldKeys(Set<FieldKey> keys)
+            {
+                super.addQueryFieldKeys(keys);
+                keys.add(SPECLIB_INFO_ID);
+                keys.add(EXPT_ANNOT_ID);
+            }
+        };
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/LibraryDocsDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/LibraryDocsDisplayColumnFactory.java
@@ -1,0 +1,82 @@
+package org.labkey.panoramapublic.query.speclib;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.User;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.panoramapublic.model.speclib.SpectrumLibrary;
+import org.labkey.panoramapublic.query.SpecLibInfoManager;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.labkey.api.util.DOM.Attribute.style;
+import static org.labkey.api.util.DOM.TD;
+import static org.labkey.api.util.DOM.TR;
+import static org.labkey.api.util.DOM.at;
+
+public class LibraryDocsDisplayColumnFactory implements DisplayColumnFactory
+{
+    private static final FieldKey SPECLIB_INFO_ID = FieldKey.fromParts("specLibInfoId");
+
+    public LibraryDocsDisplayColumnFactory() {}
+
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new DataColumn(colInfo)
+        {
+            @Override
+            public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
+            {
+                String specLibIds = ctx.get(colInfo.getFieldKey(), String.class);
+                if (!StringUtils.isBlank(specLibIds))
+                {
+                    User user = ctx.getViewContext().getUser();
+                    Set<Long> ids = Arrays.stream(specLibIds.split(","))
+                            .map(s -> NumberUtils.toLong(s, 0))
+                            .filter(l -> l != 0)
+                            .collect(Collectors.toSet());
+                    List<SpectrumLibrary> libraries = SpecLibInfoManager.getLibraries(ids, user);
+                    if (libraries.size() > 0)
+                    {
+                        Integer specLibInfoId = ctx.get(SPECLIB_INFO_ID, Integer.class);
+                        List<DOM.Renderable> runLibraryLinks = new ArrayList<>();
+                        for (SpectrumLibrary library: libraries)
+                        {
+                              runLibraryLinks.add(TR(TD(at(style, "padding:2px 2px 2px 5px;"), library.getRunLink(user)),
+                                      TD(at(style, "padding:2px;"),
+                                              library.getViewLibInfoAndDownloadLink(user, Map.of("allSpecLibIds", specLibIds, "specLibInfoId", String.valueOf(specLibInfoId)))))
+                              );
+                        }
+                        DOM.TABLE(runLibraryLinks).appendTo(out);
+                    }
+                    else
+                    {
+                        out.write("No libraries found for Ids: " + PageFlowUtil.filter(specLibIds));
+                    }
+                }
+            }
+
+            @Override
+            public void addQueryFieldKeys(Set<FieldKey> keys)
+            {
+                super.addQueryFieldKeys(keys);
+                keys.add(SPECLIB_INFO_ID);
+            }
+        };
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/LibraryDocsDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/LibraryDocsDisplayColumnFactory.java
@@ -11,7 +11,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.User;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.PageFlowUtil;
-import org.labkey.panoramapublic.model.speclib.SpectrumLibrary;
+import org.labkey.panoramapublic.model.speclib.SpectralLibrary;
 import org.labkey.panoramapublic.query.SpecLibInfoManager;
 
 import java.io.IOException;
@@ -50,16 +50,19 @@ public class LibraryDocsDisplayColumnFactory implements DisplayColumnFactory
                             .map(s -> NumberUtils.toLong(s, 0))
                             .filter(l -> l != 0)
                             .collect(Collectors.toSet());
-                    List<SpectrumLibrary> libraries = SpecLibInfoManager.getLibraries(ids, user);
+                    List<SpectralLibrary> libraries = SpecLibInfoManager.getLibraries(ids, user);
                     if (libraries.size() > 0)
                     {
                         Integer specLibInfoId = ctx.get(SPECLIB_INFO_ID, Integer.class);
                         List<DOM.Renderable> runLibraryLinks = new ArrayList<>();
-                        for (SpectrumLibrary library: libraries)
+                        for (SpectralLibrary library: libraries)
                         {
-                              runLibraryLinks.add(TR(TD(at(style, "padding:2px 2px 2px 5px;"), library.getRunLink(user)),
+                              runLibraryLinks.add(TR(
+                                      TD(at(style, "padding:2px 2px 2px 5px;"), library.getRunLink(user)),
                                       TD(at(style, "padding:2px;"),
-                                              library.getViewLibInfoAndDownloadLink(user, Map.of("allSpecLibIds", specLibIds, "specLibInfoId", String.valueOf(specLibInfoId)))))
+                                              library.getViewLibInfoAndDownloadLink(user, Map.of(
+                                                      "allSpecLibIds", StringUtils.join(ids, ","),
+                                                      "specLibInfoId", String.valueOf(specLibInfoId)))))
                               );
                         }
                         DOM.TABLE(runLibraryLinks).appendTo(out);

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/LibraryDocsDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/LibraryDocsDisplayColumnFactory.java
@@ -59,7 +59,7 @@ public class LibraryDocsDisplayColumnFactory implements DisplayColumnFactory
                         {
                               runLibraryLinks.add(TR(
                                       TD(at(style, "padding:2px 2px 2px 5px;"), library.getRunLink(user)),
-                                      TD(at(style, "padding:2px;"),
+                                      TD(at(style, "padding:2px; vertical-align:top;"),
                                               library.getViewLibInfoAndDownloadLink(user, Map.of(
                                                       "allSpecLibIds", StringUtils.join(ids, ","),
                                                       "specLibInfoId", String.valueOf(specLibInfoId)))))

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
@@ -30,14 +30,13 @@ import org.labkey.panoramapublic.model.speclib.SpecLibInfo;
 import org.labkey.panoramapublic.query.PanoramaPublicTable;
 import org.springframework.validation.Errors;
 
-import java.io.IOException;
-import java.io.Writer;
-
 public class SpecLibInfoTableInfo extends PanoramaPublicTable
 {
+    private static final String EXP = "Exp";
+
     public SpecLibInfoTableInfo(PanoramaPublicSchema schema, ContainerFilter cf)
     {
-        super(PanoramaPublicManager.getTableInfoSpecLibInfo(), schema, cf, getJoinSql(), new SQLFragment(" exp.Container "));
+        super(PanoramaPublicManager.getTableInfoSpecLibInfo(), schema, cf, getJoinSql(), new SQLFragment(EXP + ".Container"));
 
         var dependencyTypeCol = getMutableColumn("DependencyType");
         if (dependencyTypeCol != null)
@@ -87,8 +86,8 @@ public class SpecLibInfoTableInfo extends PanoramaPublicTable
     private static SQLFragment getJoinSql()
     {
         SQLFragment joinToExpAnnotSql = new SQLFragment(" INNER JOIN ");
-        joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
-        joinToExpAnnotSql.append(" ON (exp.id = experimentAnnotationsId) ");
+        joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), EXP);
+        joinToExpAnnotSql.append(" ON (" + EXP + ".id = experimentAnnotationsId) ");
         return joinToExpAnnotSql;
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
@@ -1,0 +1,205 @@
+package org.labkey.panoramapublic.query.speclib;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.LookupForeignKey;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryView;
+import org.labkey.api.query.RowIdQueryUpdateService;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.query.ValidationException;
+import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.api.util.HtmlString;
+import org.labkey.panoramapublic.PanoramaPublicManager;
+import org.labkey.panoramapublic.PanoramaPublicSchema;
+import org.labkey.panoramapublic.model.speclib.SpecLibInfo;
+import org.labkey.panoramapublic.query.PanoramaPublicTable;
+import org.springframework.validation.Errors;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class SpecLibInfoTableInfo extends PanoramaPublicTable
+{
+    public SpecLibInfoTableInfo(PanoramaPublicSchema schema, ContainerFilter cf)
+    {
+        super(PanoramaPublicManager.getTableInfoSpecLibInfo(), schema, cf, getJoinSql(), new SQLFragment(" exp.Container "));
+
+        var dependencyTypeCol = getMutableColumn("DependencyType");
+        if (dependencyTypeCol != null)
+        {
+            dependencyTypeCol.setFk(new LookupForeignKey()
+            {
+                @Override
+                public TableInfo getLookupTableInfo()
+                {
+                    return getUserSchema().getTable(PanoramaPublicSchema.TABLE_LIB_DEPENDENCY_TYPE, cf);
+                }
+            });
+        }
+
+        var sourceTypeCol = getMutableColumn("SourceType");
+        if (sourceTypeCol != null)
+        {
+            sourceTypeCol.setFk(new LookupForeignKey()
+            {
+                @Override
+                public TableInfo getLookupTableInfo()
+                {
+                    return getUserSchema().getTable(PanoramaPublicSchema.TABLE_LIB_SOURCE_TYPE, cf);
+                }
+            });
+        }
+
+        var sourcePasswordCol = getMutableColumn("SourcePassword");
+        if (sourcePasswordCol != null)
+        {
+            sourcePasswordCol.setDisplayColumnFactory(new PasswordDisplayColumnFactory());
+        }
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        return getContainer().hasPermission(user, perm);
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        return new SpecLibInfoQueryUpdateService(this);
+    }
+
+    private static SQLFragment getJoinSql()
+    {
+        SQLFragment joinToExpAnnotSql = new SQLFragment(" INNER JOIN ");
+        joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
+        joinToExpAnnotSql.append(" ON (exp.id = experimentAnnotationsId) ");
+        return joinToExpAnnotSql;
+    }
+
+    public static class PasswordDisplayColumnFactory implements DisplayColumnFactory
+    {
+        @Override
+        public DisplayColumn createRenderer(ColumnInfo colInfo)
+        {
+            return new DataColumn(colInfo)
+            {
+                @Override
+                public Object getValue(RenderContext ctx)
+                {
+                    if (ctx.getViewContext().getUser().isInSiteAdminGroup())
+                    {
+                        // Show the password only to site admins
+                        return super.getValue(ctx);
+                    }
+                    return "********";
+                }
+
+                @Override
+                public Object getDisplayValue(RenderContext ctx)
+                {
+                    return getValue(ctx);
+                }
+
+                @Override
+                public @NotNull HtmlString getFormattedHtml(RenderContext ctx)
+                {
+                    return HtmlString.of(getValue(ctx));
+                }
+
+                @Override
+                public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
+                {
+                    super.renderGridCellContents(ctx, out);
+                }
+            };
+        }
+    }
+
+    // Update service allows row deletion but not insert or edit
+    public static class SpecLibInfoQueryUpdateService extends RowIdQueryUpdateService<SpecLibInfo>
+    {
+        public SpecLibInfoQueryUpdateService(SpecLibInfoTableInfo guideSetTable)
+        {
+            super(guideSetTable);
+        }
+
+        @Override
+        protected SpecLibInfo createNewBean()
+        {
+            return new SpecLibInfo();
+        }
+
+        @Override
+        public SpecLibInfo get(User user, Container container, int key)
+        {
+            return new TableSelector(PanoramaPublicManager.getTableInfoSpecLibInfo()).getObject(key, SpecLibInfo.class);
+        }
+
+        @Override
+        public void delete(User user, Container container, int key)
+        {
+            Table.delete(PanoramaPublicManager.getTableInfoSpecLibInfo(), key);
+        }
+
+        @Override
+        protected SpecLibInfo insert(User user, Container container, SpecLibInfo bean) throws ValidationException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected SpecLibInfo update(User user, Container container, SpecLibInfo bean, Integer oldKey) throws ValidationException
+        {
+           throw new UnsupportedOperationException();
+        }
+    }
+
+    // View in the query schema browser. Show the delete icon in the toolbar but not the insert or update icons
+    public static class UserSchemaView extends QueryView
+    {
+        public UserSchemaView(UserSchema schema, QuerySettings settings, @Nullable Errors errors)
+        {
+            super(schema, settings, errors);
+        }
+
+        @Override
+        protected boolean canDelete()
+        {
+            return true;
+        }
+
+        @Override
+        protected boolean canInsert()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean showImportDataButton()
+        {
+            return false;
+        }
+
+        @Override
+        protected boolean canUpdate()
+        {
+            return false;
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
@@ -121,12 +121,6 @@ public class SpecLibInfoTableInfo extends PanoramaPublicTable
                 {
                     return HtmlString.of(getValue(ctx));
                 }
-
-                @Override
-                public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
-                {
-                    super.renderGridCellContents(ctx, out);
-                }
             };
         }
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibView.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibView.java
@@ -8,6 +8,7 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QuerySettings;
 import org.labkey.api.query.QueryView;
 import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.ViewContext;
 import org.labkey.panoramapublic.PanoramaPublicSchema;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
@@ -66,12 +67,13 @@ public class SpecLibView extends QueryView
     {
         List<DisplayColumn> displayCols = super.getDisplayColumns();
         if (_exptAnnotations != null && !_exptAnnotations.isJournalCopy()
-                && _exptAnnotations.getContainer().hasPermission(getUser(), AdminPermission.class))
+                && _exptAnnotations.getContainer().hasPermission(getUser(), UpdatePermission.class))
         {
             TableInfo table = getTable();
             if (table != null)
             {
-                var col = table.getColumn(FieldKey.fromParts("Details")).getRenderer();
+                // Show the column for adding / editing library info
+                var col = table.getColumn(FieldKey.fromParts("LibraryInfo")).getRenderer();
                 displayCols.add(col);
             }
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibView.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibView.java
@@ -1,0 +1,80 @@
+package org.labkey.panoramapublic.query.speclib;
+
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.DataRegion;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryView;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.view.ViewContext;
+import org.labkey.panoramapublic.PanoramaPublicSchema;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.panoramapublic.query.SpecLibInfoManager;
+
+import java.util.List;
+
+public class SpecLibView extends QueryView
+{
+    public static final String NAME = "Spectral Libraries";
+    public static final String QUERY_NAME = "SpectralLibraries";
+
+    private final ExperimentAnnotations _exptAnnotations;
+
+    public SpecLibView(ViewContext portalCtx)
+    {
+        this(portalCtx, null);
+    }
+
+    public SpecLibView(ViewContext portalCtx, ExperimentAnnotations exptAnnotations)
+    {
+        super(new PanoramaPublicSchema(portalCtx.getUser(), portalCtx.getContainer()));
+        _exptAnnotations = exptAnnotations;
+        setTitle(NAME);
+        setSettings(createQuerySettings(portalCtx));
+        setShowDetailsColumn(false);
+        setButtonBarPosition(DataRegion.ButtonBarPosition.TOP);
+        setShowExportButtons(false);
+        setShowBorders(true);
+        setShadeAlternatingRows(true);
+        setAllowableContainerFilterTypes(ContainerFilter.Type.Current, ContainerFilter.Type.CurrentAndSubfolders);
+        setFrame(FrameType.PORTAL);
+    }
+
+    private QuerySettings createQuerySettings(ViewContext portalCtx)
+    {
+        String viewName = _exptAnnotations != null &&
+                SpecLibInfoManager.getForExperiment(_exptAnnotations.getId(), portalCtx.getContainer()).size() > 0 ?
+                "SpectralLibrariesInfo" : null;
+
+        QuerySettings settings = getSchema().getSettings(portalCtx, NAME, QUERY_NAME, viewName);
+
+        if(settings.getContainerFilterName() == null && _exptAnnotations != null)
+        {
+            settings.setContainerFilterName(_exptAnnotations.isIncludeSubfolders() ?
+                    ContainerFilter.Type.CurrentAndSubfolders.name() : ContainerFilter.Type.Current.name());
+        }
+        // Allow only folder admins to customize the view
+        settings.setAllowCustomizeView(portalCtx.getContainer().hasPermission(portalCtx.getUser(), AdminPermission.class));
+
+        return settings;
+    }
+
+    @Override
+    public List<DisplayColumn> getDisplayColumns()
+    {
+        List<DisplayColumn> displayCols = super.getDisplayColumns();
+        if (_exptAnnotations != null && !_exptAnnotations.isJournalCopy()
+                && _exptAnnotations.getContainer().hasPermission(getUser(), AdminPermission.class))
+        {
+            TableInfo table = getTable();
+            if (table != null)
+            {
+                var col = table.getColumn(FieldKey.fromParts("Details")).getRenderer();
+                displayCols.add(col);
+            }
+        }
+        return displayCols;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/speclib/LibraryType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/speclib/LibraryType.java
@@ -35,18 +35,21 @@ public enum LibraryType
         return _extension;
     }
 
+    /**
+     * @return true if the library can be read.
+     */
     public boolean isSupported()
     {
         return _supported;
     }
 
-    public static LibraryType getType(@NotNull String typeName)
+    public static @NotNull LibraryType getType(String typeName)
     {
         try
         {
             return valueOf(typeName);
         }
-        catch(IllegalArgumentException e)
+        catch(IllegalArgumentException | NullPointerException e)
         {
             return unknown;
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/speclib/LibraryType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/speclib/LibraryType.java
@@ -1,0 +1,54 @@
+package org.labkey.panoramapublic.speclib;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum LibraryType
+{
+    bibliospec_lite("BiblioSpec", "blib", true),
+    bibliospec("BiblioSpec", "blib", true),
+    elib("EncyclopeDIA", "elib", true),
+    hunter("X!Hunter", "mgf", false),
+    midas("MIDAS", "midas", false),
+    nist("NIST", "msp", false),
+    spectrast("SpectraST", "sptxt", false),
+    chromatogram("Panorama Chromatogram Library", "clib", false),
+    unknown("Unknown Library Type", "unknown", false);
+
+    private final String _name;
+    private final String _extension;
+    private final boolean _supported;
+
+    LibraryType(String type, String extension, boolean supported)
+    {
+        _name = type;
+        _extension = extension;
+        _supported = supported;
+    }
+
+    public String getName()
+    {
+        return _name;
+    }
+
+    public String getExtension()
+    {
+        return _extension;
+    }
+
+    public boolean isSupported()
+    {
+        return _supported;
+    }
+
+    public static LibraryType getType(@NotNull String typeName)
+    {
+        try
+        {
+            return valueOf(typeName);
+        }
+        catch(IllegalArgumentException e)
+        {
+            return unknown;
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/speclib/SpecLibReader.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/speclib/SpecLibReader.java
@@ -19,6 +19,16 @@ import static org.labkey.panoramapublic.speclib.LibraryType.*;
 
 public abstract class SpecLibReader
 {
+    static
+    {
+        try {
+            Class.forName("org.sqlite.JDBC");
+        }
+        catch(ClassNotFoundException e)
+        {
+            throw new RuntimeException("Could not find SQLite driver", e);
+        }
+    }
 
     public static SpecLibReader getReader(ISpectrumLibrary library)
     {

--- a/panoramapublic/src/org/labkey/panoramapublic/speclib/SpecLibReader.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/speclib/SpecLibReader.java
@@ -15,12 +15,10 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.List;
 
+import static org.labkey.panoramapublic.speclib.LibraryType.*;
+
 public abstract class SpecLibReader
 {
-    private enum LibraryTypes
-    {
-        bibliospec_lite, bibliospec, elib, hunter, midas, nist, spectrast, chromatogram
-    }
 
     public static SpecLibReader getReader(ISpectrumLibrary library)
     {
@@ -80,13 +78,13 @@ public abstract class SpecLibReader
 
     public static boolean isBiblioSpec(ISpectrumLibrary library)
     {
-        return LibraryTypes.bibliospec_lite.name().equalsIgnoreCase(library.getLibraryType())
-                || LibraryTypes.bibliospec.name().equalsIgnoreCase(library.getLibraryType());
+        return bibliospec_lite.name().equalsIgnoreCase(library.getLibraryType())
+                || bibliospec.name().equalsIgnoreCase(library.getLibraryType());
     }
 
     public static boolean isEncyclopeDia(ISpectrumLibrary library)
     {
-        return LibraryTypes.elib.name().equalsIgnoreCase(library.getLibraryType());
+        return elib.name().equalsIgnoreCase(library.getLibraryType());
     }
 
     Connection getConnection(String libFile) throws SQLException

--- a/panoramapublic/src/org/labkey/panoramapublic/view/editSpecLibInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/editSpecLibInfo.jsp
@@ -4,7 +4,6 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.panoramapublic.model.speclib.SpecLibSourceType" %>
 <%@ page import="org.labkey.panoramapublic.model.speclib.SpecLibDependencyType" %>
-<%@ page import="org.labkey.panoramapublic.model.speclib.SpectrumLibrary" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -18,9 +17,9 @@
 %>
 <%
     JspView<PanoramaPublicController.SpecLibInfoBean> view = (JspView<PanoramaPublicController.SpecLibInfoBean>) HttpView.currentView();
-    PanoramaPublicController.SpecLibInfoBean bean = view.getModelBean();
-    PanoramaPublicController.EditSpecLibInfoForm form = bean.getForm();
-    SpectrumLibrary library = bean.getLibrary();
+    var bean = view.getModelBean();
+    var form = bean.getForm();
+    var library = bean.getLibrary();
     boolean supportedLibrary = library.isSupported();
     var returnUrl = form.getReturnURLHelper(getContainer().getStartURL(getUser()));
 %>
@@ -44,7 +43,7 @@
             frame: false,
             defaults: {
                 labelWidth: 150,
-                width: 600,
+                width: 500,
                 labelStyle: 'background-color: #E0E6EA; padding: 5px;'
             },
             items: [
@@ -139,7 +138,7 @@
                     allowBlank: true,
                     editable: false,
                     value: <%=form.getDependencyType() != null ? q(form.getDependencyType()) : null%>,
-                    afterLabelTextTpl: <%=q(helpPopup("Level of dependence on the library."))%>,
+                    afterLabelTextTpl: <%=q(helpPopup("How the library was used with the Skyline document."))%>,
                     store: [
                         <% for (SpecLibDependencyType sourceType: SpecLibDependencyType.values()) { %>
                         [ <%= q(sourceType.name()) %>, <%= q(sourceType.getLabel()) %> ],

--- a/panoramapublic/src/org/labkey/panoramapublic/view/editSpecLibInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/editSpecLibInfo.jsp
@@ -1,0 +1,189 @@
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.panoramapublic.model.speclib.SpecLibSourceType" %>
+<%@ page import="org.labkey.panoramapublic.model.speclib.SpecLibDependencyType" %>
+<%@ page import="org.labkey.panoramapublic.model.speclib.SpectrumLibrary" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("Ext4");
+    }
+%>
+<%
+    JspView<PanoramaPublicController.SpecLibInfoBean> view = (JspView<PanoramaPublicController.SpecLibInfoBean>) HttpView.currentView();
+    PanoramaPublicController.SpecLibInfoBean bean = view.getModelBean();
+    PanoramaPublicController.EditSpecLibInfoForm form = bean.getForm();
+    SpectrumLibrary library = bean.getLibrary();
+    boolean supportedLibrary = library.isSupported();
+    var returnUrl = form.getReturnURLHelper(getContainer().getStartURL(getUser()));
+%>
+
+<div style="margin-bottom:10px;">
+    <b>Spectral Library</b>: <%=h(library.getName())%>
+    <br/>
+    <b>File</b>: <%=h(library.getFileNameHint())%>
+</div>
+<labkey:errors/>
+<div id="editSpecLibInfoForm"/>
+
+<script type="text/javascript">
+
+    Ext4.onReady(function(){
+
+        var form = Ext4.create('Ext.form.Panel', {
+            renderTo: "editSpecLibInfoForm",
+            standardSubmit: true,
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 150,
+                width: 600,
+                labelStyle: 'background-color: #E0E6EA; padding: 5px;'
+            },
+            items: [
+                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
+                {
+                    xtype: 'hidden',
+                    name: 'id', // ExperimentAnnotationsId
+                    value: <%=form.getId()%>
+                },
+                {
+                    // instead of generateReturnUrlFormField(returnUrl)
+                    xtype: 'hidden',
+                    name: <%=q(ActionURL.Param.returnUrl.name())%>,
+                    value: <%=q(returnUrl)%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'specLibId', // targetedms.spectrumlibrary.id
+                    value: <%=form.getSpecLibId()%>
+                },
+                <%if(form.getSpecLibInfoId() != null){%>
+                {
+                    xtype: 'hidden',
+                    name: 'specLibInfoId', // panoramapublic.speclibinfo.id
+                    value: <%=form.getSpecLibInfoId()%>
+                },
+                <%}%>
+                {
+                    xtype: 'combobox',
+                    name: 'sourceType',
+                    itemId: 'sourceType',
+                    fieldLabel: "Library Source",
+                    allowBlank: true,
+                    editable: false,
+                    value: <%=form.getSourceType() != null ? q(form.getSourceType()) : null%>,
+                    store: [
+                        <% for (SpecLibSourceType sourceType: SpecLibSourceType.valuesForLibrary(library)) { %>
+                        [ <%= q(sourceType.name()) %>, <%= q(sourceType.getLabel()) %> ],
+                        <% } %>
+                    ],
+                    listeners: {
+                        change: function(cb, newValue) {
+                            sourceTypeComboboxChanged(cb, newValue);
+                        }
+                    }
+                },
+                {
+                    xtype: 'textfield',
+                    name: 'sourceUrl',
+                    itemId: 'sourceUrl',
+                    fieldLabel: "Library URL",
+                    disabled: <%=!SpecLibSourceType.PUBLIC_LIBRARY.name().equals(form.getSourceType())%>,
+                    value: <%=q(form.getSourceUrl())%>,
+                    afterLabelTextTpl: <%=q(helpPopup("URL where the library can be downloaded"))%>
+                },
+                {
+                    xtype: 'textfield',
+                    name: 'sourceAccession',
+                    itemId: 'sourceAccession',
+                    fieldLabel: "Accession",
+                    disabled: <%=!SpecLibSourceType.OTHER_REPOSITORY.name().equals(form.getSourceType())%>,
+                    hidden: <%=!supportedLibrary%>,
+                    value: <%=q(form.getSourceAccession())%>,
+                    afterLabelTextTpl: <%=q(helpPopup("Repository Accession", "Accession or identifier of the data in the repository. " +
+                     "This can be a ProteomeXchange ID (e.g. PXD000001), a MassIVE identifier (e.g. MSV000000001)" +
+                      " or a PeptideAtlas identifier (e.g. PASS00001)."))%>
+                },
+                {
+                    xtype: 'textfield',
+                    name: 'sourceUsername',
+                    itemId: 'sourceUsername',
+                    fieldLabel: "User Name",
+                    disabled: <%=!SpecLibSourceType.OTHER_REPOSITORY.name().equals(form.getSourceType())%>,
+                    hidden: <%=!supportedLibrary%>,
+                    value: <%=q(form.getSourceUsername())%>,
+                    afterLabelTextTpl: <%=q(helpPopup("Repository Username", "Username to access the data in the repository if the data is private."))%>
+                },
+                {
+                    xtype: 'textfield',
+                    name: 'sourcePassword',
+                    itemId: 'sourcePassword',
+                    fieldLabel: "Password",
+                    disabled: <%=!SpecLibSourceType.OTHER_REPOSITORY.name().equals(form.getSourceType())%>,
+                    hidden: <%=!supportedLibrary%>,
+                    value: "", // Don't display the password; make the user enter it every time they edit
+                    afterLabelTextTpl: <%=q(helpPopup("Repository Password", "Password to access the data in the repository if the data is private."))%>
+                },
+                {
+                    xtype: 'combobox',
+                    name: 'dependencyType',
+                    fieldLabel: "Dependency Type",
+                    allowBlank: true,
+                    editable: false,
+                    value: <%=form.getDependencyType() != null ? q(form.getDependencyType()) : null%>,
+                    afterLabelTextTpl: <%=q(helpPopup("Level of dependence on the library."))%>,
+                    store: [
+                        <% for (SpecLibDependencyType sourceType: SpecLibDependencyType.values()) { %>
+                        [ <%= q(sourceType.name()) %>, <%= q(sourceType.getLabel()) %> ],
+                        <% } %>
+                    ]
+                }
+            ],
+            buttonAlign: 'left',
+            buttons: [
+                {
+                    text: "Save",
+                    cls: 'labkey-button primary',
+                    handler: function(button) {
+                        button.setDisabled(true);
+                        form.submit({
+                            url: <%=q(urlFor(PanoramaPublicController.EditSpecLibInfoAction.class))%>,
+                            method: 'POST'
+                        });
+                    }
+                },
+                {
+                    text: 'Cancel',
+                    cls: 'labkey-button',
+                    handler: function(btn) {
+                        window.location = <%= q(returnUrl) %>;
+                    }
+                }]
+        });
+    });
+
+    function toggleTextFields(ownerCt, disable, fields) {
+        for (var i = 0; i < fields.length; i += 1) {
+            var tf = ownerCt.getComponent(fields[i]);
+            if (tf) {
+                if (disable) tf.setValue('');
+                tf.setDisabled(disable);
+            }
+        }
+    }
+
+    function sourceTypeComboboxChanged(cb, newValue) {
+        var otherRepo = newValue === <%=q(SpecLibSourceType.OTHER_REPOSITORY.name())%>;
+        var publicLib = newValue === <%=q(SpecLibSourceType.PUBLIC_LIBRARY.name())%>;
+        toggleTextFields(cb.ownerCt, !otherRepo, ['sourceAccession', 'sourceUsername', 'sourcePassword']);
+        toggleTextFields(cb.ownerCt, !publicLib, ['sourceUrl']);
+    }
+</script>

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -184,8 +184,8 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         Locator.tagWithClass("span", "x4-tree-node-text").withText(PANORAMA_PUBLIC).waitForElement(new WebDriverWait(getDriver(), 5)).click();
         // Enter the name of the destination folder in the Panorama Public project
         setFormElement(Locator.tagWithName("input", "destContainerName"), destinationFolder);
-        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Send Email to Submitter:"));
-        _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, "Assign Digital Object Identifier:")); // Don't try to assign a DOI
+        uncheck("Send Email to Submitter:");
+        uncheck("Assign Digital Object Identifier:");
 
         if(recopy)
         {
@@ -208,6 +208,22 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         // Wait for the pipeline job to finish
         waitForText("Copying experiment");
         waitForPipelineJobsToComplete(1, "Copying experiment: " + experimentTitle, false);
+    }
+
+    private void uncheck(String label)
+    {
+        scrollIntoView(Ext4Helper.Locators.checkbox(this, label));
+        int tries = 1;
+        while(_ext4Helper.isChecked(Ext4Helper.Locators.checkbox(this, label)) && tries <= 5)
+        {
+            _ext4Helper.uncheckCheckbox(Ext4Helper.Locators.checkbox(this, label));
+            tries++;
+            sleep(250);
+        }
+        if(_ext4Helper.isChecked(Ext4Helper.Locators.checkbox(this, label)))
+        {
+            Assert.fail("Did not uncheck checkbox '" + label + "'");
+        }
     }
 
     private void verifyCopy(String experimentTitle, @Nullable Integer version, String projectName, String folderName, String subfolderName, boolean recopy)


### PR DESCRIPTION
#### Rationale
Data submitted to Panorama Public, for a “complete” ProteomeXchange submission, requires the source files (spectrum files + search results files) used to build the library.  The submitter is not required to upload these files to their folder if:
- The library is publicly available (e.g. on PeptideAtlas)
- The source files are already in another PX repository
- The library is either used only as supporting information or is irrelevant to the results

We have created a new interface for the user to provide this information.
Related to Issue 40554: Do not always require raw data and search results used to build spectrum libraries linked to Skyline documents.

#### Related Pull Requests
* https://github.com/LabKey/targetedms/pull/450

#### Changes
Changes are described here: https://docs.google.com/document/d/11_AZwLZXcmF9GW8wdN6_DTgxkFalcTK8gv3bjnUCTBI/edit
- Added a SpecLibInfo table in the panoramapublic schema
- Added SpectralLibraries.sql query to get a list of spectral libraries with the same values for 'librarytype', 'name', 'filenamehint', 'skylinelibraryid', 'revision' from targetedms.spectrumlibrary
- Added a "Spectral Libraries" webpart
- The "Spectral Libraries" grid is added to the experiment details page (ShowExperimentAnnotationsAction) if there are any spectral libraries used with the Skyline documents
- User can enter additional information (e.g. publicly available library, source files in external repository etc.) for a library if the folder contains an experiment
- Spectral library information is copied to the Panorama Public folder


