### PR TITLE
Issue 44668: Display lab head user name entered in submission form

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -4648,6 +4648,26 @@ public class PanoramaPublicController extends SpringActionController
             }
             return "";
         }
+
+        public @Nullable String getLabHeadName()
+        {
+            var labHeadName = _experimentAnnotations.getLabHeadName(); // User selected as the lab head in the experiment annotations
+            if (labHeadName == null)
+            {
+                // If the lab head does not have an account on the server, the submitter can enter the lab head's name etc.
+                // in the submission form. Check if this was the case.
+                if (_experimentAnnotations.isJournalCopy())
+                {
+                    var js  = SubmissionManager.getSubmissionForJournalCopy(_experimentAnnotations);
+                    labHeadName = js != null ? js.getLabHeadNameForCopy(_experimentAnnotations.getId()) : null;
+                }
+                else if (_lastPublishedRecord != null)
+                {
+                    labHeadName = _lastPublishedRecord.getLabHeadName();
+                }
+            }
+            return labHeadName;
+        }
     }
 
     @RequiresPermission(ReadPermission.class)

--- a/panoramapublic/src/org/labkey/panoramapublic/model/JournalSubmission.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/JournalSubmission.java
@@ -158,4 +158,28 @@ public class JournalSubmission
         Submission submission = getLatestSubmission();
         return submission != null && submission.getId() == submissionId;
     }
+
+    /**
+     * @param copiedExperimentId
+     * @return The lab head name entered in the submission request that was copied with the given copiedExperimentId.
+     * Returns null if no lab head information was entered in the submission form.
+     */
+    public @Nullable String getLabHeadNameForCopy(int copiedExperimentId)
+    {
+        return getLabHeadNameInSubmission(getSubmissionForCopiedExperiment(copiedExperimentId));
+    }
+
+    /**
+     * @return The lab head name entered in the latest submission request. Returns null if no lab head information was
+     * entered in the submission form.
+     */
+    public @Nullable String getLabHeadName()
+    {
+        return getLabHeadNameInSubmission(getLatestSubmission());
+    }
+
+    private @Nullable String getLabHeadNameInSubmission(Submission submission)
+    {
+        return submission != null ? submission.getLabHeadName() : null;
+    }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -88,6 +88,7 @@
             }
         }
     }
+    String labHeadName = annotDetails.getLabHeadName();
     String accessUrl = accessUrlRecord == null ? null : accessUrlRecord.renderShortURL();
     String linkText = accessUrl == null ? null : (annot.isJournalCopy() ? "Link" : (journalCopyPending ? "Access link" : journal.getName() + " link"));
     DataLicense license = annot.getDataLicense();
@@ -264,9 +265,9 @@
         <%=h(annot.getKeywords())%>
     </li>
     <%}%>
-    <%if(annot.getSubmitter() != null || annot.getLabHead() != null){%>
+    <%if(annot.getSubmitter() != null || labHeadName != null){%>
     <li>
-        <%if(annot.getLabHead() != null) { %> <span style="margin-right:6px;"><strong>Lab head:</strong> <%=h(annot.getLabHeadName())%> </span> <%}%>
+        <%if(labHeadName != null) { %> <span style="margin-right:6px;"><strong>Lab head:</strong> <%=h(labHeadName)%> </span> <%}%>
         <%if(annot.getSubmitter() != null) { %> <strong>Submitter:</strong> <%=h(annot.getSubmitterName())%>  <%}%>
     </li>
     <%}%>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
@@ -76,7 +76,7 @@
 
     ActionURL cancelUrl = PanoramaPublicController.getViewExperimentDetailsURL(bean.getForm().getId(), getContainer());
 
-    boolean getLabHeadUserInfo = form.isGetPxid() && expAnnotations.getLabHeadUser() == null;
+    boolean getLabHeadUserInfo = expAnnotations.getLabHeadUser() == null;
 %>
 
 <div id="publishExperimentForm"></div>


### PR DESCRIPTION
#### Rationale
Data submitters can select an existing LabKey user as the lab head when they enter experiment annotations in a folder. However, if the lab head does not have an account on the server the submitter can enter their name, email and affiliation in the data submission form. We display the lab head's name in the TargetedMS Experiment webpart only if an existing user was selected in the experiment annotations. We should also display the name if it was entered in the data submission form instead.
We should also allow submitters to enter lab head details for submissions that will not be assigned a ProteomeXchange ID.