### PR TITLE
Issue 44640: Attempting to view the PxXml table in the schema browser throws a SQL exception

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -134,16 +134,16 @@ public class PanoramaPublicSchema extends UserSchema
                 if (getContainerFilter() != ContainerFilter.EVERYTHING)
                 {
                     SQLFragment joinToExpAnnotSql = new SQLFragment("INNER JOIN ");
-                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoJournalExperiment(), "je");
-                    joinToExpAnnotSql.append(" ON (je.id = JournalExperimentId) ");
+                    joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoSubmission(), "s");
+                    joinToExpAnnotSql.append(" ON (s.journalExperimentId = X.JournalExperimentId) ");
                     joinToExpAnnotSql.append(" INNER JOIN ");
                     joinToExpAnnotSql.append(PanoramaPublicManager.getTableInfoExperimentAnnotations(), "exp");
-                    joinToExpAnnotSql.append(" ON (exp.id = je.CopiedExperimentId) ");
+                    joinToExpAnnotSql.append(" ON (exp.id = s.CopiedExperimentId) ");
 
                     sql.append(joinToExpAnnotSql);
 
                     sql.append(" WHERE ");
-                    sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("exp.Container"), getContainer()));
+                    sql.append(getContainerFilter().getSQLFragment(getSchema(), new SQLFragment("exp.Container")));
                 }
                 sql.append(") ");
                 sql.append(alias);


### PR DESCRIPTION
#### Rationale
Container filter for the pxxml table is using the wrong table. The `copiedExperimentId` column was removed from the `journalexperiment` table and added to the new `submission` table in Issue 43864: Add support for dataset versioning in Panorama Public (PR: #130)

