### PR TITLE
Issue 44684: Remove hard-coded /labkey from image urls

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -53,6 +53,7 @@ import org.labkey.api.security.roles.FolderAdminRole;
 import org.labkey.api.security.roles.ProjectAdminRole;
 import org.labkey.api.security.roles.Role;
 import org.labkey.api.security.roles.RoleManager;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.SimpleNamedObject;
@@ -73,6 +74,11 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import static org.labkey.api.util.DOM.Attribute.onclick;
+import static org.labkey.api.util.DOM.Attribute.src;
+import static org.labkey.api.util.DOM.IMG;
+import static org.labkey.api.util.DOM.at;
 
 /**
  * User: vsharma
@@ -135,8 +141,13 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
                         if(id != null && container != null)
                         {
                             ActionURL detailsPage = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(container); // experiment container
-                            out.write("<span active=\"false\" loaded=\"false\" onclick=\"viewExperimentDetails(this,'" + container.getPath() + "', '" + id + "','" + detailsPage + "')\"><img id=\"expandcontract-" + id + "\" src=\"/labkey/_images/plus.gif\">&nbsp;");
-                            out.write("</span>");
+                            DOM.SPAN(at(onclick, "viewExperimentDetails(this,'" + container.getPath() + "', '" + id + "','" + detailsPage + "')")
+                                            .data("active", "false") // will be rendered as "data-active" attribute
+                                            .data("loaded", "false"), // will be rendered as "data-loaded" attribute
+                                    IMG(at(DOM.Attribute.id, "expandcontract-" + id)
+                                            .at(src, PageFlowUtil.staticResourceUrl("_images/plus.gif"))),
+                                    HtmlString.NBSP)
+                                    .appendTo(out);
                         }
                         super.renderGridCellContents(ctx, out);
                     }

--- a/panoramapublic/webapp/PanoramaPublic/js/dropDownUtil.js
+++ b/panoramapublic/webapp/PanoramaPublic/js/dropDownUtil.js
@@ -19,8 +19,8 @@ viewExperimentDetails = function (obj, experimentContainer, id, detailsPageURL)
     var abstract = null;
     var expDetails = null;
     var sampleDetails = null;
-    var loaded = obj.getAttribute('loaded');
-    var active = obj.getAttribute('active');
+    var loaded = obj.getAttribute('data-loaded');
+    var active = obj.getAttribute('data-active');
     var currentRow = $(obj).closest('tr');
     var bgColor =  $(obj).closest('tr').css('background');
     var styles = 'style="background:'+bgColor+'; border-bottom:4px solid #DDDDDD;"';
@@ -54,7 +54,7 @@ viewExperimentDetails = function (obj, experimentContainer, id, detailsPageURL)
             }
         }
 
-        $(obj).attr("loaded", "false");
+        $(obj).attr("data-loaded", "false");
     }
 
     function verifyNewCol(object, type, rowNum)
@@ -111,7 +111,7 @@ viewExperimentDetails = function (obj, experimentContainer, id, detailsPageURL)
             var newRow = html.join("");
             currentRow.after(newRow);
             fadeIn();
-            $(obj).attr("loaded", "true");
+            $(obj).attr("data-loaded", "true");
         }
     }
 
@@ -145,15 +145,15 @@ viewExperimentDetails = function (obj, experimentContainer, id, detailsPageURL)
     function fadeIn()
     {
         currentRow.next().fadeIn(500)
-        $(obj).attr("active", "true");
-        $('#expandcontract-'+id).attr('src', '/labkey/_images/minus.gif');
+        $(obj).attr("data-active", "true");
+        $('#expandcontract-'+id).attr('src', LABKEY.contextPath + '/_images/minus.gif');
     }
 
     function fadeOut()
     {
         currentRow.next().fadeOut(200);
-        $(obj).attr("active", "false");
-        $('#expandcontract-'+id).attr('src', '/labkey/_images/plus.gif');
+        $(obj).attr("data-active", "false");
+        $('#expandcontract-'+id).attr('src', LABKEY.contextPath + '/_images/plus.gif');
     }
 }
 }(jQuery);


### PR DESCRIPTION
The '/labkey' context path was hard-coded in the 'plus.gif' and 'minus.gif' image URLs in the javascript used for expanding / collapsing experiment details.
