### PR TITLE
Modification information interface

### DIFF
--- a/panoramapublic/resources/queries/panoramapublic/IsotopeModifications.query.xml
+++ b/panoramapublic/resources/queries/panoramapublic/IsotopeModifications.query.xml
@@ -1,0 +1,45 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="IsotopeModifications" tableDbType="NOT_IN_DB">
+                <columns>
+                    <column columnName="ModId">
+                        <columnTitle>Modification Id</columnTitle>
+                        <fk>
+                            <fkDbSchema>targetedms</fkDbSchema>
+                            <fkTable>IsotopeModification</fkTable>
+                            <fkColumnName>id</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="SkylineUnimodId">
+                        <description>Unimod Id from the Skyline document</description>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.modification.UnimodIdDisplayColumnFactory</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="RunIds">
+                        <columnTitle>Skyline Documents</columnTitle>
+                        <description>Skyline documents with this modification</description>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.modification.ModificationDocsDisplayColumnFactory$IsotopicModDocsColumn</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="UnimodMatch">
+                        <columnTitle>UnimodMatch</columnTitle>
+                        <textAlign>left</textAlign>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.modification.UnimodMatchDisplayColumnFactory$IsotopeUnimodMatch</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="modInfoId">
+                        <fk>
+                            <fkDbSchema>panoramapublic</fkDbSchema>
+                            <fkTable>ExperimentIsotopeModInfo</fkTable>
+                            <fkColumnName>id</fkColumnName>
+                        </fk>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/panoramapublic/resources/queries/panoramapublic/IsotopeModifications.sql
+++ b/panoramapublic/resources/queries/panoramapublic/IsotopeModifications.sql
@@ -1,0 +1,19 @@
+SELECT mod.modId,
+       mod.unimodId AS skylineUnimodId,
+       mod.runIds,
+       modinfo.Id as modInfoId,
+       COALESCE(mod.unimodId, modInfo.unimodId) as unimodMatch
+FROM
+    (SELECT
+         imod.Id AS modId,
+         imod.unimodId AS unimodId,
+         GROUP_CONCAT(DISTINCT run.id, ',') AS runIds,
+     FROM targetedms.PeptideIsotopeModification pmod
+              INNER JOIN targetedms.IsotopeModification imod ON imod.id = pmod.isotopeModId
+              INNER JOIN targetedms.Peptide pep ON pep.id = pmod.peptideId
+              INNER JOIN targetedms.PeptideGroup pg ON pg.id = pep.peptideGroupId
+              INNER JOIN targetedms.Runs run ON run.id = pg.runId
+     GROUP BY imod.Id, imod.unimodId
+    ) mod
+LEFT OUTER JOIN panoramapublic.ExperimentIsotopeModInfo modinfo
+ON mod.modId = modinfo.modId

--- a/panoramapublic/resources/queries/panoramapublic/IsotopeModifications/.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/IsotopeModifications/.qview.xml
@@ -1,0 +1,40 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            canOverride="true">
+    <columns>
+        <column name="ModId/Name" />
+        <column name="ModId/Formula" />
+        <column name="ModId/label13c">
+            <properties>
+                <property name="columnTitle" value="13C"/>
+            </properties>
+        </column>
+        <column name="ModId/label15n">
+            <properties>
+                <property name="columnTitle" value="15N"/>
+            </properties>
+        </column>
+        <column name="ModId/label18o">
+            <properties>
+                <property name="columnTitle" value="18O"/>
+            </properties>
+        </column>
+        <column name="ModId/label2h">
+            <properties>
+                <property name="columnTitle" value="2H"/>
+            </properties>
+        </column>
+        <column name="ModId/AminoAcid">
+            <properties>
+                <property name="columnTitle" value="Sites"/>
+            </properties>
+        </column>
+        <column name="ModId/Terminus" />
+        <column name="SkylineUnimodId">
+            <properties>
+                <property name="columnTitle" value="Unimod Id"/>
+            </properties>
+        </column>
+        <column name="RunIds" />
+    </columns>
+</customView>
+

--- a/panoramapublic/resources/queries/panoramapublic/IsotopeModifications/ExperimentIsotopeModInfo.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/IsotopeModifications/ExperimentIsotopeModInfo.qview.xml
@@ -1,0 +1,38 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            canOverride="true">
+    <columns>
+        <column name="ModId/Name" />
+        <column name="ModId/Formula" />
+        <column name="ModId/label13c">
+            <properties>
+                <property name="columnTitle" value="13C"/>
+            </properties>
+        </column>
+        <column name="ModId/label15n">
+            <properties>
+                <property name="columnTitle" value="15N"/>
+            </properties>
+        </column>
+        <column name="ModId/label18o">
+            <properties>
+                <property name="columnTitle" value="18O"/>
+            </properties>
+        </column>
+        <column name="ModId/label2h">
+            <properties>
+                <property name="columnTitle" value="2H"/>
+            </properties>
+        </column>
+        <column name="ModId/AminoAcid">
+            <properties>
+                <property name="columnTitle" value="Sites"/>
+            </properties>
+        </column>
+        <column name="ModId/Terminus" />
+        <column name="UnimodMatch" />
+        <column name="RunIds" />
+    </columns>
+    <sorts>
+        <sort column="UnimodMatch" descending="false" />
+    </sorts>
+</customView>

--- a/panoramapublic/resources/queries/panoramapublic/StructuralModifications.query.xml
+++ b/panoramapublic/resources/queries/panoramapublic/StructuralModifications.query.xml
@@ -1,0 +1,51 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="StructuralModifications" tableDbType="NOT_IN_DB">
+                <columns>
+                    <column columnName="ModId">
+                        <columnTitle>Modification Id</columnTitle>
+                        <fk>
+                            <fkDbSchema>targetedms</fkDbSchema>
+                            <fkTable>StructuralModification</fkTable>
+                            <fkColumnName>id</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="SkylineUnimodId">
+                        <description>Unimod Id from the Skyline document</description>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.modification.UnimodIdDisplayColumnFactory</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="NormalizedFormula">
+                        <description>Normalized modification formula from the Skyline document</description>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.modification.NormalizedFormulaDisplayColumnFactory</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="RunIds">
+                        <columnTitle>Skyline Documents</columnTitle>
+                        <description>Skyline documents with this modification</description>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.modification.ModificationDocsDisplayColumnFactory$StructuralModDocsColumn</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="UnimodMatch">
+                        <columnTitle>UnimodMatch</columnTitle>
+                        <textAlign>left</textAlign>
+                        <displayColumnFactory>
+                            <className>org.labkey.panoramapublic.query.modification.UnimodMatchDisplayColumnFactory$StructuralUnimodMatch</className>
+                        </displayColumnFactory>
+                    </column>
+                    <column columnName="ModInfoId">
+                        <fk>
+                            <fkDbSchema>panoramapublic</fkDbSchema>
+                            <fkTable>ExperimentStructuralModInfo</fkTable>
+                            <fkColumnName>id</fkColumnName>
+                        </fk>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/panoramapublic/resources/queries/panoramapublic/StructuralModifications.sql
+++ b/panoramapublic/resources/queries/panoramapublic/StructuralModifications.sql
@@ -1,0 +1,21 @@
+SELECT mod.modId,
+       mod.unimodId AS skylineUnimodId,
+       mod.formula as normalizedFormula,
+       mod.runIds,
+       modinfo.Id as modInfoId,
+       COALESCE(mod.unimodId, modInfo.unimodId) as unimodMatch
+FROM
+    (SELECT
+         smod.Id AS modId,
+         smod.unimodId AS unimodId,
+         smod.formula,
+         GROUP_CONCAT(DISTINCT run.id, ',') AS runIds,
+     FROM targetedms.PeptideStructuralModification pmod
+              INNER JOIN targetedms.StructuralModification smod ON smod.id = pmod.structuralModId
+              INNER JOIN targetedms.Peptide pep ON pep.id = pmod.peptideId
+              INNER JOIN targetedms.PeptideGroup pg ON pg.id = pep.peptideGroupId
+              INNER JOIN targetedms.Runs run ON run.id = pg.runId
+     GROUP BY smod.Id, smod.unimodId, smod.formula
+    ) mod
+LEFT OUTER JOIN panoramapublic.ExperimentStructuralModInfo modinfo
+ON mod.modId = modinfo.modId

--- a/panoramapublic/resources/queries/panoramapublic/StructuralModifications/.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/StructuralModifications/.qview.xml
@@ -1,0 +1,19 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            canOverride="true">
+    <columns>
+        <column name="ModId/Name" />
+        <column name="ModId/Formula" />
+        <column name="ModId/AminoAcid">
+            <properties>
+                <property name="columnTitle" value="Sites"/>
+            </properties>
+        </column>
+        <column name="ModId/Terminus" />
+        <column name="SkylineUnimodId">
+            <properties>
+                <property name="columnTitle" value="Unimod Id"/>
+            </properties>
+        </column>
+        <column name="RunIds" />
+    </columns>
+</customView>

--- a/panoramapublic/resources/queries/panoramapublic/StructuralModifications/ExperimentStructuralModInfo.qview.xml
+++ b/panoramapublic/resources/queries/panoramapublic/StructuralModifications/ExperimentStructuralModInfo.qview.xml
@@ -1,0 +1,18 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            canOverride="true">
+    <columns>
+        <column name="ModId/Name" />
+        <column name="NormalizedFormula"/>
+        <column name="ModId/AminoAcid">
+            <properties>
+                <property name="columnTitle" value="Sites"/>
+            </properties>
+        </column>
+        <column name="ModId/Terminus" />
+        <column name="UnimodMatch" />
+        <column name="RunIds" />
+    </columns>
+    <sorts>
+        <sort column="UnimodMatch" descending="false" />
+    </sorts>
+</customView>

--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-22.001-22.002.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-22.001-22.002.sql
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CREATE TABLE panoramapublic.ExperimentStructuralModInfo
+(
+    _ts               TIMESTAMP,
+    Id                SERIAL NOT NULL,
+    CreatedBy         USERID,
+    Created           TIMESTAMP,
+    ModifiedBy        USERID,
+    Modified          TIMESTAMP,
+
+    ExperimentAnnotationsId   INT NOT NULL,
+    ModId                     BIGINT NOT NULL, -- targetedms.structuralmodification.Id
+    UnimodId                  INT NOT NULL,
+    UnimodName                VARCHAR NOT NULL,
+    UnimodId2                 INT,
+    UnimodName2               VARCHAR,
+
+
+    CONSTRAINT PK_ExperimentStructuralModInfo PRIMARY KEY (Id),
+    CONSTRAINT FK_ExperimentStructuralModInfo_ExperimentAnnotations FOREIGN KEY (ExperimentAnnotationsId) REFERENCES panoramapublic.ExperimentAnnotations(Id),
+    CONSTRAINT FK_ExperimentStructuralModInfo_StructuralModification FOREIGN KEY (ModId) REFERENCES targetedms.StructuralModification(Id),
+    CONSTRAINT UQ_ExperimentStructuralModInfo UNIQUE (ExperimentAnnotationsId, ModId)
+);
+CREATE INDEX IX_ExperimentStructuralModInfo_ExperimentAnnotationsId ON panoramapublic.ExperimentStructuralModInfo(experimentAnnotationsId);
+CREATE INDEX IX_ExperimentStructuralModInfo_ModId ON panoramapublic.ExperimentStructuralModInfo(ModId);
+
+CREATE TABLE panoramapublic.ExperimentIsotopeModInfo
+(
+    _ts               TIMESTAMP,
+    Id                SERIAL NOT NULL,
+    CreatedBy         USERID,
+    Created           TIMESTAMP,
+    ModifiedBy        USERID,
+    Modified          TIMESTAMP,
+
+    ExperimentAnnotationsId   INT NOT NULL,
+    ModId                     BIGINT NOT NULL, -- targetedms.isotopemodification.Id
+    UnimodId                  INT NOT NULL,
+    UnimodName                VARCHAR NOT NULL,
+
+    CONSTRAINT PK_ExperimentIsotopeModInfo PRIMARY KEY (Id),
+    CONSTRAINT FK_ExperimentIsotopeModInfo_ExperimentAnnotations FOREIGN KEY (ExperimentAnnotationsId) REFERENCES panoramapublic.ExperimentAnnotations(Id),
+    CONSTRAINT FK_ExperimentIsotopeModInfo_IsotopeModification FOREIGN KEY (ModId) REFERENCES targetedms.IsotopeModification(Id),
+    CONSTRAINT UQ_ExperimentIsotopeModInfo UNIQUE (ExperimentAnnotationsId, ModId)
+);
+CREATE INDEX IX_ExperimentIsotopeModInfo_ExperimentAnnotationsId ON panoramapublic.ExperimentIsotopeModInfo(experimentAnnotationsId);
+CREATE INDEX IX_ExperimentIsotopeModInfo_ModId ON panoramapublic.ExperimentIsotopeModInfo(ModId);
+
+-- We will no longer try to assign Unimod Ids automatically during data validation. We will rely instead on the user-assigned
+-- values in the ExperimentStructuralModInfo and ExperimentIsotopeModInfo tables.
+ALTER TABLE panoramapublic.ModificationValidation DROP COLUMN UnimodMatches;
+-- ModInfoId refers to either panoramapublic.ExperimentStructuralModInfo.Id OR panoramapublic.ExperimentIsotopeModInfo.Id
+-- depending on the value in ModType column
+ALTER TABLE panoramapublic.ModificationValidation ADD COLUMN ModInfoId INT;

--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -526,7 +526,9 @@
                 <description>Structural / Isotopic</description>
             </column>
             <column columnName="UnimodId">
-                <url>https://www.unimod.org/modifications_view.php?editid1=${unimodid}</url>
+                <displayColumnFactory>
+                    <className>org.labkey.panoramapublic.query.modification.UnimodIdDisplayColumnFactory</className>
+                </displayColumnFactory>
             </column>
             <column columnName="UnimodName">
                 <description>Name of the modification in unimod.xml, as expected by ProteomeXchange</description>
