### PR TITLE
Bug fixes for validation pipeline

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -1954,14 +1954,19 @@ public class PanoramaPublicController extends SpringActionController
 
         protected void checkForValidation(ExperimentAnnotations experimentAnnotations, PublishExperimentForm form)
         {
+            DataValidation validation;
             if (form.getValidationId() != null)
             {
-                var validation = DataValidationManager.getValidation(form.getValidationId(), getContainer());
-                if (validation != null && DataValidationManager.isPipelineJobRunning(validation))
-                {
-                    throw new RedirectException(getPxValidationStatusUrl(_experimentAnnotations.getId(),
-                            validation.getId(), _experimentAnnotations.getContainer()));
-                }
+                validation = DataValidationManager.getValidation(form.getValidationId(), getContainer());
+            }
+            else
+            {
+                validation = DataValidationManager.getLatestValidation(experimentAnnotations.getId(), experimentAnnotations.getContainer());
+            }
+            if (validation != null && DataValidationManager.isPipelineJobRunning(validation))
+            {
+                throw new RedirectException(getPxValidationStatusUrl(_experimentAnnotations.getId(),
+                        validation.getId(), _experimentAnnotations.getContainer()));
             }
         }
 
@@ -3314,21 +3319,10 @@ public class PanoramaPublicController extends SpringActionController
     private static HtmlView getValidationSummary(Status status, ExperimentAnnotations exptAnnotations, boolean displayExperimentTitle, Container container, User user)
     {
         DataValidation validation = status.getValidation();
-        boolean outdated = DataValidationManager.isValidationOutdated(validation, exptAnnotations, user);
-
-        if (outdated || validation.getStatus() == null)
-        {
-            return new HtmlView(DIV(at(style, "background-color: #FFF6D8;margin:2px;font-weight:bold;"),
-                                    SPAN(cl("labkey-error"), outdated ?
-                                            "The latest validation results are outdated. Please click the button below to re-run validation."
-                                            : "Validation is incomplete.")));
-        }
 
         var statusFile = PipelineService.get().getStatusFile(validation.getJobId());
         User createdByUser = UserManager.getUser(validation.getCreatedBy());
-        String pxStatus = validation.getStatus() != null ? validation.getStatus().getLabel() : "Incomplete";
         ActionURL validationDetailsUrl = getPxValidationStatusUrl(exptAnnotations.getId(), validation.getId(), container);
-        var color = PxStatus.Complete == validation.getStatus() ? "darkgreen" : PxStatus.IncompleteMetadata == validation.getStatus() ? "#ef771a" : "#d70101";
         return new HtmlView(TABLE(cl("lk-fields-table"),
                 displayExperimentTitle ? row("Experiment: ", DIV(exptAnnotations.getTitle(), HtmlString.NBSP, new Link.LinkBuilder("View Details")
                         .href(getViewExperimentDetailsURL(exptAnnotations.getId(), container)).build())) : HtmlString.EMPTY_STRING,
@@ -3338,12 +3332,48 @@ public class PanoramaPublicController extends SpringActionController
                                 .href(PageFlowUtil.urlProvider(UserUrls.class).getUserDetailsURL(container, user.getUserId(), null))
                                 .clearClasses().build()) :
                         row("Created By: ", "Unknown User " + validation.getCreatedBy()),
-                row("ProteomeXchange Status:", SPAN(at(style, "color:" + color), B(pxStatus), HtmlString.NBSP, new Link.LinkBuilder("[Details]").href(validationDetailsUrl).build())),
+                row("ProteomeXchange Status:", SPAN(getValidationStatusForSummary(validation, statusFile, exptAnnotations, user),
+                        HtmlString.NBSP, new Link.LinkBuilder("[Details]").href(validationDetailsUrl).build())),
                 row("Validation Log:", statusFile != null ?
                         new Link.LinkBuilder("View log").href(PageFlowUtil.urlProvider(PipelineStatusUrls.class)
                                 .urlDetails(container, validation.getJobId())).build()
                         : SPAN("Log file not found for job Id " + validation.getJobId()))
         ));
