### PR TITLE
Issue 44656: NPE when viewing PX XML summary in a submitted folder that has not yet been copied

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -3594,7 +3594,12 @@ public class PanoramaPublicController extends SpringActionController
 
             StringBuilder summaryHtml = new StringBuilder();
             PxHtmlWriter writer = new PxHtmlWriter(summaryHtml);
-            Submission submission = expAnnot.isJournalCopy() ? js.getSubmissionForCopiedExperiment(expAnnot.getId()) : js.getLatestCopiedSubmission();
+            Submission submission = expAnnot.isJournalCopy() ? js.getSubmissionForCopiedExperiment(expAnnot.getId()) : js.getLatestSubmission();
+            if (submission == null)
+            {
+                errors.reject(ERROR_MSG, "Could not find a " + (expAnnot.isJournalCopy() ? "copied" : "current") + " submission request for experiment Id: " + experimentId);
+                return new SimpleErrorView(errors);
+            }
             PxExperimentAnnotations pxInfo = new PxExperimentAnnotations(expAnnot, js.getJournalExperiment(), submission);
             pxInfo.setPxChangeLog(form.getChangeLog());
             pxInfo.setVersion(PxXmlManager.getNextVersion(js.getJournalExperimentId()));


### PR DESCRIPTION
Site admins are able to view a summary of the metadata that will be submitted for an experiment when it is announced on ProteomeXchange. This action is usually used in the folder copy on Panorama Public but sometimes it is helpful to see the information in the user's folder. When the action is invoked in a folder that has not yet been copied to Panorama Public it throws a NullPointerException.
