### PR TITLE
Selenium 4.2 compatibility

### DIFF
--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -26,6 +26,7 @@ import org.labkey.test.util.TextSearcher;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -234,7 +235,7 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         clickAndWait(copyLink);
 
         // In the copy form's folder tree view select the Panorama Public project as the destination.
-        Locator.tagWithClass("span", "x4-tree-node-text").withText(PANORAMA_PUBLIC).waitForElement(new WebDriverWait(getDriver(), 5)).click();
+        Locator.tagWithClass("span", "x4-tree-node-text").withText(PANORAMA_PUBLIC).waitForElement(new WebDriverWait(getDriver(), Duration.ofSeconds(5))).click();
         // Enter the name of the destination folder in the Panorama Public project
         setFormElement(Locator.tagWithName("input", "destContainerName"), destinationFolder);
         uncheck("Assign ProteomeXchange ID:");


### PR DESCRIPTION
#### Rationale
Several deprecated `WebDriverWait` constructors were removed in Selenium 4.1.3. Need top stop using them to update Selenium.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1122

#### Changes
* Stop using deprecated `WebDriverWait` constructor