+    }
+
+    @NotNull
+    private static DOM.Renderable getValidationStatusForSummary(DataValidation validation, PipelineStatusFile pipelineStatus, ExperimentAnnotations exptAnnotations, User user)
+    {
+        if (validation.isComplete())
+        {
+            if(DataValidationManager.isValidationOutdated(validation, exptAnnotations, user))
+            {
+                return warningStatus("The latest validation results are outdated. Please click the button below to re-run validation.");
+            }
+            else
+            {
+                var color = PxStatus.Complete == validation.getStatus() ? "darkgreen" : PxStatus.IncompleteMetadata == validation.getStatus() ? "#ef771a" : "#d70101";
+                return SPAN(at(style, "color:" + color), B(validation.getStatus().getLabel()));
+            }
+        }
+        else if (pipelineStatus != null)
+        {
+            if (DataValidationManager.isRunningStatus(pipelineStatus))
+            {
+                return SPAN(cl("alert-info").at(style, "padding:8px;font-weight:bold;"), "VALIDATION IS RUNNING");
+            }
+            else if (PipelineJob.TaskStatus.error.matches(pipelineStatus.getStatus()))
+            {
+                return warningStatus("VALIDATION ERROR");
+            }
+        }
+        return warningStatus("VALIDATION IS INCOMPLETE");
+    }
+
+    @NotNull
+    private static DOM.Renderable warningStatus(String statusString)
+    {
+        return SPAN(cl("alert-warning labkey-error").at(style, "padding:8px;font-weight:bold;"), statusString);
     }
 
     @NotNull

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDoc.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDoc.java
@@ -5,10 +5,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
-import org.labkey.api.files.FileContentService;
-import org.labkey.panoramapublic.proteomexchange.validator.DataValidator;
 
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
@@ -39,6 +36,12 @@ public class SkylineDoc extends SkylineDocValidation<SkylineDocSampleFile>
         return _container;
     }
 
+    public String getNameAndUserGivenName()
+    {
+        String userGivenName = getUserGivenName();
+        return getName() + (userGivenName != null && !userGivenName.equals(getName()) ? " (" + userGivenName + ") " : "");
+    }
+
     @NotNull
     public JSONObject toJSON(Container experimentContainer)
     {
@@ -54,7 +57,7 @@ public class SkylineDoc extends SkylineDocValidation<SkylineDocSampleFile>
                 jsonObject.put("rel_container", relPath);
             }
         }
-        jsonObject.put("name", getName());
+        jsonObject.put("name", getNameAndUserGivenName());
         jsonObject.put("valid", foundAllSampleFiles());
         jsonObject.put("sampleFiles", getSampleFilesJSON());
         return jsonObject;

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDocValidation.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDocValidation.java
@@ -10,6 +10,7 @@ public abstract class SkylineDocValidation<S extends SkylineDocSampleFile>
     private int _validationId;
     private long _runId; // Refers to targetedms.runs.id
     private String _name; // Name of the .sky.zip file
+    private String _userGivenName;
 
     public abstract @NotNull List<S> getSampleFiles();
 
@@ -51,6 +52,16 @@ public abstract class SkylineDocValidation<S extends SkylineDocSampleFile>
     public void setName(String name)
     {
         _name = name;
+    }
+
+    public String getUserGivenName()
+    {
+        return _userGivenName;
+    }
+
+    public void setUserGivenName(String userGivenName)
+    {
+        _userGivenName = userGivenName;
     }
 
     public boolean isValid()

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLibValidation.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLibValidation.java
@@ -340,7 +340,7 @@ public abstract class SpecLibValidation <D extends SkylineDocSpecLib>
     private boolean isIncompleteBlib()
     {
         // Return true if no spectrum or peptide id file names were found in the .blib
-        return !isPrositLibrary() && (!hasSpectrumFiles() || !hasIdFiles());
+        return isBibliospecLibrary() && !isPrositLibrary() && (!hasSpectrumFiles() || !hasIdFiles());
     }
 
     private boolean hasSpectrumFiles()

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/Status.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/Status.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.data.Container;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
 
@@ -148,7 +149,7 @@ public class Status extends GenericValidationStatus <SkylineDoc, SpecLib>
         {
             docMod.put("container", doc.getRunContainer().getPath());
         }
