### PR TITLE
Update validation status after saving a combination modification

### DIFF
--- a/panoramapublic/resources/queries/panoramapublic/IsotopeModifications.query.xml
+++ b/panoramapublic/resources/queries/panoramapublic/IsotopeModifications.query.xml
@@ -25,7 +25,6 @@
                         </displayColumnFactory>
                     </column>
                     <column columnName="UnimodMatch">
-                        <columnTitle>UnimodMatch</columnTitle>
                         <textAlign>left</textAlign>
                         <displayColumnFactory>
                             <className>org.labkey.panoramapublic.query.modification.UnimodMatchDisplayColumnFactory$IsotopeUnimodMatch</className>

--- a/panoramapublic/resources/queries/panoramapublic/StructuralModifications.query.xml
+++ b/panoramapublic/resources/queries/panoramapublic/StructuralModifications.query.xml
@@ -31,7 +31,6 @@
                         </displayColumnFactory>
                     </column>
                     <column columnName="UnimodMatch">
-                        <columnTitle>UnimodMatch</columnTitle>
                         <textAlign>left</textAlign>
                         <displayColumnFactory>
                             <className>org.labkey.panoramapublic.query.modification.UnimodMatchDisplayColumnFactory$StructuralUnimodMatch</className>

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -7838,7 +7838,7 @@ public class PanoramaPublicController extends SpringActionController
             modInfo.setUnimodName(mod1.getName());
             modInfo.setUnimodId2(mod2.getId());
             modInfo.setUnimodName2(mod2.getName());
-            ModificationInfoManager.saveStructuralModInfo(modInfo, getUser());
+            ModificationInfoManager.saveStructuralModInfo(modInfo, _expAnnot, getContainer(), getUser());
 
             return true;
         }


### PR DESCRIPTION
- Call the correct method that updates the validation status after Unimod information is saved for a combination modification
- Remove `<columnTitle>` for the "UnimodMatch" column. The title will display correctly as "Unimod Match".
