### PR TITLE
Only link tests in rundown table if there is a failure

### DIFF
--- a/testresults/src/org/labkey/testresults/view/rundown.jsp
+++ b/testresults/src/org/labkey/testresults/view/rundown.jsp
@@ -257,9 +257,9 @@
                         <tr>
                             <td style="width: 200px; max-width: 200px; overflow: hidden; text-overflow: ellipsis; padding: 0;">
                                 <% if (Arrays.stream(problemRuns).anyMatch(run -> problems.isFail(run, test))) { %>
-                                <a href="<%=h(new ActionURL(TestResultsController.ShowFailures.class, c).addParameter("end", df.format(selectedDate)).addParameter("failedTest", test))%>" target="_blank"><%=h(test)%></a>
+                                <%=link(test).href(new ActionURL(TestResultsController.ShowFailures.class, c).addParameter("end", df.format(selectedDate)).addParameter("failedTest", test)).target("_blank").clearClasses()%>
                                 <% } else { %>
-                                <%= h(test) %>
+                                <%=h(test)%>
                                 <% } %>
                             </td>
                             <% for (RunDetail run : problemRuns) { %>

--- a/testresults/src/org/labkey/testresults/view/rundown.jsp
+++ b/testresults/src/org/labkey/testresults/view/rundown.jsp
@@ -17,6 +17,7 @@
 <%@ page import="java.util.List" %>
 <%@ page import="static org.labkey.testresults.TestResultsModule.ViewType" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.util.Arrays" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     /*
@@ -255,7 +256,11 @@
                         <% for (String test : problemTests) { %>
                         <tr>
                             <td style="width: 200px; max-width: 200px; overflow: hidden; text-overflow: ellipsis; padding: 0;">
+                                <% if (Arrays.stream(problemRuns).anyMatch(run -> problems.isFail(run, test))) { %>
                                 <a href="<%=h(new ActionURL(TestResultsController.ShowFailures.class, c).addParameter("end", df.format(selectedDate)).addParameter("failedTest", test))%>" target="_blank"><%=h(test)%></a>
+                                <% } else { %>
+                                <%= h(test) %>
+                                <% } %>
                             </td>
                             <% for (RunDetail run : problemRuns) { %>
                             <td class="highlightrun highlighttd-<%=run.getId()%>" style="width: 60px; overflow: hidden; padding: 0;">


### PR DESCRIPTION
#### Rationale
Tests in the rundown table should only be linked to the test failure page if they had a failure because if there is only a leak or hang, there are no failures to show.