-        docMod.put("name", doc.getName());
+        docMod.put("name", doc.getNameAndUserGivenName());
         return docMod;
     }
 
@@ -181,7 +182,7 @@ public class Status extends GenericValidationStatus <SkylineDoc, SpecLib>
         if (validatedCount > 0)
         {
             boolean missingFilesFound = getSkylineDocs().stream().anyMatch(doc -> !doc.isPending() && !doc.isValid());
-            json.put("Validating sample files for Skyline documents: " + validatedCount + "/" + documentCount + " completed."
+            json.put("Sample file validation completed for " + validatedCount + " / " + StringUtilsLabKey.pluralize(documentCount, "document") + "."
             + (missingFilesFound ? " Found missing sample files." : ""));
         }
         if (getModifications().size() > 0)
@@ -193,7 +194,7 @@ public class Status extends GenericValidationStatus <SkylineDoc, SpecLib>
         if (validatedCount > 0)
         {
             boolean missingFilesFound = getSpectralLibraries().stream().anyMatch(lib -> !lib.isPending() && !lib.isValid());
-            json.put("Validating spectral libraries: " + validatedCount + " completed."
+            json.put("Spectral library validation completed for " + StringUtilsLabKey.pluralize(validatedCount, "library", "libraries") + "."
                     + (missingFilesFound ? " Found invalid libraries." : ""));
         }
         return json;

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/Status.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/Status.java
@@ -189,12 +189,11 @@ public class Status extends GenericValidationStatus <SkylineDoc, SpecLib>
             boolean invalidModsFound = getModifications().stream().anyMatch(mod -> !mod.isValid());
             json.put("Modifications validation complete." + (invalidModsFound ? " Found invalid modifications." : ""));
         }
-        int specLibCount = getSpectralLibraries().size();
         validatedCount = getSpectralLibraries().stream().filter(lib -> !lib.isPending()).count();
         if (validatedCount > 0)
         {
             boolean missingFilesFound = getSpectralLibraries().stream().anyMatch(lib -> !lib.isPending() && !lib.isValid());
-            json.put("Validating spectral libraries: " + validatedCount + "/" + specLibCount + " completed."
+            json.put("Validating spectral libraries: " + validatedCount + " completed."
                     + (missingFilesFound ? " Found invalid libraries." : ""));
         }
         return json;

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/DataValidator.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/DataValidator.java
@@ -77,10 +77,12 @@ public class DataValidator
     private void validateLibraries(ValidatorStatus status, User user)
     {
         _listener.validatingSpectralLibraries();
-        // sleep();
+
         FileContentService fcs = FileContentService.get();
         for (SpecLibValidator specLib: status.getSpectralLibraries())
         {
+            _listener.validatingSpectralLibrary(specLib);
+
             try (DbScope.Transaction transaction = PanoramaPublicManager.getSchema().getScope().ensureTransaction())
             {
                 specLib.setValidationId(status.getValidation().getId());
@@ -99,6 +101,8 @@ public class DataValidator
 
                 transaction.commit();
             }
+
+            _listener.spectralLibraryValidated(specLib);
         }
 
         _listener.spectralLibrariesValidated(status);
@@ -261,7 +265,7 @@ public class DataValidator
                 Set<SampleFileKey> sampleFileKeys = sampleFileNameAndKeys.computeIfAbsent(sampleFile.getFileName(), k -> new HashSet<>());
                 sampleFileKeys.add(sampleFile.getKey());
             }
-            _listener.sampleFilesValidated(skyDoc, status);
+            _listener.sampleFilesValidated(skyDoc);
         }
 
         // Sample files that have the same name but were imported from different paths or have different acquired time

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/DataValidatorListener.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/DataValidatorListener.java
@@ -4,10 +4,12 @@ public interface DataValidatorListener
 {
     void started(ValidatorStatus status);
     void validatingDocument(SkylineDocValidator document);
-    void sampleFilesValidated(SkylineDocValidator document, ValidatorStatus status);
+    void sampleFilesValidated(SkylineDocValidator document);
     void validatingModifications();
     void modificationsValidated(ValidatorStatus status);
     void validatingSpectralLibraries();
+    void validatingSpectralLibrary(SpecLibValidator specLib);
+    void spectralLibraryValidated(SpecLibValidator specLib);
     void spectralLibrariesValidated(ValidatorStatus status);
     void error(String message);
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/SpecLibValidator.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/SpecLibValidator.java
@@ -424,26 +424,14 @@ public class SpecLibValidator extends SpecLibValidation<ValidatorSkylineDocSpecL
             source1.addAll(List.of(f1, f2, f3, f6_same_as_f4));
             assertTrue(areSameSources(source1, source2));
 
-            // Test null values for spectrumSourceFile, e.g. when we add a LibSourcefile for MaxQuant files. Here the idFile variable
-            // is set to mqpar.xml or evidence.txt.  The spectrumSourceVariable remains null.
+            // Test null values for spectrumSourceFile, e.g. when we add a LibSourcefile for MaxQuant files. In this case the idFile variable
+            // is set to mqpar.xml or evidence.txt.  The spectrumSourceFile variable remains null.
             LibSourceFile f7_spec_src_null = new LibSourceFile(null, "evidence.txt", null);
             LibSourceFile f8_spec_src_null = new LibSourceFile(null, "msms.txt", null);
             source1.clear();
             source2.clear();
             source1.addAll(List.of(f7_spec_src_null, f8_spec_src_null));
             source2.addAll(List.of(f7_spec_src_null, f8_spec_src_null));
-            assertTrue(areSameSources(source1, source2));
-
-            assertTrue(areSameSources(null, null));
-            assertFalse(areSameSources(source1, null));
-            assertFalse(areSameSources(null, source2));
-
-            LibSourceFile f9 = new LibSourceFile("file1", null, null);
-            LibSourceFile f10 = new LibSourceFile("file1", null, null);
-            source1.clear();
-            source2.clear();
-            source1.addAll(List.of(f9, f10));
-            source2.addAll(List.of(f9, f10));
             assertTrue(areSameSources(source1, source2));
         }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/SpecLibValidator.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/SpecLibValidator.java
@@ -188,15 +188,19 @@ public class SpecLibValidator extends SpecLibValidation<ValidatorSkylineDocSpecL
     {
         if (sources != null)
         {
-            sources.sort(Comparator.comparing(LibSourceFile::getSpectrumSourceFile)
-                    .thenComparing(LibSourceFile::getIdFile));
+            sources.sort(specLibSourceComparator());
         }
         if (docLibSources != null)
         {
-            docLibSources.sort(Comparator.comparing(LibSourceFile::getSpectrumSourceFile)
-                    .thenComparing(LibSourceFile::getIdFile));
+            docLibSources.sort(specLibSourceComparator());
         }
         return Objects.equals(sources, docLibSources);
+    }
+
+    private static Comparator<LibSourceFile> specLibSourceComparator()
+    {
+        return Comparator.comparing(LibSourceFile::getSpectrumSourceFile, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(LibSourceFile::getIdFile, Comparator.nullsLast(Comparator.naturalOrder()));
     }
 
     private void validateLibrarySources(List<LibSourceFile> sources, FileContentService fcs, ExperimentAnnotations expAnnotations)
@@ -418,6 +422,28 @@ public class SpecLibValidator extends SpecLibValidation<ValidatorSkylineDocSpecL
             assertFalse(areSameSources(source1, source2));
             source1.clear();
             source1.addAll(List.of(f1, f2, f3, f6_same_as_f4));
+            assertTrue(areSameSources(source1, source2));
+
+            // Test null values for spectrumSourceFile, e.g. when we add a LibSourcefile for MaxQuant files. Here the idFile variable
+            // is set to mqpar.xml or evidence.txt.  The spectrumSourceVariable remains null.
+            LibSourceFile f7_spec_src_null = new LibSourceFile(null, "evidence.txt", null);
+            LibSourceFile f8_spec_src_null = new LibSourceFile(null, "msms.txt", null);
+            source1.clear();
+            source2.clear();
+            source1.addAll(List.of(f7_spec_src_null, f8_spec_src_null));
+            source2.addAll(List.of(f7_spec_src_null, f8_spec_src_null));
+            assertTrue(areSameSources(source1, source2));
+
+            assertTrue(areSameSources(null, null));
+            assertFalse(areSameSources(source1, null));
+            assertFalse(areSameSources(null, source2));
+
+            LibSourceFile f9 = new LibSourceFile("file1", null, null);
+            LibSourceFile f10 = new LibSourceFile("file1", null, null);
+            source1.clear();
+            source2.clear();
+            source1.addAll(List.of(f9, f10));
+            source2.addAll(List.of(f9, f10));
             assertTrue(areSameSources(source1, source2));
         }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/DataValidationManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/DataValidationManager.java
@@ -248,6 +248,7 @@ public class DataValidationManager
             if (run != null)
             {
                 doc.setRunContainer(run.getContainer());
+                doc.setUserGivenName(run.getDescription());
             }
         }
         return docs;
