### PR TITLE
Issue 44416: Fix MacCossLabModules issues found while testing LK 21.11

### DIFF
--- a/lincs/resources/queries/targetedms/TargetedMSRunAndAnnotations.sql
+++ b/lincs/resources/queries/targetedms/TargetedMSRunAndAnnotations.sql
@@ -15,9 +15,9 @@
  */
 SELECT
 runs.*,
-(SELECT GROUP_CONCAT(DISTINCT(Value), ',') AS Values FROM replicateAnnotation WHERE Name='cell_id' AND replicateId IN (SELECT Id FROM replicate where runId = runs.Id)) AS CellLine,
+(SELECT GROUP_CONCAT(DISTINCT(Value), ', ') FROM replicateAnnotation WHERE Name='cell_id' AND replicateId IN (SELECT Id FROM replicate where runId = runs.Id)) AS CellLine,
 -- Added DetPlate column to enable sorting on plate
-(SELECT GROUP_CONCAT(DISTINCT(Value), ',') AS Values FROM replicateAnnotation WHERE Name='det_plate' AND replicateId IN (SELECT Id FROM replicate where runId = runs.Id)) AS DetPlate,
+(SELECT GROUP_CONCAT(DISTINCT(Value), ', ') FROM replicateAnnotation WHERE Name='det_plate' AND replicateId IN (SELECT Id FROM replicate where runId = runs.Id)) AS DetPlate,
 metadata.Label,
 metadata.Token
 FROM runs

--- a/panoramapublic/build.gradle
+++ b/panoramapublic/build.gradle
@@ -25,5 +25,6 @@ dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"), depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:targetedms", depProjectConfig: "published", depExtension: "module")
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataValidator.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/SubmissionDataValidator.java
@@ -295,7 +295,7 @@ public class SubmissionDataValidator
         if(sourceFiles.size() == 1 && !sourceFiles.get(0).hasIdFile())
         {
             String fileName = sourceFiles.get(0).getSpectrumSourceFile();
-            return "Prositintensity_prosit_publication_v1".equals(fileName) && preSkyline21(run);
+            return "Prositintensity_prosit_publication_v1".equals(fileName);
         }
         return false;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
@@ -3,6 +3,9 @@
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.api.util.PageFlowUtil" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
+<%@ page import="org.labkey.api.files.FileContentService" %>
+<%@ page import="org.labkey.api.targetedms.TargetedMSService" %>
+<%@ page import="org.labkey.api.webdav.WebdavService" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <labkey:errors/>
@@ -12,7 +15,12 @@
     // NOTE: This is a link to the data download documentation page on PanoramaWeb.  It will not work on any other server.
     var downloadDataDocHref = "/home/wiki-page.view?name=download_public_data";
     // WebDAV URL to the RawFiles folder in the file root
-    var webdavUrl = AppProps.getInstance().getBaseServerUrl() + PageFlowUtil.encodePath("_webdav" + getContainer().getPath() + "/@files/RawFiles/");
+    var webdavUrl = AppProps.getInstance().getBaseServerUrl() + AppProps.getInstance().getContextPath()
+            + WebdavService.getPath()
+            .append(getContainer().getParsedPath())
+            .append(FileContentService.FILES_LINK, true)
+            .append(TargetedMSService.RAW_FILES_DIR, true)
+            .encode();
 %>
 <p>
     Select one or more files or folders in the browser above and click the download icon ( <span class="fa fa-download"></span> ).


### PR DESCRIPTION
- Table in the "LINCS Data" webpart is not displayed due to errors reported for the TargetedMSRunAndAnnotations.sql query
- WebDAV link in the "Download Data" webpart in the panoramapublic module is missing a "/" before "_webdav"
- Check for a Prosit spectral library should not be dependent on the Skyline version. A value of "Prositintensity_prosit_publication_v1" is expected in the fileName column of a Bibliospec library based on Prosit predictions. This will be updated later if required for future Skyline versions.
