### PR TITLE
Issue 44679: Handle HTML tags in citations returned by Literature Citation Exporter

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -5555,6 +5555,11 @@ public class PanoramaPublicController extends SpringActionController
             return _citation;
         }
 
+        public HtmlString getHtmlCitation()
+        {
+            return ExperimentAnnotations.getHtmlCitation(_citation);
+        }
+
         public void setCitation(String citation)
         {
             _citation = citation;

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -217,15 +217,12 @@
         <% } %>
     </div>
  <% } %>
-<%if(annot.getCitation() != null && annot.getPublicationLink() != null){%>
-    <div class="link"><%=h(annot.getCitation())%> <strong><br />[<a href="<%=h(annot.getPublicationLink())%>" target="_blank">Publication</a>]</strong></div>
-<%}%>
-<%if(annot.getCitation() != null && annot.getPublicationLink() == null){%>
-    <div class="link"><%=h(annot.getCitation())%> </div>
-<%}%>
-<%if(annot.getCitation() == null && annot.getPublicationLink() != null){%>
-    <div class="link"><strong><br />[<a href="<%=h(annot.getPublicationLink())%>" target="_blank">Publication</a>]</strong></div>
-<%}%>
+<% if(annot.getCitation() != null || annot.getPublicationLink() != null) { %>
+    <div class="link">
+        <% if (annot.hasCitation()) { %> <%=annot.getHtmlCitation() %> <% } %>
+        <% if (annot.getPublicationLink() != null) { %> <div><strong>[<a href="<%=h(annot.getPublicationLink())%>" target="_blank">Publication</a>]</strong></div> <% } %>
+    </div>
+<% } %>
 <div>
     <% boolean addSep = false; %>
     <% if(license != null){%>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
@@ -38,7 +38,7 @@
         }
         if (<%=form.hasLinkAndCitation()%>) {
             items.push({xtype: 'component', html: '<b>Link:</b> ' + <%=qh(form.getLink())%>});
-            items.push({xtype: 'component', html: '<b>Citation:</b> <i>' + <%=qh(form.getCitation())%> + '</i>'});
+            items.push({xtype: 'component', html: '<b>Citation:</b> <i>' + <%=q(form.getHtmlCitation())%> + '</i>'});
         }
         else {
             items.push({xtype: 'component', html: 'Publication details were not entered.'});


### PR DESCRIPTION
#### Rationale
Citations returned by the NCBI Literature Citation Exporter can contain HTML tags (e.g. `<sup>`, `<sub>`, `<i>`) for formatting. Pass the citation through `PageFlowUtil.validateHtml()` and `PageFlowUtil.sanitizeHtml()` and so that we can safely display the formatted citation. 