@@ -255,7 +256,9 @@ public class DataValidationManager
 
     private static List<SkylineDocSampleFile> getSkylineDocSampleFiles(SimpleFilter filter)
     {
-        return new TableSelector(PanoramaPublicManager.getTableInfoSkylineDocSampleFile(), filter, null).getArrayList(SkylineDocSampleFile.class);
+        Sort sort = new Sort(FieldKey.fromParts("SampleFileId")); // Get the validated sample files sorted by the sampleFileId
+        sort.appendSortColumn(FieldKey.fromParts("Id"), Sort.SortDirection.ASC, false); // Sort by id next. .wiff and .wiff.scan will have the same sampleFileId
+        return new TableSelector(PanoramaPublicManager.getTableInfoSkylineDocSampleFile(), filter, sort).getArrayList(SkylineDocSampleFile.class);
     }
 
     private static List<Modification> getModifications(SimpleFilter filter)

--- a/panoramapublic/webapp/PanoramaPublic/js/pxValidation.js
+++ b/panoramapublic/webapp/PanoramaPublic/js/pxValidation.js
@@ -253,8 +253,8 @@ Ext4.define('LABKEY.pxvalidation.SkyDocsGridPanel', {
                                     ambiguousFilesMsg = '<div class="pxv-invalid"><em>Files marked as ambiguous have the same name in one or more documents in the folder but are different ' +
                                             'files based their acquired time on the mass spectrometer. ' +
                                             'Click the View Files link in the table below to view sample files with the same name. ' +
-                                            '<br>' +
-                                            'File names imported into Skyline documents being submitted must have unique names if they are different files.' + '</em></div>';
+                                            '<div style="margin-top:8px;">' +
+                                            'File names imported into Skyline documents being submitted must have unique names if they are different files.' + '</div></em></div>';
                                 }
                             }
                             return ambiguousFilesMsg;
