### PR TITLE
Switch to stable-ordered sets for TableSelector calls

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateManager.java
@@ -21,8 +21,9 @@ import org.labkey.api.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -118,7 +119,7 @@ public class ChromLibStateManager
     static List<LibPeptideGroup> getPeptideGroups(ITargetedMSRun run, TargetedMSService svc)
     {
         return new TableSelector(svc.getTableInfoPeptideGroup(),
-                Set.of("id", "runId", "label", "sequenceId", "representativedatastate"),
+                new LinkedHashSet<>(Arrays.asList("id", "runId", "label", "sequenceId", "representativedatastate")),
                 new SimpleFilter(FieldKey.fromParts("runId"), run.getId()), null)
                 .getArrayList(LibPeptideGroup.class);
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/DataValidationManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/DataValidationManager.java
@@ -185,7 +185,7 @@ public class DataValidationManager
     {
         SimpleFilter filter = new SimpleFilter(FieldKey.fromParts("validationId"), validationId);
         return new TableSelector(PanoramaPublicManager.getTableInfoSkylineDocValidation(),
-                Set.of("runId"), filter, null).getArrayList(Long.class);
+                Collections.singleton("runId"), filter, null).getArrayList(Long.class);
     }
 
     public static @NotNull Status getIncompleteSkyDocsInContainer(@NotNull DataValidation validation, @NotNull Container container, User user)
@@ -614,7 +614,7 @@ public class DataValidationManager
     {
         var filter = new SimpleFilter(FieldKey.fromParts("validationId"), validationId);
         var skyDocValidationIds = new TableSelector(PanoramaPublicManager.getTableInfoSkylineDocValidation(),
-                Set.of("Id"), filter, null).getArrayList(Integer.class);
+                Collections.singleton("Id"), filter, null).getArrayList(Integer.class);
 
         var skyDocValidationIdsFilter = new SimpleFilter().addInClause(FieldKey.fromParts("SkylineDocValidationId"), skyDocValidationIds);
         Table.delete(PanoramaPublicManager.getTableInfoSkylineDocSampleFile(), skyDocValidationIdsFilter);
@@ -625,7 +625,7 @@ public class DataValidationManager
     {
         var filter = new SimpleFilter(FieldKey.fromParts("validationId"), validationId);
         var modValidationIds = new TableSelector(PanoramaPublicManager.getTableInfoModificationValidation(),
-                Set.of("Id"), filter, null).getArrayList(Integer.class);
+                Collections.singleton("Id"), filter, null).getArrayList(Integer.class);
 
         var modValidationIdsFilter = new SimpleFilter().addInClause(FieldKey.fromParts("ModificationValidationId"), modValidationIds);
         Table.delete(PanoramaPublicManager.getTableInfoSkylineDocModification(), modValidationIdsFilter);
@@ -636,7 +636,7 @@ public class DataValidationManager
     {
         var filter = new SimpleFilter(FieldKey.fromParts("validationId"), validationId);
         var specLibIds = new TableSelector(PanoramaPublicManager.getTableInfoSpecLibValidation(),
-                Set.of("Id"), filter, null).getArrayList(Integer.class);
+                Collections.singleton("Id"), filter, null).getArrayList(Integer.class);
 
         var specLibIdFilter = new SimpleFilter().addInClause(FieldKey.fromParts("SpecLibValidationId"), specLibIds);
         Table.delete(PanoramaPublicManager.getTableInfoSpecLibSourceFile(), specLibIdFilter);


### PR DESCRIPTION
#### Rationale
Develop switched to require stable ordered sets in uses of TableSelector.

https://teamcity.labkey.org/buildConfiguration/bt310/1831720?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true

```
FATAL PipelineJob              2022-05-24T01:51:55,788            JobThread-2.1 : (from pipeline job log file /mnt/teamcity/work/76bc57f58253098f/build/deploy/files/PanoramaPublicValidationTest Project ☃~!@$&()_+{}-=[],.#äöüÅ/Folder 2/@files/Experiment_Validation_3_2022-05-24_01-51-54.log: Error validating experiment data)
java.lang.IllegalStateException: This TableSelector method must not be called with an unstable ordered column set
	at org.labkey.api.data.TableSelector.ensureStableColumnOrder(TableSelector.java:289) ~[api-22.6-SNAPSHOT.jar:?]
	at org.labkey.api.data.TableSelector.createPrimitiveArrayList(TableSelector.java:206) ~[api-22.6-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector$ArrayListResultSetHandler.handle(BaseSelector.java:141) ~[api-22.6-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector$ArrayListResultSetHandler.handle(BaseSelector.java:123) ~[api-22.6-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutingSelector$ExecutingResultSetFactory.handleResultSet(SqlExecutingSelector.java:455) ~[api-22.6-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector.getArrayList(BaseSelector.java:108) ~[api-22.6-SNAPSHOT.jar:?]
	at org.labkey.api.data.BaseSelector.getArrayList(BaseSelector.java:103) ~[api-22.6-SNAPSHOT.jar:?]
	at org.labkey.panoramapublic.query.DataValidationManager.deleteModificationValidation(DataValidationManager.java:628) ~[panoramapublic-22.6-SNAPSHOT.jar:?]
	at org.labkey.panoramapublic.query.DataValidationManager.clearValidation(DataValidationManager.java:606) ~[panoramapublic-22.6-SNAPSHOT.jar:?]
	at org.labkey.panoramapublic.pipeline.PxDataValidationTask.doValidation(PxDataValidationTask.java:60) ~[panoramapublic-22.6-SNAPSHOT.jar:?]
	at org.labkey.panoramapublic.pipeline.PxDataValidationTask.run(PxDataValidationTask.java:35) ~[panoramapublic-22.6-SNAPSHOT.jar:?]
```

#### Changes
* Use Collections.singleton() and LinkedHashSet