@@ -534,10 +536,7 @@
             <column columnName="Inferred">
                 <description>True if the Unimod Id was inferred</description>
             </column>
-            <column columnName="UnimodMatches">
-                <isHidden>true</isHidden>
-                <description>Possible Unimod matches if a single match was not found</description>
-            </column>
+            <column columnName="ModInfoId"/>
         </columns>
     </table>
     <table tableName="SkylineDocModification" tableDbType="TABLE">
@@ -630,6 +629,117 @@
                     <fkTable>SpectrumLibrary</fkTable>
                 </fk>
             </column>
+        </columns>
+    </table>
+    <table tableName="ExperimentStructuralModInfo" tableDbType="TABLE">
+        <columns>
+            <column columnName="_ts">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Created">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="CreatedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Modified">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="ModifiedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Id"/>
+            <column columnName="ExperimentAnnotationsId">
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>panoramapublic</fkDbSchema>
+                    <fkTable>ExperimentAnnotations</fkTable>
+                </fk>
+            </column>
+            <column columnName="ModId">
+                <description>Structural modification in the Skyline document</description>
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>targetedms</fkDbSchema>
+                    <fkTable>StructuralModification</fkTable>
+                </fk>
+            </column>
+            <column columnName="UnimodId">
+                <description>Assigned Unimod Id</description>
+                <displayColumnFactory>
+                    <className>org.labkey.panoramapublic.query.modification.UnimodIdDisplayColumnFactory</className>
+                </displayColumnFactory>
+            </column>
+            <column columnName="UnimodName" />
+            <column columnName="UnimodId2">
+                <description>Additional assigned Unimod Id for a combination modification</description>
+                <displayColumnFactory>
+                    <className>org.labkey.panoramapublic.query.modification.UnimodIdDisplayColumnFactory</className>
+                </displayColumnFactory>
+            </column>
+            <column columnName="UnimodName2" />
+        </columns>
+    </table>
+    <table tableName="ExperimentIsotopeModInfo" tableDbType="TABLE">
+        <columns>
+            <column columnName="_ts">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Created">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="CreatedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Modified">
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="ModifiedBy">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="Id"/>
+            <column columnName="ExperimentAnnotationsId">
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>panoramapublic</fkDbSchema>
+                    <fkTable>ExperimentAnnotations</fkTable>
+                </fk>
+            </column>
+            <column columnName="ModId">
+                <description>Isotope modification in the Skyline document</description>
+                <fk>
+                    <fkColumnName>Id</fkColumnName>
+                    <fkDbSchema>targetedms</fkDbSchema>
+                    <fkTable>IsotopeModification</fkTable>
+                </fk>
+            </column>
+            <column columnName="UnimodId">
+                <description>Assigned Unimod Id</description>
+                <displayColumnFactory>
+                    <className>org.labkey.panoramapublic.query.modification.UnimodIdDisplayColumnFactory</className>
+                </displayColumnFactory>
+            </column>
+            <column columnName="UnimodName" />
         </columns>
     </table>
 </tables>

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicManager.java
@@ -120,6 +120,16 @@ public class PanoramaPublicManager
         return getSchema().getTable(PanoramaPublicSchema.TABLE_SPEC_LIB_INFO);
     }
 
+    public static TableInfo getTableInfoExperimentStructuralModInfo()
+    {
+        return getSchema().getTable(PanoramaPublicSchema.TABLE_EXPT_STRUCTURAL_MOD_INFO);
+    }
+
+    public static TableInfo getTableInfoExperimentIsotopeModInfo()
+    {
+        return getSchema().getTable(PanoramaPublicSchema.TABLE_EXPT_ISOTOPE_MOD_INFO);
+    }
+
     public static ActionURL getRawDataTabUrl(Container container)
     {
         return PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(container, TargetedMSService.RAW_FILES_TAB);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -44,12 +44,15 @@ import org.labkey.panoramapublic.model.speclib.SpecLibKey;
 import org.labkey.panoramapublic.pipeline.CopyExperimentPipelineProvider;
 import org.labkey.panoramapublic.pipeline.PxValidationPipelineProvider;
 import org.labkey.panoramapublic.proteomexchange.ExperimentModificationGetter;
+import org.labkey.panoramapublic.proteomexchange.Formula;
 import org.labkey.panoramapublic.proteomexchange.SkylineVersion;
+import org.labkey.panoramapublic.proteomexchange.UnimodModification;
 import org.labkey.panoramapublic.proteomexchange.validator.SkylineDocValidator;
 import org.labkey.panoramapublic.proteomexchange.validator.SpecLibValidator;
 import org.labkey.panoramapublic.query.ContainerJoin;
 import org.labkey.panoramapublic.query.ExperimentTitleDisplayColumn;
 import org.labkey.panoramapublic.query.JournalManager;
+import org.labkey.panoramapublic.query.modification.ModificationsView;
 import org.labkey.panoramapublic.query.speclib.SpecLibView;
 import org.labkey.panoramapublic.security.CopyTargetedMSExperimentRole;
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentWebPart;
@@ -78,7 +81,7 @@ public class PanoramaPublicModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.001;
+        return 22.002;
     }
 
     @Override
@@ -226,6 +229,24 @@ public class PanoramaPublicModule extends SpringModule
             }
         };
 
+        BaseWebPartFactory structuralModsFactory = new BaseWebPartFactory("Structural Modifications")
+        {
+            @Override
+            public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+            {
+                return new ModificationsView.StructuralModsView(portalCtx);
+            }
+        };
+
+        BaseWebPartFactory isotopeModsFactory = new BaseWebPartFactory("Isotope Modifications")
+        {
+            @Override
+            public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+            {
+                return new ModificationsView.IsotopeModsView(portalCtx);
+            }
+        };
+
         List<WebPartFactory> webpartFactoryList = new ArrayList<>();
         webpartFactoryList.add(experimentAnnotationsListFactory);
         webpartFactoryList.add(containerExperimentFactory);
@@ -233,6 +254,8 @@ public class PanoramaPublicModule extends SpringModule
         webpartFactoryList.add(peptideSearchFactory);
         webpartFactoryList.add(dataDownloadInfoFactory);
         webpartFactoryList.add(spectralLibrariesFactory);
+        webpartFactoryList.add(structuralModsFactory);
+        webpartFactoryList.add(isotopeModsFactory);
         return webpartFactoryList;
     }
 
@@ -323,6 +346,7 @@ public class PanoramaPublicModule extends SpringModule
         set.add(SpecLibValidator.TestCase.class);
         set.add(ExperimentModificationGetter.TestCase.class);
         set.add(ContainerJoin.TestCase.class);
+        set.add(Formula.TestCase.class);
         return set;
 
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -50,6 +50,8 @@ import org.labkey.panoramapublic.query.ExperimentAnnotationsTableInfo;
 import org.labkey.panoramapublic.query.JournalExperimentTableInfo;
 import org.labkey.panoramapublic.query.PanoramaPublicTable;
 import org.labkey.panoramapublic.query.SubmissionTableInfo;
+import org.labkey.panoramapublic.query.modification.ExperimentIsotopeModInfoTableInfo;
+import org.labkey.panoramapublic.query.modification.ExperimentStructuralModInfoTableInfo;
 import org.labkey.panoramapublic.query.speclib.SpecLibInfoTableInfo;
 import org.springframework.validation.BindException;
 
@@ -78,6 +80,8 @@ public class PanoramaPublicSchema extends UserSchema
     public static final String TABLE_PX_STATUS = "PxStatus";
     public static final String TABLE_MOD_TYPE = "ModType";
     public static final String TABLE_SPEC_LIB_INFO = "SpecLibInfo";
+    public static final String TABLE_EXPT_STRUCTURAL_MOD_INFO = "ExperimentStructuralModInfo";
+    public static final String TABLE_EXPT_ISOTOPE_MOD_INFO = "ExperimentIsotopeModInfo";
 
     public static final String TABLE_LIB_DEPENDENCY_TYPE = "SpecLibDependencyType";
     public static final String TABLE_LIB_SOURCE_TYPE = "SpecLibSourceType";
@@ -285,6 +289,15 @@ public class PanoramaPublicSchema extends UserSchema
                     "Modification type (structural or isotopic)");
         }
 
+        if(TABLE_EXPT_STRUCTURAL_MOD_INFO.equalsIgnoreCase(name))
+        {
+            return new ExperimentStructuralModInfoTableInfo(this, cf);
+        }
+        if(TABLE_EXPT_ISOTOPE_MOD_INFO.equalsIgnoreCase(name))
+        {
+            return new ExperimentIsotopeModInfoTableInfo(this, cf);
+        }
+
         return null;
     }
 
