### PR TITLE
Attempt to fix failing ExperimentModificationGetter tests on TeamCity

### DIFF
--- a/panoramapublic/resources/unimod_NO_NAMESPACE.xml
+++ b/panoramapublic/resources/unimod_NO_NAMESPACE.xml
@@ -2,9 +2,7 @@
 <!--Copyright (C) 2002-2006 Unimod; this information may be copied, distributed and/or-->
 <!--modified under certain conditions, but it comes WITHOUT ANY WARRANTY; see the-->
 <!--accompanying Design Science License for more details-->
-<unimod xmlns:umod="http://www.unimod.org/xmlns/schema/unimod_2"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://www.unimod.org/xmlns/schema/unimod_2 http://www.unimod.org/xmlns/schema/unimod_2/unimod_2.xsd"
+<unimod xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              majorVersion="2"
              minorVersion="0">
    <elements>

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -46,7 +46,6 @@ import org.labkey.panoramapublic.pipeline.PxValidationPipelineProvider;
 import org.labkey.panoramapublic.proteomexchange.ExperimentModificationGetter;
 import org.labkey.panoramapublic.proteomexchange.Formula;
 import org.labkey.panoramapublic.proteomexchange.SkylineVersion;
-import org.labkey.panoramapublic.proteomexchange.UnimodModification;
 import org.labkey.panoramapublic.proteomexchange.UnimodUtil;
 import org.labkey.panoramapublic.proteomexchange.validator.SkylineDocValidator;
 import org.labkey.panoramapublic.proteomexchange.validator.SpecLibValidator;
@@ -330,7 +329,9 @@ public class PanoramaPublicModule extends SpringModule
     public Set<Class> getIntegrationTests()
     {
         return Set.of(
-                PanoramaPublicController.TestCase.class
+                PanoramaPublicController.TestCase.class,
+                ExperimentModificationGetter.TestCase.class,
+                UnimodUtil.TestCase.class
         );
     }
 
@@ -345,10 +346,8 @@ public class PanoramaPublicModule extends SpringModule
         set.add(SpecLibKey.TestCase.class);
         set.add(SkylineDocValidator.TestCase.class);
         set.add(SpecLibValidator.TestCase.class);
-        set.add(ExperimentModificationGetter.TestCase.class);
         set.add(ContainerJoin.TestCase.class);
         set.add(Formula.TestCase.class);
-        set.add(UnimodUtil.TestCase.class);
         return set;
 
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
@@ -22,11 +22,9 @@ import org.junit.Test;
 import org.labkey.api.targetedms.IModification;
 import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.TargetedMSService;
-import org.labkey.api.util.JunitUtil;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -372,11 +370,10 @@ public class ExperimentModificationGetter
         @Test
         public void testStructuralMods() throws IOException
         {
-            File unimodXml = getUnimodFile();
             UnimodModifications uMods = null;
             try
             {
-                uMods = new UnimodParser().parse(unimodXml);
+                uMods = new UnimodParser().parse();
             }
             catch (Exception e)
             {
@@ -755,25 +752,13 @@ public class ExperimentModificationGetter
             }
         }
 
-        private File getUnimodFile() throws IOException
-        {
-            File root = JunitUtil.getSampleData(null, "../../../server");
-            if(root == null)
-            {
-                root = new File(System.getProperty("user.dir"));
-            }
-            // /modules/MacCossLabModules/PanoramaPublic/resources/unimod_NO_NAMESPACE.xml
-            return new File(root, "/modules/MacCossLabModules/PanoramaPublic/resources/unimod_NO_NAMESPACE.xml");
-        }
-
         @Test
         public void testIsotopicMods() throws IOException
         {
-            File unimodXml = getUnimodFile();
             UnimodModifications uMods = null;
             try
             {
-                uMods = new UnimodParser().parse(unimodXml);
+                uMods = new UnimodParser().parse();
             }
             catch (Exception e)
             {

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodParser.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodParser.java
@@ -56,7 +56,7 @@ public class UnimodParser
         return parse(unimodXml);
     }
 
-    public UnimodModifications parse(File unimodXml) throws PxException
+    private UnimodModifications parse(File unimodXml) throws PxException
     {
         if(!unimodXml.exists())
         {


### PR DESCRIPTION
#### Rationale
ExperimentModificationGetter tests that read unimod_NO_NAMESPACE.xml are failing on TeamCity with a "UNIMOD xml file does not exist" error.

#### Changes
- Moved the tests from the Unit test category to the Integration tests category so that the server is running when the tests are executed.
- Remove namespace declaration from unimod_NO_NAMESPACE.xml