@@ -437,11 +437,11 @@ Ext4.define('LABKEY.pxvalidation.SpecLibsGridPanel', {
                     // Skyline documents with the library
                     '<tpl if="documents.length &gt; 0">',
                     '<div class="pxv-tpl-table-title" style="margin-bottom:5px;">Skyline documents with the library</div>',
-                    '<ul>',
+                    '<table class="pxv-tpl-table">',
                     '<tpl for="documents">',
-                    '<li>{[this.docLink(values)]}</li>',
+                    '<tr> <td>{[this.docLink(values)]}</td> </tr>',
                     '</tpl>',
-                    '</ul>',
+                    '</table>',
                     '</div>',
                     '</tpl>',
                     {


### PR DESCRIPTION
#### Changes
-  If a validation job is running, redirect to the validation running page when the "Submit" button is clicked.
- Display a "validation running" message in the validation summary panel on the experiment details page if the pipeline job is running.
- If the user has entered a different name for their document, display that name in parenthesis next to the Skyline document name on the validation results page.
- Bug fix - EncyclopeDIA libraries show up as "incomplete" even if all the spectrum files used for the library were found
- Bug fix - handle null values for spectrumSourceFile when comparing source files lists for libraries
- Log each library to the job log as it gets validated
- Better validation summary reporting when the validation job is running
- Sample files displayed on the validation results page are sorted by sampleFileId
- Display Skyline documents for a spectral library in a table rather than as a list.