@@ -336,7 +349,9 @@ public class PanoramaPublicSchema extends UserSchema
     public @NotNull QueryView createView(ViewContext context, @NotNull QuerySettings settings, @Nullable BindException errors)
     {
         if (TABLE_SPEC_LIB_INFO.equalsIgnoreCase(settings.getQueryName())
-        || TABLE_DATA_VALIDATION.equalsIgnoreCase(settings.getQueryName()))
+                || TABLE_EXPT_STRUCTURAL_MOD_INFO.equals(settings.getQueryName())
+                || TABLE_EXPT_ISOTOPE_MOD_INFO.equalsIgnoreCase(settings.getQueryName())
+                || TABLE_DATA_VALIDATION.equalsIgnoreCase(settings.getQueryName()))
         {
             // Show the delete icon in the toolbar but not the insert or update icons
             return new QueryView(this, settings, errors)
@@ -381,6 +396,8 @@ public class PanoramaPublicSchema extends UserSchema
         hs.add(TABLE_PX_XML);
         hs.add(TABLE_SPEC_LIB_INFO);
         hs.add(TABLE_DATA_VALIDATION);
+        hs.add(TABLE_EXPT_STRUCTURAL_MOD_INFO);
+        hs.add(TABLE_EXPT_ISOTOPE_MOD_INFO);
         return hs;
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -75,8 +75,11 @@ import org.labkey.panoramapublic.proteomexchange.ProteomeXchangeService;
 import org.labkey.panoramapublic.proteomexchange.ProteomeXchangeServiceException;
 import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
 import org.labkey.panoramapublic.query.JournalManager;
+import org.labkey.panoramapublic.query.ModificationInfoManager;
 import org.labkey.panoramapublic.query.SpecLibInfoManager;
 import org.labkey.panoramapublic.query.SubmissionManager;
+import org.labkey.panoramapublic.query.modification.ExperimentModInfo;
+import org.labkey.panoramapublic.query.modification.ExperimentStructuralModInfo;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -183,6 +186,9 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             // Copy any Spectral library information provided by the user in the source container
             copySpecLibInfos(sourceExperiment, targetExperiment, user);
 
+            // Copy any modifications related information provided by the user in the source container
+            copyModificationInfos(sourceExperiment, targetExperiment, user);
+
             // Assign a reviewer account if one was requested
             Pair<User, String> reviewer = assignReviewer(js, targetExperiment, previousCopy, jobSupport, currentSubmission.isKeepPrivate(), user, log);
 
@@ -210,6 +216,25 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             info.setId(0);
             info.setExperimentAnnotationsId(targetExperiment.getId());
             SpecLibInfoManager.save(info, user);
+        }
+    }
+
+    private void copyModificationInfos(ExperimentAnnotations sourceExperiment, ExperimentAnnotations targetExperiment, User user)
+    {
+        List<ExperimentStructuralModInfo> strModInfos = ModificationInfoManager.getStructuralModInfosForExperiment(sourceExperiment.getId(), sourceExperiment.getContainer());
+        for (ExperimentStructuralModInfo info: strModInfos)
+        {
+            info.setId(0);
+            info.setExperimentAnnotationsId(targetExperiment.getId());
+            ModificationInfoManager.saveStructuralModInfo(info, user);
+        }
+
+        List<ExperimentModInfo> isotopeModInfos = ModificationInfoManager.getIsotopeModInfosForExperiment(sourceExperiment.getId(), sourceExperiment.getContainer());
+        for (ExperimentModInfo info: isotopeModInfos)
+        {
+            info.setId(0);
+            info.setExperimentAnnotationsId(targetExperiment.getId());
+            ModificationInfoManager.saveIsotopeModInfo(info, user);
         }
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ChemElement.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ChemElement.java
@@ -1,0 +1,94 @@
+package org.labkey.panoramapublic.proteomexchange;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ChemElement
+{
+    // Source: Unimod
+    H("H",1.00794),
+    H2("2H", "H'", 2.014101779),
+    Li("Li",6.941),
+    B("B",10.811),
+    C("C",12.0107),
+    C13("13C","C'", 13.00335483),
+    N("N",14.0067),
+    N15("15N","N'", 15.00010897),
+    O("O",15.9994),
+    O18("18O", "O'", 17.9991603),
+    F("F",18.9984032),
+    Na("Na",22.98977),
+    Mg("Mg",24.305),
+    Al("Al",26.9815386),
+    Si("Si",28.085),
+    P("P",30.973761),
+    S("S",32.065),
+    Cl("Cl",35.453),
+    K("K",39.0983),
+    Ca("Ca",40.078),
+    Cr("Cr",51.9961),
+    Mn("Mn",54.938045),
+    Fe("Fe",55.845),
+    Ni("Ni",58.6934),
+    Co("Co",58.933195),
+    Cu("Cu",63.546),
+    Zn("Zn",65.409),
+    As("As",74.9215942),
+    Se("Se",78.96),
+    Br("Br",79.904),
+    Mo("Mo",95.94),
+    Ru("Ru",101.07),
+    Pd("Pd",106.42),
+    Ag("Ag",107.8682),
+    Cd("Cd",112.411),
+    I("I",126.90447),
+    Pt("Pt",195.084),
+    Au("Au",196.96655),
+    Hg("Hg",200.59);
+
+    private final String _title;
+    private final String _symbol;
+    private final double _avgMass;
+
+    private static Map<String, ChemElement> titleMap = new HashMap<>();
+    private static Map<String, ChemElement> symbolMap = new HashMap<>();
+    static
+    {
+        for (ChemElement el: ChemElement.values())
+        {
+            symbolMap.put(el.getSymbol(), el);
+            titleMap.put(el.getTitle(), el);
+        }
+    }
+
+    public static ChemElement getElement(String title)
+    {
+        return titleMap.get(title);
+    }
+
+    public static ChemElement getElementForSymbol(String symbol)
+    {
+        return symbolMap.get(symbol);
+    }
+
+    ChemElement(String title, double avgMass)
+    {
+        this(title, title, avgMass);
+    }
+    ChemElement(String title, String symbol, double avgMass)
+    {
+        _title = title;
+        _symbol = symbol;
+        _avgMass = avgMass;
+    }
+
+    public String getTitle()
+    {
+        return _title;
+    }
+
+    public String getSymbol()
+    {
+        return _symbol;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/Formula.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/Formula.java
@@ -1,0 +1,285 @@
+package org.labkey.panoramapublic.proteomexchange;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class Formula
+{
+    private final TreeMap<ChemElement, Integer> _elementCounts; // Map is sorted on natural ordering of ChemElement
+
+    public Formula()
+    {
+        _elementCounts = new TreeMap<>();
+    }
+
+    public void addElement(@NotNull ChemElement element, int count)
+    {
+        Integer currentCount = _elementCounts.computeIfAbsent(element, el -> 0);
+        int newCount = currentCount + count;
+        if (newCount != 0)
+        {
+            _elementCounts.put(element, newCount);
+        }
+        else
+        {
+            _elementCounts.remove(element);
+        }
+    }
+
+    public SortedMap<ChemElement, Integer> getElementCounts()
+    {
+        return Collections.unmodifiableSortedMap(_elementCounts);
+    }
+
+    public String getFormula()
+    {
+        StringBuilder positive = new StringBuilder();
+        StringBuilder negative = new StringBuilder();
+        for (ChemElement el: _elementCounts.keySet())
+        {
+            int count = _elementCounts.get(el);
+            boolean pos = count > 0;
+            count = count < 0 ? count * -1 : count;
+            String formulaPart = el.getSymbol() + (count > 1 ? count : "");
+            if (pos)
+            {
+                positive.append(formulaPart);
+            }
+            else
+            {
+                negative.append(formulaPart);
+            }
+        }
+        String separator = positive.length() > 0 && negative.length() > 0 ? " - " : (negative.length() > 0 ? "-" : "");
+        return positive + separator + negative;
+    }
+
+    public Formula addFormula(@NotNull Formula otherFormula)
+    {
+        Formula newFormula = new Formula();
+
+        this._elementCounts.forEach(newFormula::addElement);
+        otherFormula._elementCounts.forEach(newFormula::addElement);
+
+        return newFormula;
+    }
+
+    public Formula subtractFormula(@NotNull Formula otherFormula)
+    {
+        Formula newFormula = new Formula();
+
+        this._elementCounts.forEach(newFormula::addElement);
+        otherFormula._elementCounts.forEach((key, value) -> newFormula.addElement(key, value * -1));
+
+        return newFormula;
+    }
+
+    public boolean isEmpty()
+    {
+        return _elementCounts.isEmpty();
+    }
+
+    @Override
+    public String toString()
+    {
+        return getFormula();
+    }
+
+    /**
+     * @param input formula to normalize
+     * @return Returns the normalized formula of the form H'6C'8N'4 - H2C6N4.
+     * Elements in the formula are ordered according to the order of {@link ChemElement}.
+     * Returns the input formula if there is an error in parsing the formula.
+     */
+    public static @NotNull String normalizeFormula(String input)
+    {
+        Formula formula = tryParse(input, new ArrayList<>());
+        return formula != null ? formula.getFormula() : input;
+    }
+
+    /**
+     * @param input formula to normalize
+     * @return Returns the normalized formula of the form H'6C'8N'4 - H2C6N4.
+     * Elements in the formula are ordered according to the order of {@link ChemElement}.
+     * Returns null if there is an error in parsing the input formula.
+     */
+    public static @Nullable String normalizeIfValid(String input)
+    {
+        Formula formula = tryParse(input, new ArrayList<>());
+        return formula != null ? formula.getFormula() : null;
+    }
+
+    /**
+     * Parses a formula of the form H'6C'8N'4 - H2C6N4. Returns null if exceptions were thrown while parsing the formula.
+     * The error messages are added to the given errors parameter.
+     * @param input formula to parse
+     * @param errors parse error messages
+     * @return a Formula object representing the input formula, or null if there were errors in parsing the formula
+     */
+    public static @Nullable Formula tryParse(String input, @NotNull List<String> errors)
+    {
+        try
+        {
+            return parse(input);
+        }
+        catch (IllegalArgumentException ex)
+        {
+            errors.add("Failed to parse formula '" + input + "'. " + ex.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Parses a formula of the form H'6C'8N'4 - H2C6N4. An exception is throws if there are more than one subtraction
+     * operations in the input formula (e.g. H2C'6 - N4 - C6) there are unrecognized elements in the formula or if
+     * the formula contains unrecognized elements.
+     * @param input formula to parse
+     * @return a Formula object representing the input formula
+     */
+    public static @NotNull Formula parse(String input)
+    {
+        return parse(input, new Formula(), false);
+    }
+
+    // Based on BiomassCalc.ParseCounts() in Skyline.
+    // Other related code:
+    // BiomassCalc.ParseMassExpression() and BiomassCalc.ParseMass()
+    // Formula.ParseToDictionary()
+    private static Formula parse(String input, Formula formula, boolean negative)
+    {
+        if(StringUtils.isBlank(input))
+        {
+            return formula != null ? formula : new Formula();
+        }
+
+        if (formula == null) formula = new Formula();
+
+        // Assume formulas are of the form H'6C'8N'4 - H2C6N4.
+        // The part of the formula following ' - ' are the element masses that will be subtracted
+        // from the total mass.  Only one negative part is allowed. We will parse the positive and negative parts separately.
+        input = input.trim();
+
+        while (input.length() > 0)
+        {
+            if (input.startsWith("-"))
+            {
+                if (negative)
+                {
+                    throw new IllegalArgumentException("More than one subtraction operation is not supported if a formula.");
+                }
+                return parse(input.substring(1), formula, true);
+            }
+            String sym = getNextSymbol(input);
+            ChemElement el = ChemElement.getElementForSymbol(sym);
+
+            // Unrecognized element
+            if (el == null)
+            {
+                throw new IllegalArgumentException("Unrecognized element in formula: " + sym);
+            }
+
+            input = input.substring(sym.length());
+            int endCount = 0;
+            while (endCount < input.length() && Character.isDigit(input.charAt(endCount)))
+            {
+                endCount++;
+            }
+
+            int count = endCount == 0 ? 1 : Integer.parseInt(input.substring(0, endCount));
+
+            if (negative)
+            {
+                count = -count;
+            }
+
+            formula.addElement(el, count);
+            input = input.substring(endCount).trim();
+        }
+        return formula;
+    }
+
+    private static String getNextSymbol(String input)
+    {
+        // Skip the first character, since it is always the start of
+        // the symbol, and then look for the end of the symbol.
+        for (int i = 1; i < input.length(); i++)
+        {
+            char c = input.charAt(i);
+            if (!Character.isLowerCase(c) && c != '\'' && c != '"')
+            {
+                return input.substring(0, i);
+            }
+        }
+        return input;
+    }
+
+    public static class TestCase extends Assert
+    {
+        @Test
+        public void testFormula()
+        {
+            assertTrue(Formula.parse(null).isEmpty());
+            assertTrue(Formula.parse("").isEmpty());
+
+            var C12H8S2O6 = "C12H8S2O6";
+            var SO4 = "SO4";
+            assertEquals("H8C12O6S2", Formula.parse(C12H8S2O6).getFormula());
+            var subtracted = C12H8S2O6+ " - " +SO4;
+            assertEquals("H8C12O2S", Formula.parse(subtracted).getFormula());
+            assertEquals("H8C12O2S", Formula.parse(C12H8S2O6).subtractFormula(Formula.parse(SO4)).getFormula());
+            assertEquals("-O4S",  new Formula().subtractFormula(Formula.parse(SO4)).getFormula());
+            assertEquals("O4S",  Formula.parse(SO4).addFormula(new Formula()).getFormula());
+
+            var formula = new Formula();
+            formula.addElement(ChemElement.C, 3);
+            formula.addElement(ChemElement.H, 8);
+            formula.addElement(ChemElement.O, 2);
+            formula.addElement(ChemElement.C13, 3);
+            formula.addElement(ChemElement.N, 0);
+            assertEquals("H8C3C'3O2", formula.getFormula());
+            // H4C3O + H4C'3O = H8C3C'3O2
+            assertEquals(formula.getFormula(), Formula.parse("H4C3O").addFormula(Formula.parse("H4C'3O")).getFormula());
+
+            var errors = new ArrayList<String>();
+            var input = subtracted + subtracted;
+            formula = Formula.tryParse(input, errors); // More than one subtraction operation is not supported
+            assertNull(formula);
+            assertEquals(1, errors.size());
+            assertEquals("Failed to parse formula '" + input + "'. More than one subtraction operation is not supported if a formula.", errors.get(0));
+
+            errors = new ArrayList<>();
+            input = C12H8S2O6 + 'X' + SO4;
+            formula = Formula.tryParse(input, errors); // Unrecognized element in formula
+            assertNull(formula);
+            assertEquals("Failed to parse formula '" + input + "'. Unrecognized element in formula: X", errors.get(0));
+
+
+            // Check our ability to handle strangely constructed chemical formulas (from MassCalcTest.TestGetIonFormula() in Skyline)
+            var normalized = "H9C12S2";
+            assertEquals(Formula.parse("C12H9S2P0").getFormula(), Formula.parse("C12H9S2").getFormula()); // P0 is weird
+            assertEquals(normalized, Formula.parse("C12H9S2P0").getFormula());
+            normalized = "H9C12PS2";
+            assertEquals(Formula.parse("C12H9S2P1").getFormula(), Formula.parse("C12H9S2P").getFormula()); // P1 is weird
+            assertEquals(normalized, Formula.parse("C12H9S2P1").getFormula());
+            normalized = "H9C12P";
+            assertEquals(Formula.parse("C12H9S0P").getFormula(), Formula.parse("C12H9P").getFormula()); // S0 is weird, and not at end
+            assertEquals(normalized, Formula.parse("C12H9S0P").getFormula());
+
+            assertEquals("Cl", Formula.parse("Cl1").getFormula());
+            assertEquals("-Cl", Formula.parse(" - Cl1").getFormula());
+            assertEquals("O2 - H2N2", Formula.parse("OO-HNHN").getFormula());
+            assertEquals("O - H2N2", Formula.parse("OO-HNHNO").getFormula());
+            assertEquals("C6N2 - C'6N'2", Formula.parse("C5NNC - C'N'C'5N'").getFormula());
+            assertEquals("C7N2Cl - C'6N'2", Formula.parse("C5NNCClC - C'N'C'5N'").getFormula());
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodModifications.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodModifications.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.labkey.panoramapublic.proteomexchange.UnimodParser.*;
 
@@ -39,6 +40,16 @@ public class UnimodModifications
         _modIdModIdxMap = new HashMap<>();
         _formulaModIdxMap = new HashMap<>();
         _aminoAcids = new HashMap<>();
+    }
+
+    public List<UnimodModification> getModifications()
+    {
+        return Collections.unmodifiableList(_modifications);
+    }
+
+    public List<UnimodModification> getStructuralModifications()
+    {
+        return Collections.unmodifiableList(_modifications.stream().filter(mod -> mod.isStructural()).collect(Collectors.toList()));
     }
 
     public void add(UnimodModification uMod) throws PxException
@@ -154,7 +165,7 @@ public class UnimodModifications
                 }
             }
         }
-        return UnimodModification.normalizeFormula(formulaPos.append(formulaNeg.length() > 3 ? formulaNeg : "").toString());
+        return Formula.normalizeFormula(formulaPos.append(formulaNeg.length() > 3 ? formulaNeg : "").toString());
     }
 
     private void addElementAndCount(String element, int count, StringBuilder formulaPos, StringBuilder formulaNeg)

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
@@ -290,6 +290,12 @@ public class ExperimentAnnotationsManager
         Table.delete(PanoramaPublicManager.getTableInfoSpecLibInfo(),
                 new SimpleFilter().addCondition(FieldKey.fromParts("ExperimentAnnotationsId"), expAnnotations.getId()));
 
+        // Delete any rows in the panoramapublic.ExperimentStructuralModInfo and panoramapublic.ExperimentIsotopeModInfo tables
+        Table.delete(PanoramaPublicManager.getTableInfoExperimentStructuralModInfo(),
+                new SimpleFilter().addCondition(FieldKey.fromParts("ExperimentAnnotationsId"), expAnnotations.getId()));
+        Table.delete(PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo(),
+                new SimpleFilter().addCondition(FieldKey.fromParts("ExperimentAnnotationsId"), expAnnotations.getId()));
+
         // Delete any data validation rows for this experiment
         DataValidationManager.deleteValidations(expAnnotations.getId(), expAnnotations.getContainer());
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ModificationInfoManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ModificationInfoManager.java
@@ -1,0 +1,129 @@
+package org.labkey.panoramapublic.query;
+
+import org.apache.commons.lang3.StringUtils;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.SqlSelector;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.security.User;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.panoramapublic.PanoramaPublicManager;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.panoramapublic.query.modification.ExperimentModInfo;
+import org.labkey.panoramapublic.query.modification.ExperimentStructuralModInfo;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ModificationInfoManager
+{
+    private ModificationInfoManager() {}
+
+    public static ExperimentStructuralModInfo getStructuralModInfo(int modInfoId)
+    {
+        return new TableSelector(PanoramaPublicManager.getTableInfoExperimentStructuralModInfo()).getObject(modInfoId, ExperimentStructuralModInfo.class);
+    }
+
+    public static ExperimentModInfo getIsotopeModInfo(int modInfoId)
+    {
+        return new TableSelector(PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo()).getObject(modInfoId, ExperimentModInfo.class);
+    }
+
+    public static ExperimentStructuralModInfo getStructuralModInfo(long modificationId, int experimentAnnotationsId)
+    {
+        return getModInfo(modificationId, experimentAnnotationsId, PanoramaPublicManager.getTableInfoExperimentStructuralModInfo(), ExperimentStructuralModInfo.class);
+    }
+
+    public static ExperimentModInfo getIsotopeModInfo(long modificationId, int experimentAnnotationsId)
+    {
+        return getModInfo(modificationId, experimentAnnotationsId, PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo(), ExperimentModInfo.class);
+    }
+
+    private static <T extends ExperimentModInfo> T getModInfo(long modificationId, int experimentAnnotationsId, TableInfo tableInfo, Class<T> cls)
+    {
+        var filter = new SimpleFilter().addCondition(FieldKey.fromParts("experimentAnnotationsId"), experimentAnnotationsId);
+        filter.addCondition(FieldKey.fromParts("ModId"), modificationId);
+        return new TableSelector(tableInfo, filter, null).getObject(cls);
+    }
+
+    public static ExperimentStructuralModInfo saveStructuralModInfo (ExperimentStructuralModInfo modInfo, User user)
+    {
+        return Table.insert(user, PanoramaPublicManager.getTableInfoExperimentStructuralModInfo(), modInfo);
+    }
+
+    public static ExperimentModInfo saveIsotopeModInfo (ExperimentModInfo modInfo, User user)
+    {
+        return Table.insert(user, PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo(), modInfo);
+    }
+
+    public static void deleteIsotopeModInfo(ExperimentModInfo modInfo, int expAnnotationsId, Container container)
+    {
+        deleteModInfo(modInfo, expAnnotationsId, container, PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo());
+    }
+
+    public static void deleteStructuralModInfo(ExperimentModInfo modInfo, int expAnnotationsId, Container container)
+    {
+        deleteModInfo(modInfo, expAnnotationsId, container, PanoramaPublicManager.getTableInfoExperimentStructuralModInfo());
+    }
+
+    private static void deleteModInfo(ExperimentModInfo modInfo, int expAnnotationsId, Container container, TableInfo tableInfo)
+    {
+        ExperimentAnnotations experimentAnnotations = ExperimentAnnotationsManager.get(expAnnotationsId, container);
+        if (experimentAnnotations != null && modInfo.getExperimentAnnotationsId() == expAnnotationsId)
+        {
+            Table.delete(tableInfo, modInfo.getId());
+        }
+    }
+
+    public static List<ExperimentStructuralModInfo> getStructuralModInfosForExperiment(int experimentAnnotationsId, Container container)
+    {
+        return getModInfosForExperiment(experimentAnnotationsId, container, PanoramaPublicManager.getTableInfoExperimentStructuralModInfo(), ExperimentStructuralModInfo.class);
+    }
+
+    public static List<ExperimentModInfo> getIsotopeModInfosForExperiment(int experimentAnnotationsId, Container container)
+    {
+        return getModInfosForExperiment(experimentAnnotationsId, container, PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo(), ExperimentModInfo.class);
+    }
+
+    private static <T extends ExperimentModInfo> List<T> getModInfosForExperiment(int experimentAnnotationsId, Container container, TableInfo tableInfo, Class<T> cls)
+    {
+        var expAnnotations = ExperimentAnnotationsManager.get(experimentAnnotationsId);
+        if (expAnnotations != null && expAnnotations.getContainer().equals(container))
+        {
+            var filter = new SimpleFilter().addCondition(FieldKey.fromParts("experimentAnnotationsId"), experimentAnnotationsId);
+            return new TableSelector(tableInfo, filter, null).getArrayList(cls);
+        }
+        return Collections.emptyList();
+    }
+
+    public static boolean runsHaveStructuralModifications(List<Long> runIds, User user, Container container)
+    {
+        return runsHaveModifications(runIds, TargetedMSService.get().getTableInfoPeptideStructuralModification(), user, container);
+    }
+
+    public static boolean runsHaveIsotopeModifications(List<Long> runIds, User user, Container container)
+    {
+        return runsHaveModifications(runIds, TargetedMSService.get().getTableInfoPeptideIsotopeModification(), user, container);
+    }
+
+    private static boolean runsHaveModifications(List<Long> runIds, TableInfo tableInfo, User user, Container container)
+    {
+        if (runIds.size() == 0) return false;
+
+        TargetedMSService svc = TargetedMSService.get();
+        SQLFragment sql = new SQLFragment("SELECT mod.Id FROM ")
+                .append(tableInfo, "mod")
+                .append(" INNER JOIN ")
+                .append(svc.getTableInfoGeneralMolecule(), "gm").append(" ON gm.Id = mod.peptideId ")
+                .append(" INNER JOIN ")
+                .append(svc.getTableInfoPeptideGroup(), "pg").append(" ON pg.Id = gm.peptideGroupId ")
+                .append(" WHERE pg.runId IN (").append(StringUtils.join(runIds, ",")).append(") ");
+        var schema = svc.getUserSchema(user, container).getDbSchema();
+        sql = schema.getSqlDialect().limitRows(sql, 1);
+        return new SqlSelector(schema, sql).exists();
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentIsotopeModInfoTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentIsotopeModInfoTableInfo.java
@@ -1,0 +1,67 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.RowIdQueryUpdateService;
+import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.panoramapublic.PanoramaPublicManager;
+import org.labkey.panoramapublic.PanoramaPublicSchema;
+import org.labkey.panoramapublic.query.ContainerJoin;
+import org.labkey.panoramapublic.query.PanoramaPublicTable;
+
+public class ExperimentIsotopeModInfoTableInfo extends PanoramaPublicTable
+{
+    public ExperimentIsotopeModInfoTableInfo(PanoramaPublicSchema schema, ContainerFilter cf)
+    {
+        super(PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo(), schema, cf, ContainerJoin.ExpAnnotJoin);
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        return getContainer().hasPermission(user, perm);
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        return new RowIdQueryUpdateService<ExperimentModInfo>(this)
+        {
+            @Override
+            protected ExperimentModInfo createNewBean()
+            {
+                return new ExperimentModInfo();
+            }
+
+            @Override
+            public ExperimentModInfo get(User user, Container container, int key)
+            {
+                return new TableSelector(PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo()).getObject(key, ExperimentModInfo.class);
+            }
+
+            @Override
+            public void delete(User user, Container container, int key)
+            {
+                Table.delete(PanoramaPublicManager.getTableInfoExperimentIsotopeModInfo(), key);
+            }
+
+            @Override
+            protected ExperimentModInfo insert(User user, Container container, ExperimentModInfo bean)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected ExperimentModInfo update(User user, Container container, ExperimentModInfo bean, Integer oldKey)
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentModInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentModInfo.java
@@ -1,0 +1,70 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.labkey.api.util.Pair;
+import org.labkey.panoramapublic.model.DbEntity;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ExperimentModInfo extends DbEntity
+{
+    private int _experimentAnnotationsId;
+    private long _modId;
+    private int _unimodId;
+    private String _unimodName;
+
+    public int getExperimentAnnotationsId()
+    {
+        return _experimentAnnotationsId;
+    }
+
+    public void setExperimentAnnotationsId(int experimentAnnotationsId)
+    {
+        _experimentAnnotationsId = experimentAnnotationsId;
+    }
+
+    public int getUnimodId()
+    {
+        return _unimodId;
+    }
+
+    public void setUnimodId(int unimodId)
+    {
+        _unimodId = unimodId;
+    }
+
+    public String getUnimodName()
+    {
+        return _unimodName;
+    }
+
+    public void setUnimodName(String unimodName)
+    {
+        _unimodName = unimodName;
+    }
+
+    public long getModId()
+    {
+        return _modId;
+    }
+
+    public void setModId(long modId)
+    {
+        _modId = modId;
+    }
+
+    public List<Integer> getUnimodIds()
+    {
+        return Collections.singletonList(_unimodId);
+    }
+
+    public List<Pair<Integer, String>> getUnimodIdsAndNames()
+    {
+        return Collections.singletonList(new Pair<>(_unimodId, _unimodName));
+    }
+
+    public boolean isCombinationMod()
+    {
+        return false;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentStructuralModInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentStructuralModInfo.java
@@ -1,0 +1,64 @@
+package org.labkey.panoramapublic.query.modification;
+
+
+import org.labkey.api.util.Pair;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ExperimentStructuralModInfo extends ExperimentModInfo
+{
+    private Integer _unimodId2;
+    private String _unimodName2;
+
+    public Integer getUnimodId2()
+    {
+        return _unimodId2;
+    }
+
+    public void setUnimodId2(Integer unimodId2)
+    {
+        _unimodId2 = unimodId2;
+    }
+
+    public String getUnimodName2()
+    {
+        return _unimodName2;
+    }
+
+    public void setUnimodName2(String unimodName2)
+    {
+        _unimodName2 = unimodName2;
+    }
+
+    @Override
+    public List<Integer> getUnimodIds()
+    {
+        if (_unimodId2 == null)
+        {
+            return super.getUnimodIds();
+        }
+        var list = new ArrayList<>(super.getUnimodIds());
+        list.add(_unimodId2);
+        return Collections.unmodifiableList(list);
+    }
+
+    @Override
+    public List<Pair<Integer, String>> getUnimodIdsAndNames()
+    {
+        if (_unimodId2 == null)
+        {
+            return super.getUnimodIdsAndNames();
+        }
+        var list = new ArrayList<>(super.getUnimodIdsAndNames());
+        list.add(new Pair<>(_unimodId2, _unimodName2));
+        return Collections.unmodifiableList(list);
+    }
+
+    @Override
+    public boolean isCombinationMod()
+    {
+        return _unimodId2 != null;
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentStructuralModInfoTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/ExperimentStructuralModInfoTableInfo.java
@@ -1,0 +1,67 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.Table;
+import org.labkey.api.data.TableSelector;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.RowIdQueryUpdateService;
+import org.labkey.api.security.User;
+import org.labkey.api.security.UserPrincipal;
+import org.labkey.api.security.permissions.Permission;
+import org.labkey.panoramapublic.PanoramaPublicManager;
+import org.labkey.panoramapublic.PanoramaPublicSchema;
+import org.labkey.panoramapublic.query.ContainerJoin;
+import org.labkey.panoramapublic.query.PanoramaPublicTable;
+
+public class ExperimentStructuralModInfoTableInfo extends PanoramaPublicTable
+{
+    public ExperimentStructuralModInfoTableInfo(PanoramaPublicSchema schema, ContainerFilter cf)
+    {
+        super(PanoramaPublicManager.getTableInfoExperimentStructuralModInfo(), schema, cf, ContainerJoin.ExpAnnotJoin);
+    }
+
+    @Override
+    public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)
+    {
+        return getContainer().hasPermission(user, perm);
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        return new RowIdQueryUpdateService<ExperimentStructuralModInfo>(this)
+        {
+            @Override
+            protected ExperimentStructuralModInfo createNewBean()
+            {
+                return new ExperimentStructuralModInfo();
+            }
+
+            @Override
+            public ExperimentStructuralModInfo get(User user, Container container, int key)
+            {
+                return new TableSelector(PanoramaPublicManager.getTableInfoExperimentStructuralModInfo()).getObject(key, ExperimentStructuralModInfo.class);
+            }
+
+            @Override
+            public void delete(User user, Container container, int key)
+            {
+                Table.delete(PanoramaPublicManager.getTableInfoExperimentStructuralModInfo(), key);
+            }
+
+            @Override
+            protected ExperimentStructuralModInfo insert(User user, Container container, ExperimentStructuralModInfo bean)
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected ExperimentStructuralModInfo update(User user, Container container, ExperimentStructuralModInfo bean, Integer oldKey)
+            {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/ModificationDocsDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/ModificationDocsDisplayColumnFactory.java
@@ -1,0 +1,148 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryUrls;
+import org.labkey.api.security.User;
+import org.labkey.api.targetedms.ITargetedMSRun;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.api.targetedms.TargetedMSUrls;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.Link;
+import org.labkey.api.util.PageFlowUtil;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.labkey.api.util.DOM.Attribute.style;
+import static org.labkey.api.util.DOM.TD;
+import static org.labkey.api.util.DOM.TR;
+import static org.labkey.api.util.DOM.at;
+
+/**
+ * Used with the "RunIds" column of the custom queries StructuralModifications.sql and IsotopeModifications.sql
+ * Displays links to the Skyline documents represented by "RunIds" along with a link to the peptides that have
+ * the modification in each document.
+ */
+public abstract class ModificationDocsDisplayColumnFactory implements DisplayColumnFactory
+{
+    private static final FieldKey MOD_ID = FieldKey.fromParts("ModId");
+
+    protected abstract String getPeptideModTableName();
+    protected abstract String getModIdQueryParam();
+
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new DataColumn(colInfo)
+        {
+            @Override
+            public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
+            {
+                String runIds = ctx.get(colInfo.getFieldKey(), String.class);
+                if (!StringUtils.isBlank(runIds))
+                {
+                    User user = ctx.getViewContext().getUser();
+                    Set<Long> ids = Arrays.stream(runIds.split(","))
+                            .map(r -> NumberUtils.toLong(r, 0))
+                            .filter(l -> l != 0)
+                            .collect(Collectors.toSet());
+
+                    List<ITargetedMSRun> runs = getRuns(ids, user);
+                    if (runs.size() > 0)
+                    {
+                        Long modId = ctx.get(MOD_ID, Long.class);
+                        List<DOM.Renderable> runPeptideLinks = new ArrayList<>();
+                        for (ITargetedMSRun run: runs)
+                        {
+                            runPeptideLinks.add(TR(
+                                    TD(at(style, "padding:2px 2px 2px 5px;"), runLink(run)),
+                                    modId != null ? TD(at(style, "padding:2px; vertical-align:top;"), peptidesLink(run, modId)) : HtmlString.EMPTY_STRING)
+                            );
+                        }
+                        DOM.TABLE(runPeptideLinks).appendTo(out);
+                    }
+                    else
+                    {
+                        out.write("No runs found for Ids: " + PageFlowUtil.filter(runIds));
+                    }
+                }
+            }
+
+            @Override
+            public void addQueryFieldKeys(Set<FieldKey> keys)
+            {
+                super.addQueryFieldKeys(keys);
+                keys.add(MOD_ID);
+            }
+        };
+    }
+
+    private List<ITargetedMSRun> getRuns(Collection<Long> runIds, User user)
+    {
+        var runs = new ArrayList<ITargetedMSRun>();
+        var svc = TargetedMSService.get();
+        runIds.forEach(id -> runs.add(svc.getRun(id, user)));
+        return runs.stream().filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    private @NotNull DOM.Renderable runLink(@NotNull ITargetedMSRun run)
+    {
+        var runUrl = PageFlowUtil.urlProvider(TargetedMSUrls.class).getShowRunUrl(run.getContainer(), run.getId());
+        return new Link.LinkBuilder(run.getFileName()).href(runUrl).clearClasses().build();
+    }
+
+    private @NotNull DOM.Renderable peptidesLink(ITargetedMSRun run, Long modId)
+    {
+        String query = getPeptideModTableName();
+        var peptidesLink = PageFlowUtil.urlProvider(QueryUrls.class).urlExecuteQuery(run.getContainer(), "targetedms", query);
+        peptidesLink.addParameter("query.PeptideId/PeptideGroupId/RunId~eq", run.getId());
+        peptidesLink.addParameter(getModIdQueryParam(), modId);
+        return new Link.LinkBuilder("[PEPTIDES]").href(peptidesLink).build();
+    }
+
+    public static class StructuralModDocsColumn extends ModificationDocsDisplayColumnFactory
+    {
+        @Override
+        protected String getPeptideModTableName()
+        {
+            return "PeptideStructuralModification";
+        }
+
+        @Override
+        protected String getModIdQueryParam()
+        {
+            return "query.StructuralModId/Id~eq";
+        }
+    }
+
+    public static class IsotopicModDocsColumn extends ModificationDocsDisplayColumnFactory
+    {
+        @Override
+        protected String getPeptideModTableName()
+        {
+            return "PeptideIsotopeModification";
+        }
+
+        @Override
+        protected String getModIdQueryParam()
+        {
+            return "query.IsotopeModId/Id~eq";
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/ModificationsView.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/ModificationsView.java
@@ -1,0 +1,83 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.DataRegion;
+import org.labkey.api.query.QuerySettings;
+import org.labkey.api.query.QueryUrls;
+import org.labkey.api.query.QueryView;
+import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.ViewContext;
+import org.labkey.panoramapublic.PanoramaPublicSchema;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+
+public class ModificationsView extends QueryView
+{
+    protected final ExperimentAnnotations _exptAnnotations;
+    private final String _title;
+    private final String _queryName;
+    private final String _customViewName;
+
+    public ModificationsView(ViewContext portalCtx, String queryName, String title, String customViewName, @Nullable ExperimentAnnotations exptAnnotations)
+    {
+        super(new PanoramaPublicSchema(portalCtx.getUser(), portalCtx.getContainer()));
+        _exptAnnotations = exptAnnotations;
+        _title = title;
+        _queryName = queryName;
+        _customViewName = customViewName;
+
+        setTitle(title);
+        setSettings(createQuerySettings(portalCtx));
+        setShowDetailsColumn(false);
+        setButtonBarPosition(DataRegion.ButtonBarPosition.TOP);
+        setShowExportButtons(false);
+        setShowBorders(true);
+        setShadeAlternatingRows(true);
+        setAllowableContainerFilterTypes(ContainerFilter.Type.Current, ContainerFilter.Type.CurrentAndSubfolders);
+        setFrame(FrameType.PORTAL);
+    }
+
+    protected QuerySettings createQuerySettings(ViewContext portalCtx)
+    {
+        QuerySettings settings = getSchema().getSettings(portalCtx, _title, _queryName, null);
+        if (_exptAnnotations != null)
+        {
+            // If we are given an ExperimentAnnotations it means that this view is being displayed on the experiment details page.
+            // We will display a non-customizable view in this case.  The user can click the grid title to view the customizable query.
+            settings.setContainerFilterName(_exptAnnotations.isIncludeSubfolders() ?
+                    ContainerFilter.Type.CurrentAndSubfolders.name() : ContainerFilter.Type.Current.name());
+            settings.setViewName(_customViewName);
+            settings.setAllowChooseView(false);
+        }
+
+        setTitleHref(PageFlowUtil.urlProvider(QueryUrls.class).urlExecuteQuery(portalCtx.getContainer(), PanoramaPublicSchema.SCHEMA_NAME, _queryName));
+
+        return settings;
+    }
+
+    public static class StructuralModsView extends ModificationsView
+    {
+        public StructuralModsView(ViewContext portalCtx)
+        {
+            this(portalCtx, null);
+        }
+
+        public StructuralModsView(ViewContext portalCtx, @Nullable ExperimentAnnotations exptAnnotations)
+        {
+            super(portalCtx, "StructuralModifications", "Structural Modifications", "ExperimentStructuralModInfo", exptAnnotations);
+        }
+    }
+
+    public static class IsotopeModsView extends ModificationsView
+    {
+        public IsotopeModsView(ViewContext portalCtx)
+        {
+            this(portalCtx, null);
+        }
+
+        public IsotopeModsView(ViewContext portalCtx, @Nullable ExperimentAnnotations exptAnnotations)
+        {
+            super(portalCtx, "IsotopeModifications", "Isotope Modifications", "ExperimentIsotopeModInfo", exptAnnotations);
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/NormalizedFormulaDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/NormalizedFormulaDisplayColumnFactory.java
@@ -1,0 +1,37 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.panoramapublic.proteomexchange.Formula;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+
+/**
+ * Used with the "NormalizedFormula" column of the custom query StructuralModifications.sql. The raw value in this column
+ * is the formula from the Skyline document which may or may not be normalized. Displays the normalized formula if it
+ * is parsed without errors. Otherwise displays the original formula.
+ */
+public class NormalizedFormulaDisplayColumnFactory implements DisplayColumnFactory
+{
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new DataColumn(colInfo)
+        {
+            @Override
+            public void renderGridCellContents(RenderContext ctx, Writer out) throws IOException
+            {
+                String formula = ctx.get(colInfo.getFieldKey(), String.class);
+                if (formula != null)
+                {
+                    out.write(Formula.normalizeFormula(formula));
+                }
+            }
+        };
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/UnimodIdDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/UnimodIdDisplayColumnFactory.java
@@ -1,0 +1,34 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.panoramapublic.proteomexchange.UnimodModification;
+
+import java.io.Writer;
+
+/**
+ * Displays a link to the Unimod page for a modification with the given Unimod Id.
+ * Example: https://www.unimod.org/modifications_view.php?editid1=4
+ */
+public class UnimodIdDisplayColumnFactory implements DisplayColumnFactory
+{
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new DataColumn(colInfo)
+        {
+            @Override
+            public void renderGridCellContents(RenderContext ctx, Writer out)
+            {
+                Integer unimodId = ctx.get(colInfo.getFieldKey(), Integer.class);
+                if (unimodId != null)
+                {
+                    UnimodModification.getLink(unimodId).appendTo(out);
+                }
+            }
+        };
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/query/modification/UnimodMatchDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/modification/UnimodMatchDisplayColumnFactory.java
@@ -1,0 +1,182 @@
+package org.labkey.panoramapublic.query.modification;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.targetedms.IModification;
+import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.api.util.DOM;
+import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.Link;
+import org.labkey.api.view.ActionURL;
+import org.labkey.panoramapublic.PanoramaPublicController;
+import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.panoramapublic.proteomexchange.UnimodModification;
+import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
+import org.labkey.panoramapublic.query.ModificationInfoManager;
+
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.labkey.api.util.DOM.Attribute.style;
+import static org.labkey.api.util.DOM.B;
+import static org.labkey.api.util.DOM.DIV;
+import static org.labkey.api.util.DOM.SPAN;
+import static org.labkey.api.util.DOM.at;
+import static org.labkey.api.util.DOM.cl;
+
+public abstract class UnimodMatchDisplayColumnFactory<T extends ExperimentModInfo> implements DisplayColumnFactory
+{
+    private static final FieldKey MOD_ID = FieldKey.fromParts("ModId");
+    private static final FieldKey MOD_INFO_ID = FieldKey.fromParts("ModInfoId");
+
+    abstract ActionURL getMatchToUnimodAction(RenderContext ctx);
+    abstract ActionURL getDeleteAction(RenderContext ctx);
+    abstract T getModInfo(int modInfoId);
+    abstract IModification getModification(long dbModId);
+
+    @Override
+    public DisplayColumn createRenderer(ColumnInfo colInfo)
+    {
+        return new DataColumn(colInfo)
+        {
+            @Override
+            public void renderGridCellContents(RenderContext ctx, Writer out)
+            {
+                Integer unimodId = ctx.get(colInfo.getFieldKey(), Integer.class);
+
+                if (unimodId != null)
+                {
+                    Integer modInfoId = ctx.get(MOD_INFO_ID, Integer.class);
+                    if (modInfoId == null)
+                    {
+                        // This is the Unimod Id from the Skyline document
+                        UnimodModification.getLink(unimodId).appendTo(out);
+                    }
+                    else
+                    {
+                        var modInfo = getModInfo(modInfoId);
+                        DIV(getAssignedUnimodDetails(modInfo)).appendTo(out);
+
+                        int exptId = modInfo.getExperimentAnnotationsId();
+                        var dbMod = getModification(modInfo.getModId());
+                        var deleteUrl = getDeleteAction(ctx).addParameter("id", exptId).addParameter("modInfoId", modInfoId);
+                        DIV(at(style, "margin-top:5px;"), new Link.LinkBuilder("[Delete]")
+                                .href(deleteUrl)
+                                .clearClasses().addClass("labkey-error")
+                                .usePost(String.format("Are you sure you want to delete the saved Unimod information for modification '%s'?",
+                                        dbMod != null ? dbMod.getName() : ""))
+                                .build())
+                                .appendTo(out);
+                    }
+                }
+                else
+                {
+                    // If there is an experiment in the container then display a link to find a Unimod match
+                    ExperimentAnnotations exptAnnotations = ExperimentAnnotationsManager.getExperimentInContainer(ctx.getContainer());
+                    Integer exptId = exptAnnotations != null ? exptAnnotations.getId() : null;
+
+                    Long modId = ctx.get(MOD_ID, Long.class);
+
+                    if (modId != null && exptId != null)
+                    {
+                        var url = getMatchToUnimodAction(ctx).addParameter("id", exptId).addParameter("modificationId", modId);
+                        url.addReturnURL(ctx.getViewContext().getActionURL());
+                        var findMatchLink = new Link.LinkBuilder("Find Match").href(url);
+                        DIV(cl("alert-warning"), findMatchLink).appendTo(out);
+                    }
+                }
+            }
+
+            @Override
+            public void addQueryFieldKeys(Set<FieldKey> keys)
+            {
+                super.addQueryFieldKeys(keys);
+                keys.add(MOD_ID);
+                keys.add(MOD_INFO_ID);
+            }
+        };
+    }
+
+    protected List<DOM.Renderable> getAssignedUnimodDetails(T modInfo)
+    {
+        return List.of(
+                SPAN("**"), UnimodModification.getLink(modInfo.getUnimodId(), true),
+                HtmlString.NBSP,
+                SPAN("(" + modInfo.getUnimodName() + ")")
+        );
+    }
+
+    public static class StructuralUnimodMatch extends UnimodMatchDisplayColumnFactory<ExperimentStructuralModInfo>
+    {
+        @Override
+        ActionURL getMatchToUnimodAction(RenderContext ctx)
+        {
+            return new ActionURL(PanoramaPublicController.StructuralModToUnimodOptionsAction.class, ctx.getContainer());
+        }
+
+        @Override
+        ActionURL getDeleteAction(RenderContext ctx)
+        {
+            return new ActionURL(PanoramaPublicController.DeleteStructuralModInfoAction.class, ctx.getContainer());
+        }
+
+        @Override
+        ExperimentStructuralModInfo getModInfo(int modInfoId)
+        {
+            return ModificationInfoManager.getStructuralModInfo(modInfoId);
+        }
+
+        @Override
+        IModification getModification(long dbModId)
+        {
+            return TargetedMSService.get().getStructuralModification(dbModId);
+        }
+
+        @Override
+        protected List<DOM.Renderable> getAssignedUnimodDetails(ExperimentStructuralModInfo modInfo)
+        {
+            List<DOM.Renderable> list = new ArrayList<>(super.getAssignedUnimodDetails(modInfo));
+            if (modInfo.isCombinationMod())
+            {
+                list.add(SPAN(at(style, "margin:0 10px 0 10px;"), B("+")));
+                list.add(UnimodModification.getLink(modInfo.getUnimodId2(), true));
+                list.add(HtmlString.NBSP);
+                list.add(SPAN("(" + modInfo.getUnimodName2() + ")"));
+            }
+            return list;
+        }
+    }
+
+    public static class IsotopeUnimodMatch extends UnimodMatchDisplayColumnFactory<ExperimentModInfo>
+    {
+        @Override
+        ActionURL getMatchToUnimodAction(RenderContext ctx)
+        {
+            return new ActionURL(PanoramaPublicController.MatchToUnimodIsotopeAction.class, ctx.getContainer());
+        }
+
+        @Override
+        ActionURL getDeleteAction(RenderContext ctx)
+        {
+            return new ActionURL(PanoramaPublicController.DeleteIsotopeModInfoAction.class, ctx.getContainer());
+        }
+
+        @Override
+        ExperimentModInfo getModInfo(int modInfoId)
+        {
+            return ModificationInfoManager.getIsotopeModInfo(modInfoId);
+        }
+
+        @Override
+        IModification getModification(long dbModId)
+        {
+            return TargetedMSService.get().getStructuralModification(dbModId);
+        }
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/view/combinationModInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/combinationModInfo.jsp
@@ -1,0 +1,327 @@
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.panoramapublic.proteomexchange.UnimodModification" %>
+<%@ page import="org.labkey.panoramapublic.proteomexchange.ChemElement" %>
+<%@ page import="org.labkey.panoramapublic.proteomexchange.Formula" %>
+<%@ page import="java.util.Map" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("Ext4");
+    }
+%>
+<%
+    JspView<PanoramaPublicController.CombinationModificationBean> view = (JspView<PanoramaPublicController.CombinationModificationBean>) HttpView.currentView();
+    var bean = view.getModelBean();
+    var form = bean.getForm();
+    var modification = bean.getModification();
+    var modFormula = bean.getModFormula();
+    var unimodMods = bean.getUnimodModificationList();
+    var returnUrl = form.getReturnURLHelper(PanoramaPublicController.getViewExperimentDetailsURL(form.getId(), getContainer()));
+%>
+<labkey:errors/>
+
+<style>
+    .display-value {
+        font-size: 14px;
+        margin-top: 10px;
+    }
+</style>
+
+<div id="combinationModInfoForm"></div>
+
+<script type="text/javascript">
+
+    const elementOrder = {}; // Order of elements in a normalized formula
+    let idx = 0;
+    <% for (var el: bean.getElementOrder()) { %>
+    elementOrder[<%=q(el)%>] = idx++;
+    <% } %>
+
+    class Formula {
+
+        constructor() {
+            this.elementCounts = {};
+        }
+        subtractElement(el, count) {
+            this.addElement(el, count * -1);
+        }
+        addElement(element, count) {
+            const currentCount = this.elementCounts[element];
+            if (currentCount) {
+                count = currentCount + count;
+            }
+            this.elementCounts[element] = count;
+        }
+        subtractFormula(otherFormula) {
+            const newFormula = new Formula();
+            Object.keys(this.elementCounts).forEach(el => newFormula.addElement(el, this.elementCounts[el]));
+            Object.keys(otherFormula.elementCounts).forEach(el => newFormula.subtractElement(el, otherFormula.elementCounts[el]));
+
+            return newFormula;
+        }
+        isEmpty() {
+            return !Object.keys(this.elementCounts).find(el => this.elementCounts[el] !== 0);
+        }
+        getFormula() {
+            let posForm = "";
+            let negForm = "";
+
+            const sortedKeys = Object.keys(this.elementCounts).sort((a,b) => elementOrder[a] - elementOrder[b]);
+            for (const elem of sortedKeys) {
+                let cnt = this.elementCounts[elem];
+                if (cnt > 0) {
+                    posForm += elem + (cnt > 1 ? cnt : "");
+                }
+                else if (cnt < 0) {
+                    cnt = cnt * -1;
+                    negForm += elem + (cnt > 1 ? cnt : "");
+                }
+            }
+            const sep = posForm && negForm ? " - " : negForm ? "-" : "";
+            return posForm + sep + negForm;
+        }
+    }
+
+    const modFormula = new Formula();
+    <% for (var entry: modFormula.getElementCounts().entrySet()) { %>
+    modFormula.addElement(<%=q(entry.getKey().getSymbol())%>, <%=entry.getValue()%>);
+    <% } %>
+
+    let selectedUnimod1 = undefined;
+    let selectedUnimod2 = undefined;
+    let formPanel, combo1, combo2;
+
+    Ext4.onReady(function(){
+
+        combo1 = createUnimodCb(1);
+        combo2 = createUnimodCb(2);
+
+        <% if (form.getUnimodId1() != null) { %>
+            const record1 = combo1.getStore().getById(<%=form.getUnimodId1()%>);
+            if (record1) selectedUnimod1 = record1.data;
+        <% } %>
+
+        <% if (form.getUnimodId2() != null) { %>
+            const record2 = combo2.getStore().getById(<%=form.getUnimodId2()%>);
+            if (record2) selectedUnimod2 = record2.data;
+        <% } %>
+
+        formPanel = Ext4.create('Ext.form.Panel', {
+            renderTo: "combinationModInfoForm",
+            standardSubmit: true,
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 160,
+                width: 800,
+                labelStyle: 'background-color: #E0E6EA; padding: 5px;'
+            },
+            items: [
+                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
+                {
+                    xtype: 'hidden',
+                    name: 'id', // ExperimentAnnotationsId
+                    value: <%=form.getId()%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: <%=q(ActionURL.Param.returnUrl.name())%>,
+                    value: <%=q(returnUrl)%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'modificationId',
+                    value: <%=form.getModificationId()%>
+                },
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Modification Name",
+                    value: <%=q(modification.getName())%>
+                },
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Formula",
+                    value: <%=q(Formula.normalizeFormula(modification.getFormula()))%>
+                },
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Amino Acid(s)",
+                    value: <%=q(modification.getAminoAcid())%>
+                },
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Terminus",
+                    value: <%=q(modification.getTerminus())%>
+                },
+                {
+                    xtype: 'label',
+                    width: 600,
+                    text: 'This modification is a combination of',
+                    style: {'text-align': 'center', 'margin': '10px 0 10px 0'}
+                },
+                {
+                    xtype: 'component',
+                    itemId: 'formulaDiff',
+                    style: {'text-align': 'left', 'margin': '10px 0 10px 0'}
+                },
+                combo1,
+                {
+                    xtype: 'label',
+                    text: '--- AND ---',
+                    width: 600,
+                    style: {'text-align': 'center', 'margin': '10px 0 10px 0'}
+                },
+                combo2
+            ],
+            buttonAlign: 'left',
+            buttons: [
+                {
+                    text: "Save",
+                    cls: 'labkey-button primary',
+                    handler: function() {
+                        formPanel.submit({
+                            url: <%=q(urlFor(PanoramaPublicController.DefineCombinationModificationAction.class))%>,
+                            method: 'POST'
+                        });
+                    }
+                },
+                {text: 'Cancel',
+                    cls: 'labkey-button',
+                    handler: function() {
+                        window.location = <%= q(returnUrl) %>;
+                    }
+                }]
+        });
+
+        if (selectedUnimod1 && selectedUnimod2) {
+            updateFormulaDiff();
+        }
+    });
+
+    function createUnimodCb(cbIdx) {
+
+        const createDataSourceFilter = function(value) {
+            return Ext4.create('Ext.util.Filter', {
+                filterFn: function(item) {
+                    // Filter on display name or formula
+                    return Ext4.String.startsWith(item.data.displayName, value, true) || Ext4.String.startsWith(item.data.formula, value);
+                }
+            });
+        };
+
+        return Ext4.create('Ext.form.field.ComboBox', {
+            xtype: 'combo',
+            name: 'unimodId' + cbIdx,
+            itemId: 'unimodId' + cbIdx,
+            fieldLabel: "Unimod Modification " + cbIdx,
+            allowBlank: false,
+            editable : true,
+            queryMode : 'local',
+            forceSelection: true, // restrict the selected value to one of the values in the list
+            displayField: 'displayName',
+            valueField: 'id',
+            value: cbIdx === 1 ? <%=form.getUnimodId1() != null ? form.getUnimodId1() : null %> :
+                                 <%=form.getUnimodId2() != null ? form.getUnimodId2() : null %>,
+            store: createStore(),
+            labelWidth: 160,
+            width: 600,
+            labelStyle: 'background-color: #E0E6EA; padding: 5px;',
+            listeners: {
+                scope: this,
+                select: function (combo, records){
+                    const record = records[0];
+                    if (cbIdx === 1) selectedUnimod1 = record.data;
+                    else selectedUnimod2 = record.data;
+                    updateFormulaDiff();
+                },
+                change: function(combo, newValue) {
+                    const store = combo.getStore();
+                    store.clearFilter(true);
+                    store.addFilter(createDataSourceFilter(newValue));
+                }
+            }
+        });
+    }
+
+    const alertCls = 'alert';
+    const alertInfoCls = 'alert-info';
+    const alertWarnCls = 'alert-warning';
+
+    function updateFormulaDiff() {
+
+        let totalFormula = new Formula();
+        totalFormula = addUnimod(totalFormula, selectedUnimod1);
+        totalFormula = addUnimod(totalFormula, selectedUnimod2);
+        const diffFormula = modFormula.subtractFormula(totalFormula);
+        const formulaBalanced = diffFormula.isEmpty();
+
+        let html = '';
+        html += selectedUnimod1 ? selectedUnimod1["formula"] : span('---');
+        html += span('+');
+        html += selectedUnimod2 ? selectedUnimod2["formula"] : span('---');
+        html += span('=');
+        html += totalFormula.getFormula();
+        if (formulaBalanced) {
+            html += '<span style="color:green;margin-left:10px;" class="fa fa-check-circle"></span>';
+        }
+        else {
+            html += span(' (Difference: ' + diffFormula.getFormula() + ')');
+            html += '<span style="color:red;" class="fa fa-times-circle"></span>';
+        }
+
+        const el = formPanel.getComponent("formulaDiff");
+        if (el != null)
+        {
+            if (!el.hasCls(alertCls)) el.addCls(alertCls);
+
+            el.removeCls(formulaBalanced ? alertWarnCls : alertInfoCls);
+            el.addCls(formulaBalanced ? alertInfoCls : alertWarnCls);
+            el.update(html);
+        }
+    }
+
+    function span(str) {
+        return '<span style="margin: 0 10px 0 10px;font-weight:bold;">' + str + '</span>';
+    }
+
+    function addUnimod(formula, unimodRecord) {
+        if (unimodRecord) {
+            const composition = unimodRecord['composition'];
+            Object.keys(composition).forEach(el => formula.addElement(el, composition[el]));
+        }
+        return formula;
+    }
+
+    function createStore() {
+        return Ext4.create('Ext.data.Store', {
+            fields: ['id', 'name', 'displayName', 'formula', 'composition'],
+            data:   [
+                <% for(UnimodModification mod: unimodMods){ %>
+                {
+                    "id":<%=mod.getId()%>,
+                    "name":<%=q(mod.getName())%>,
+                    "formula": <%= q(mod.getNormalizedFormula()) %>,
+                    "displayName":<%= q(mod.getName() + ", " + mod.getNormalizedFormula() + ", Unimod:" + mod.getId()) %>,
+                    "composition": {
+                        <% for (Map.Entry<ChemElement, Integer> entry: mod.getFormula().getElementCounts().entrySet()) { %>
+                            <%=q(entry.getKey().getSymbol())%>:  <%=entry.getValue()%> ,
+                        <% } %>
+                        }
+                },
+                <% } %>
+            ]
+        });
+    }
+</script>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxValidationStatus.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxValidationStatus.jsp
@@ -92,7 +92,7 @@
     table.pxv-tpl-table td,
     table.pxv-tpl-table th
     {
-        border:1px solid black; padding:8px;
+        border:1px solid slategray; padding:8px;
     }
 
 </style>
@@ -371,6 +371,7 @@
                 style:  {margin: '10px'},
                 items:  [
                             {xtype: 'component', padding: '10, 5, 0, 5', html: 'Folder: ' + htmlEncode(validationJson["folder"])},
+                            {xtype: 'component', padding: '0, 5, 0, 5', html: experimentLink()},
                             {xtype: 'component', padding: '0, 5, 10, 5', html: 'Date: ' + htmlEncode(validationJson["date"])},
                             {
                                 xtype:   'component',
@@ -391,13 +392,19 @@
         return {xtype: 'label', text: 'Missing JSON property "validation"'};
     }
 
-    function link(text, href, cssCls) {
+    function link(text, href, cssCls, sameTab) {
         const cls = cssCls ? ' class="' + cssCls + '" ' : '';
-        return '<a ' + cls + ' href="' + htmlEncode(href) + '" target="_blank">' + htmlEncode(text) + '</a>';
+        const target = sameTab && sameTab === true ? '' : ' target="_blank" ';
+        return '<a ' + cls + ' href="' + htmlEncode(href) + '" ' + target + ' >' + htmlEncode(text) + '</a>';
     }
 
     function documentLink(documentName, containerPath, runId) {
-        return link(documentName, LABKEY.ActionURL.buildURL('targetedms', 'showPrecursorList.view', containerPath, {id: runId}));
+        return link(documentName, LABKEY.ActionURL.buildURL('targetedms', 'showPrecursorList', containerPath, {id: runId}));
+    }
+
+    function experimentLink() {
+        return link("[View experiment details]", LABKEY.ActionURL.buildURL('panoramapublic', 'showExperimentAnnotations',
+                LABKEY.ActionURL.getContainer(), {id: <%=experimentAnnotationsId%>}), 'labkey-text-link', true);
     }
 
     function unimodLink(unimodId, cls) {
@@ -408,6 +415,21 @@
         return '<span class="pxv-invalid">MISSING</span>';
     }
 
+    function assignUnimodLink(dbModId, modType, experimentAnnotationsId) {
+        if (!modType) return;
+        const modTypeUpper = modType.toUpperCase();
+        const action = modTypeUpper === 'STRUCTURAL' ? 'structuralModToUnimodOptions' : 'matchToUnimodIsotope';
+        const params = {
+            'id': experimentAnnotationsId,
+            'modificationId': dbModId,
+            'returnUrl': LABKEY.ActionURL.buildURL(LABKEY.ActionURL.getController(), LABKEY.ActionURL.getAction(),
+                    LABKEY.ActionURL.getContainer(), LABKEY.ActionURL.getParameters())
+        };
+
+        var href = LABKEY.ActionURL.buildURL('panoramapublic', action, LABKEY.ActionURL.getContainer(), params);
+        return '<span style="margin-left:5px;">'  + link("Find Match", href, 'labkey-text-link', true) + '</span>';
+    }
+
     // -----------------------------------------------------------
     // Displays the modifications validation grid
     // -----------------------------------------------------------
@@ -416,21 +438,25 @@
         if (json["modifications"]) {
             const modificationsStore = Ext4.create('Ext.data.Store', {
                 storeId: 'modificationsStore',
-                fields:  ['id', 'skylineModInfo', 'unimodId', 'unimodName', 'inferred', 'valid', 'modType', 'dbModId', 'documents', 'possibleUnimodMatches'],
+                fields:  ['id', 'skylineModInfo', 'unimodId', 'unimodName', 'inferred', 'valid', 'modType', 'dbModId', 'documents', 'unimodMatches'],
                 data:    json,
                 proxy:   { type: 'memory', reader: { type: 'json', root: 'modifications' }},
                 sorters: [
-                    {
-                        property: 'valid',
-                        direction: 'ASC'
-                    },
                     {
                         property: 'modType',
                         direction: 'DESC' // Structural modifications first
                     },
                     {
+                        property: 'valid',
+                        direction: 'DESC'
+                    },
+                    {
                         property: 'unimodId',
-                        direction: 'ASC'
+                        direction: 'DESC'
+                    },
+                    {
+                        property: 'unimodMatches',
+                        direction: 'DESC'
                     }
                 ]
             });
@@ -467,17 +493,37 @@
                         text: 'Unimod Id',
                         dataIndex: 'unimodId',
                         flex: 2,
-                        renderer: function (value) {
-                            // Can do metadata.style = "color:green;" or metadata.tdCls = 'green'
+                        renderer: function (value, metadata, record) {
                             if (value) return unimodLink(value, 'pxv-valid');
-                            else return missing();
+                            else if (record.data['unimodMatches']) {
+                                var ret = ''; var sep = '';
+                                var matches = record.data['unimodMatches'];
+                                for (var i = 0; i < matches.length; i++) {
+                                    ret += sep + unimodLink(matches[i]['unimodId'], 'pxv-valid');
+                                    sep = ' + ';
+                                }
+                                return ret;
+                            }
+                            else return missing() + assignUnimodLink(record.data['dbModId'], record.data['modType'], <%=experimentAnnotationsId%>);
                         }
                     },
                     {
                         text: 'Unimod Name',
                         dataIndex: 'unimodName',
                         flex: 3,
-                        renderer: function (v) { return htmlEncode(v); }
+                        renderer: function (value, metadata, record) {
+                            if (value) return htmlEncode(value);
+                            else if (record.data['unimodMatches']) {
+                                var ret = ''; var sep = '';
+                                var matches = record.data['unimodMatches'];
+                                for (var i = 0; i < matches.length; i++) {
+                                    ret += sep + htmlEncode(matches[i]['name']);
+                                    sep = ' + ';
+                                }
+                                return ret;
+                            }
+                            else return '';
+                        }
                     },
                     {
                         text: 'Type',
@@ -501,18 +547,6 @@
                     rowBodyTpl: new Ext4.XTemplate(
 
                             '<div class="pxv-grid-expanded-row">',
-
-                            // Possible Unimod matches
-                            '<tpl if="possibleUnimodMatches.length &gt; 0">',
-                            '<div class="pxv-tpl-table-title">Possible Unimod Matches</div>',
-                            '<table class="pxv-tpl-table">',
-                            headerRowTpl.apply(["Unimod Id", "Name", "Composition", "Sites"]),
-                            '<tbody>',
-                            '<tpl for="possibleUnimodMatches">',
-                            '<tr> <td>{[this.unimodLink(values)]}</td> <td>{name}</td> <td>{formula}</td> <td>{sites}</td> </tr>',
-                            '</tpl>',
-                            '</tbody></table>',
-                            '</tpl>',
 
                             // Skyline documents with this modification
                             '<div class="pxv-tpl-table-title">Skyline documents with the modification</div>',
@@ -548,11 +582,9 @@
                 }]
             });
             if (hasInferred) {
-                var noteHtml = "Modifications ending with <strong>**</strong> in the Name column did not have a Unimod Id in the Skyline document."
-                        + " A Unimod Id was inferred based on the formula, modification site(s) and terminus in the modification definition."
-                        + " If any of the inferred Unimod Ids is incorrect, please choose a modification with a Unimod Id in Skyline and re-upload the document."
-                        + " If you cannot find the modification in Skyline's built-in modification list, please"
-                        + " <a class=\"alert-link\" href=\"https://panoramaweb.org/support.url\" target=\"_blank\">contact the Skyline / Panorama support team</a>.";
+                var noteHtml = "Modification names starting with <strong>**</strong> in the Name column did not have a Unimod Id in the Skyline document."
+                        + " A Unimod match was was inferred based on the formula, modification site(s) and terminus in the modification definition"
+                        + ", or a combination modification was defined.";
                 var note = {
                     xtype: 'component',
                     padding: 10,

--- a/panoramapublic/src/org/labkey/panoramapublic/view/unimodMatchInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/unimodMatchInfo.jsp
@@ -1,0 +1,213 @@
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.panoramapublic.proteomexchange.UnimodModification" %>
+<%@ page import="org.labkey.panoramapublic.proteomexchange.Formula" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+
+<%!
+    @Override
+    public void addClientDependencies(ClientDependencies dependencies)
+    {
+        dependencies.add("Ext4");
+    }
+%>
+<%
+    JspView<PanoramaPublicController.UnimodMatchBean> view = (JspView<PanoramaPublicController.UnimodMatchBean>) HttpView.currentView();
+    var bean = view.getModelBean();
+    var form = bean.getForm();
+    var modification = bean.getModification();
+    var unimodMatches = bean.getUnimodMatches();
+    var returnUrl = form.getReturnURLHelper(PanoramaPublicController.getViewExperimentDetailsURL(form.getId(), getContainer()));
+
+    var defineCombinationModUrl = new ActionURL(PanoramaPublicController.DefineCombinationModificationAction.class, getContainer())
+            .addParameter("id", form.getId())
+            .addParameter("modificationId", form.getModificationId())
+            .addReturnURL(form.getReturnActionURL(PanoramaPublicController.getViewExperimentDetailsURL(form.getId(), getContainer())));
+%>
+<labkey:errors/>
+
+<style>
+    .display-value {
+        font-size: 14px;
+        margin-top: 10px;
+    }
+</style>
+
+
+<div id="unimodMatchDiv"></div>
+<%if (bean.getUnimodMatches().size() == 0 && !bean.isIsotopicMod()) { %>
+<div class="alert alert-info" style="width:800px;">
+    Define a custom <%=button("Combination Modification").href(defineCombinationModUrl)%> if this modification is a combination of two modifications.
+</div>
+<% } %>
+<div style="width:800px;margin-top:30px; margin-left:8px;"><%=button("Cancel").href(returnUrl).style("padding:4px 15px")%></div>
+
+<script type="text/javascript">
+
+    Ext4.onReady(function(){
+
+        var items = [
+            {
+                xtype: 'displayfield',
+                fieldCls: 'display-value',
+                fieldLabel: "Name",
+                value: <%=q(modification.getName())%>
+            },
+            {
+                xtype: 'displayfield',
+                fieldCls: 'display-value',
+                fieldLabel: "Formula",
+                value: <%=q(Formula.normalizeFormula(modification.getFormula()))%>
+            },
+            <% if (bean.isIsotopicMod()) { %>
+            {
+                xtype: 'displayfield',
+                fieldCls: 'display-value',
+                fieldLabel: "Label",
+                value: <%=q(bean.getLabels())%>
+            },
+            <% } %>
+            {
+                xtype: 'displayfield',
+                fieldCls: 'display-value',
+                fieldLabel: "Amino Acid(s)",
+                value: <%=q(modification.getAminoAcid())%>
+            },
+            {
+                xtype: 'displayfield',
+                fieldCls: 'display-value',
+                fieldLabel: "Terminus",
+                value: <%=q(modification.getTerminus())%>
+            },
+            {
+                xtype: 'component',
+                <% if (unimodMatches.size() == 0) { %>
+                cls: 'alert labkey-error alert-warning',
+                <% } %>
+                html: unimodMatchesHtml()
+            },
+        ];
+
+        <% for (int i = 0; i < unimodMatches.size(); i++) {
+            UnimodModification unimodMatch = unimodMatches.get(i);
+        %>
+            items.push(createForm(<%=unimodMatches.size() > 1 ? i : -1%>,
+                    <%=unimodMatch.getId()%>,
+                    <%=q(unimodMatch.getLink().getHtmlString())%>,
+                    <%=q(unimodMatch.getName())%>,
+                    <%=q(unimodMatch.getNormalizedFormula())%>,
+                    <%=q(unimodMatch.getModSitesWithPosition())%>,
+                    <%=q(unimodMatch.getTerminus())%>));
+        <% } %>
+
+        Ext4.create('Ext.panel.Panel', {
+            renderTo: "unimodMatchDiv",
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 160,
+                width: 800,
+                labelStyle: 'background-color: #E0E6EA; padding: 5px;'
+            },
+            items: items
+        });
+    });
+
+    function createForm(index, unimodId, unimodLink, name, formula, sites, terminus)
+    {
+        var form = Ext4.create('Ext.form.Panel', {
+            standardSubmit: true,
+            border: false,
+            frame: false,
+            defaults: {
+                labelWidth: 160,
+                width: 500,
+                labelStyle: 'background-color: #C0C6CA; padding: 5px;'
+            },
+            items: [
+                { xtype: 'hidden', name: 'X-LABKEY-CSRF', value: LABKEY.CSRF },
+                {
+                    xtype: 'label',
+                    text: '---------------- Unimod Match ' + (index > -1 ? index + 1 : '') + ' ----------------',
+                    style: {'text-align': 'left', 'margin': '10px 0 10px 0'}
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'id', // ExperimentAnnotationsId
+                    value: <%=form.getId()%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: <%=q(ActionURL.Param.returnUrl.name())%>,
+                    value: <%=q(returnUrl)%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'modificationId',
+                    value: <%=form.getModificationId()%>
+                },
+                {
+                    xtype: 'hidden',
+                    name: 'unimodId',
+                    value: unimodId
+                },
+
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Name",
+                    value: '<div>' + name + ', ' + unimodLink + '</div>'
+                },
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Formula",
+                    value: formula
+                },
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Sites",
+                    value: sites
+                },
+                {
+                    xtype: 'displayfield',
+                    fieldCls: 'display-value',
+                    fieldLabel: "Terminus",
+                    value: terminus
+                }
+            ],
+            buttonAlign: 'left',
+            buttons: [
+                {
+                    text: "Save Match",
+                    cls: 'labkey-button primary',
+                    handler: function(button) {
+                        button.setDisabled(true);
+                        form.submit({
+                            url: <%=q(urlFor(bean.isIsotopicMod()
+                            ? PanoramaPublicController.MatchToUnimodIsotopeAction.class
+                            : PanoramaPublicController.MatchToUnimodStructuralAction.class))%>,
+                            method: 'POST'
+                        });
+                    }
+                }]
+        });
+        return form;
+    }
+
+    function unimodMatchesHtml() {
+        let html = '<div>';
+        const modMatchCount = <%=unimodMatches.size()%>;
+        html += modMatchCount === 0 ? 'No Unimod matches were found for the modification.'
+                : 'The modification matches ' + modMatchCount + ' Unimod modification' + (modMatchCount > 1 ? 's' : '')
+        + '. Click the link next to the Unimod name to view the modification page on the Unimod website.'
+        + ' Click the "Save Match" button to associate the Unimod Id with the modification.';
+        html += '</div>';
+        return html;
+    }
+</script>

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -11,6 +11,7 @@ import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.components.SubfoldersWebPart;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentInsertPage;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
+import org.labkey.test.pages.panoramapublic.DataValidationPage;
 import org.labkey.test.tests.targetedms.TargetedMSTest;
 import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
@@ -153,6 +154,24 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         setFormElement(Locator.name("quf_FirstName"), "Submitter");
         setFormElement(Locator.name("quf_LastName"), lastName);
         clickButton("Submit");
+    }
+
+    void goToExperimentDetailsPage()
+    {
+        goToDashboard();
+        new TargetedMsExperimentWebPart(this).clickMoreDetails();
+    }
+
+    DataValidationPage submitValidationJob()
+    {
+        goToDashboard();
+        var expWebPart = new TargetedMsExperimentWebPart(this);
+        expWebPart.clickSubmit();
+        assertTextPresent("Click the button to start a new data validation job",
+                "Validate Data for ProteomeXchange",
+                "Submit without a ProteomeXchange ID");
+        clickButton("Validate Data for ProteomeXchange");
+        return new DataValidationPage(this);
     }
 
     void submitWithoutPXId()
@@ -325,6 +344,8 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         // these tests use the UIContainerHelper for project creation, but we can use the APIContainerHelper for deletion
         APIContainerHelper apiContainerHelper = new APIContainerHelper(this);
         apiContainerHelper.deleteProject(PANORAMA_PUBLIC, afterTest);
+
+        _userHelper.deleteUsers(false,ADMIN_USER, SUBMITTER);
 
         super.doCleanup(afterTest);
     }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicModificationsTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicModificationsTest.java
@@ -1,0 +1,274 @@
+package org.labkey.test.tests.panoramapublic;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.categories.External;
+import org.labkey.test.categories.MacCossLabModules;
+import org.labkey.test.components.WebPart;
+import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.Ext4Helper;
+import org.labkey.test.util.TextSearcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@Category({External.class, MacCossLabModules.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
+public class PanoramaPublicModificationsTest extends PanoramaPublicBaseTest
+{
+    private static final String SKY_FILE_1 = "HighPrecModSkydTest.sky.zip";
+
+    private static final String STRUCTURAL_MOD = "Structural Modifications";
+    private static final String ISOTOPE_MOD = "Isotope Modifications";
+
+    private final Unimod methyl = new Unimod(34, "Methyl", "H2C");
+    private final Unimod propionyl = new Unimod(58, "Propionyl", "H4C3O");
+    private final String methylPropionyl = "MethylPropionyl";
+    private final String propionylation = "Propionylation";
+
+    @Test
+    public void testAddModInfo()
+    {
+        String projectName = getProjectName();
+        String folderName = "ModificationsTest";
+
+        setupSourceFolder(projectName, folderName, SUBMITTER);
+        impersonate(SUBMITTER);
+        updateSubmitterAccountInfo("One");
+
+        // Upload document
+        importData(SKY_FILE_1, 1);
+
+        goToDashboard();
+        portalHelper.enterAdminMode();
+        portalHelper.addBodyWebPart(STRUCTURAL_MOD);
+        portalHelper.addBodyWebPart(ISOTOPE_MOD);
+
+        testCustomizeGrid(STRUCTURAL_MOD, false);
+        testCustomizeGrid(ISOTOPE_MOD, false);
+
+        // Add the "Targeted MS Experiment" webpart
+        String experimentTitle = "This is an experiment to test user-entered modification information";
+        createExperimentCompleteMetadata(experimentTitle);
+
+        goToDashboard();
+
+        testCustomizeGrid(STRUCTURAL_MOD, true);
+        testCustomizeGrid(ISOTOPE_MOD, true);
+
+        testSaveMatchForStructuralMod(propionylation, List.of(propionyl, new Unimod(206, "Delta:H(4)C(3)O(1)", propionyl.getFormula())),
+                0);
+
+        String methylPropionylFormula = "H6C4O";
+        testDefineCombinationMod(methylPropionyl, methylPropionylFormula, methyl, methyl, "H4C2", "H4C3O", "H2C2O", false);
+        testDefineCombinationMod(methylPropionyl, methylPropionylFormula, methyl, propionyl, methylPropionylFormula, "H4C3O", "", true);
+
+        testCopy(projectName, folderName, experimentTitle,  folderName + " Copy");
+    }
+
+
+    private void testDefineCombinationMod(String modificationName, String modFormula, Unimod unimod1, Unimod unimod2, String combinedFormula, String difference1, String difference2, boolean balanced)
+    {
+        goToDashboard();
+        goToExperimentDetailsPage();
+
+        var modsTable = new DataRegionTable(STRUCTURAL_MOD, this);
+        int rowIdx = checkModificationRow(modsTable, modificationName);
+
+        clickFindMatchInRow(modsTable, rowIdx);
+        assertTextPresent("Unimod Match Options ");
+        clickButton("Combination Modification");
+
+        assertTextPresent("Define Combination Modification");
+        var webpart = portalHelper.getBodyWebPart("Combination Modification");
+        _ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithLabel("Unimod Modification 1:"), unimod1.displayName());
+
+        // Examples: H2C+---=H2C (Difference: H4C3O) OR H2C+H2C=H4C2 (Difference: H2C2O)
+        String formatString = "%s+%s=%s (Difference: %s)";
+        checkFormulaDiff(webpart, String.format(formatString, unimod1.getFormula(), "---", unimod1.getFormula(), difference1), false);
+
+        _ext4Helper.selectComboBoxItem(Ext4Helper.Locators.formItemWithLabel("Unimod Modification 2:"), unimod2.displayName());
+        if (balanced)
+        {
+            checkFormulaDiff(webpart, String.format("%s+%s=%s", unimod1.getFormula(), unimod2.getFormula(), modFormula), true);
+        }
+        else
+        {
+            checkFormulaDiff(webpart, String.format(formatString, unimod1.getFormula(), unimod2.getFormula(), combinedFormula, difference2), false);
+        }
+
+        clickButton("Save");
+        if (!balanced)
+        {
+            assertTextPresent(String.format("Selected Unimod modification formulas do not add up to the formula of the modification. Combined formula is %s. Difference from the modification formula is %s.",
+                    combinedFormula, difference2));
+        }
+        else
+        {
+            modsTable = new DataRegionTable(STRUCTURAL_MOD, this);
+            checkModificationRow(modsTable, modificationName, unimod1, unimod2);
+        }
+    }
+
+    private void checkFormulaDiff(WebPart webpart, String expectedText, boolean balanced)
+    {
+        var formulaDiff = Locator.XPathLocator.tag("div").withClass("alert").findElement(webpart);
+        assertTrue("Expected formula diff: " + expectedText + " but found " + formulaDiff.getText(), formulaDiff.getText().contains(expectedText));
+        assertTrue(formulaDiff.getAttribute("class").contains(balanced ? "alert-info" : "alert-warning"));
+        if (balanced)
+        {
+            assertNotNull("Expected balanced formula indicator", Locator.XPathLocator.tag("span").withClass("fa fa-check-circle").findElementOrNull(formulaDiff));
+        }
+        else
+        {
+            assertNotNull("Expected unbalanced formula indicator", Locator.XPathLocator.tag("span").withClass("fa fa-times-circle").findElementOrNull(formulaDiff));
+        }
+    }
+
+    private void testSaveMatchForStructuralMod(String modificationName, List<Unimod> matches, int correctMatchIndex)
+    {
+        var modsTable = new DataRegionTable(STRUCTURAL_MOD, this);
+        int rowIdx = checkModificationRow(modsTable, modificationName, null);
+
+        clickFindMatchInRow(modsTable, rowIdx);
+        assertTextPresent("Unimod Match Options ");
+        clickButton("Unimod Match");
+        List<String> expectedTexts = new ArrayList<>();
+        expectedTexts.add("The modification matches " + matches.size() + " Unimod modification" + (matches.size() > 1 ? "s" : ""));
+        int i = 0;
+        for (Unimod unimod: matches)
+        {
+            expectedTexts.add("Unimod Match " + ++i);
+            expectedTexts.add(unimod.getUnimodId());
+        }
+        var unimodMatchWebPart = portalHelper.getBodyWebPart("Unimod Match");
+        assertTextPresentInThisOrder(new TextSearcher(unimodMatchWebPart.getComponentElement().getText()), expectedTexts.toArray(new String[0]));
+
+        clickButtonByIndex("Save Match", correctMatchIndex);
+
+        modsTable = new DataRegionTable(STRUCTURAL_MOD, this);
+        checkModificationRow(modsTable, modificationName, matches.get(correctMatchIndex));
+    }
+
+
+    private void testCustomizeGrid(String drName, boolean folderHasExperiment)
+    {
+        var modsTable = new DataRegionTable(drName, this);
+        var customizeView = modsTable.openCustomizeGrid();
+        customizeView.addColumn("UnimodMatch");
+        customizeView.applyCustomView();
+        List<String> unimodMatchCellText = modsTable.getColumnDataAsText("UnimodMatch");
+        if (folderHasExperiment)
+        {
+            // Folder has an experiment and the test document has modifications without Unimod Ids.  We expect to see "Find Match" links
+            assertTrue("Expected 'Find Match' text in the UnimodMatch column of the " + drName + " table. Folder has an experiment",
+                    unimodMatchCellText.stream().anyMatch(t -> t.contains("FIND MATCH")));
+        }
+        else
+        {
+            // If the folder does not have an experiment then we should not see the "Find Match" link
+            assertTrue("Unexpected 'Find Match' text in the UnimodMatch column of the " + drName + " table. Folder does not have an experiment",
+                    unimodMatchCellText.stream().noneMatch(t -> t.contains("FIND MATCH")));
+        }
+    }
+
+    private void testCopy(String projectName, String folderName, String experimentTitle, String targetFolder)
+    {
+        var validationPage = submitValidationJob();
+
+        validationPage.verifyModificationStatus(propionylation, true, propionyl.getUnimodId(), propionyl.getName());
+        validationPage.verifyModificationStatus(methylPropionyl, true, methyl.getUnimodId(), methyl.getName(), propionyl.getUnimodId(), propionyl.getName());
+
+        submitWithoutPxIdButton();
+        goToDashboard();
+        assertTextPresent("Copy Pending!");
+
+        // Copy the experiment to the Panorama Public project
+        copyExperimentAndVerify(projectName, folderName, experimentTitle, targetFolder);
+        goToProjectFolder(PANORAMA_PUBLIC, targetFolder);
+        goToExperimentDetailsPage();
+        var modsTable = new DataRegionTable(STRUCTURAL_MOD, this);
+        checkModificationRow(modsTable, propionylation, propionyl);
+        checkModificationRow(modsTable, methylPropionyl, methyl, propionyl);
+    }
+
+    private int checkModificationRow(DataRegionTable modsTable, String modificationName)
+    {
+        return checkModificationRow(modsTable, modificationName, null, null);
+    }
+
+    private int checkModificationRow(DataRegionTable modsTable, String modificationName, Unimod assignedMatch1)
+    {
+        return checkModificationRow(modsTable, modificationName, assignedMatch1, null);
+    }
+
+    private int checkModificationRow(DataRegionTable modsTable, String modificationName, Unimod assignedMatch1, Unimod assignedMatch2)
+    {
+        int rowIdx = modsTable.getRowIndex("ModId/Name", modificationName);
+        assertNotEquals("Expected a row in the " + modsTable.getDataRegionName() + " table for modification name " + modificationName, -1, rowIdx);
+        String expectedText;
+        if (assignedMatch1 != null)
+        {
+            expectedText = String.format("**%s (%s)", assignedMatch1.getUnimodId(), assignedMatch1.getName());
+            if (assignedMatch2 != null)
+            {
+                //Example: **UNIMOD:34 (Methyl)+UNIMOD:58 (Propionyl)
+                expectedText = String.format("%s+%s (%s)", expectedText, assignedMatch2.getUnimodId(), assignedMatch2.getName());
+            }
+        }
+        else
+        {
+            expectedText = "FIND MATCH";
+        }
+        var cellText = modsTable.getDataAsText(rowIdx, "UnimodMatch");
+        assertTrue("UnimodMatch cell text (" + cellText + ") does not contain expected text: " + expectedText, cellText.contains(expectedText));
+        return rowIdx;
+    }
+
+    private void clickFindMatchInRow(DataRegionTable modsTable, int rowIdx)
+    {
+        var row = modsTable.findRow(rowIdx);
+        var findMatchLink = Locator.XPathLocator.tag("a").withText("Find Match").findElement(row);
+        clickAndWait(findMatchLink);
+    }
+
+    private static class Unimod
+    {
+        private final int _unimodId;
+        private final String _name;
+        private final String _formula;
+
+        public Unimod(int unimodId, String name, String formula)
+        {
+            _unimodId = unimodId;
+            _name = name;
+            _formula = formula;
+        }
+
+        public String getUnimodId()
+        {
+            return "UNIMOD:" + _unimodId;
+        }
+
+        public String getName()
+        {
+            return _name;
+        }
+
+        public String getFormula()
+        {
+            return _formula;
+        }
+
+        public String displayName()
+        {
+            return _name + ", " + _formula + ", " + "Unimod:" + _unimodId;
+        }
+    }
+}

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -349,18 +349,6 @@ public class PanoramaPublicTest extends PanoramaPublicBaseTest
         return accessLink;
     }
 
-    private DataValidationPage submitValidationJob()
-    {
-        goToDashboard();
-        var expWebPart = new TargetedMsExperimentWebPart(this);
-        expWebPart.clickSubmit();
-        assertTextPresent("Click the button to start a new data validation job",
-                "Validate Data for ProteomeXchange",
-                "Submit without a ProteomeXchange ID");
-        clickButton("Validate Data for ProteomeXchange");
-        return new DataValidationPage(this);
-    }
-
     private void testSubmitWithSubfolders(TargetedMsExperimentWebPart expWebPart)
     {
         goToDashboard();


### PR DESCRIPTION
#### Rationale
Modifications in a Skyline document don't always have a Unimod Id. This can be due to modification definitions that combine two modifications, or because of reuse of older template documents or saved custom modifications.
For a "complete" ProteomeXchange submission all modifications in the submitted Skyline documents must have a Unimod Id. In the previous work (PR#184) an attempt was made to assign Unimod Ids during the data validation process. However, this can sometimes result in an incorrect assignment, especially for combination modifications.  We want to let the submitter assign Unimod Ids or define combination modifications.
The changes are described in this Google doc:
https://docs.google.com/document/d/1DcwjDDkQdV9ZspbRjFxLuxG0V1JREz4R26cOg2XJDII/edit

#### Related Pull Requests
* https://github.com/LabKey/MacCossLabModules/pull/184

#### Changes
- Added an interface for users to:
  - Find a Unimod match for modifications that did not have a Unimod Id in the Skyline document .
  - Define a combination modification for a structural modification that is a combination of two modifications.
- Removed automatic Unimod matching from the ProteomeXchange DataValidator.
- Updated PX validation details UI to show user-assigned Unimod Ids and combination modifications.
- PX validation status is updated when a user-assigned modification information is added or deleted
- Modification information saved in the source folder is copied to the Panorama Public copy.
- Added Formula and ChemElement classes to build / add / subtract and normalize modification formulas
- Added test coverage