### PR TITLE
Issue 45851: Include metadata when creating a draft DOI

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -912,7 +912,7 @@ public class PanoramaPublicController extends SpringActionController
         @Override
         public void validateCommand(DataCiteCredentialsForm form, Errors errors)
         {
-            String user = form.getUser();
+            String user = form.getProdUser();
             String password = form.getPassword();
             String doiPrefix = form.getDoiPrefix();
 
@@ -950,7 +950,7 @@ public class PanoramaPublicController extends SpringActionController
         public boolean handlePost(DataCiteCredentialsForm form, BindException errors)
         {
             PropertyManager.PropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(DataCiteService.CREDENTIALS, true);
-            map.put(DataCiteService.USER, form.getUser());
+            map.put(DataCiteService.USER, form.getProdUser());
             map.put(DataCiteService.PASSWORD, form.getPassword());
             map.put(DataCiteService.PREFIX, form.getDoiPrefix());
             map.put(DataCiteService.TEST_USER, form.getTestUser());
@@ -986,7 +986,7 @@ public class PanoramaPublicController extends SpringActionController
                 {
                     // Force the user to re-enter the passwords; do not set them in the form
 
-                    form.setUser(map.get(DataCiteService.USER));
+                    form.setProdUser(map.get(DataCiteService.USER));
                     form.setDoiPrefix(map.get(DataCiteService.PREFIX));
 
                     form.setTestUser(map.get(DataCiteService.TEST_USER));
@@ -1008,7 +1008,7 @@ public class PanoramaPublicController extends SpringActionController
 
     public static class DataCiteCredentialsForm
     {
-        private String _user;
+        private String _prodUser;
         private String _password;
         private String _doiPrefix;
         private String _testUser;
@@ -1035,14 +1035,14 @@ public class PanoramaPublicController extends SpringActionController
             _testPassword = testPassword;
         }
 
-        public String getUser()
+        public String getProdUser()
         {
-            return _user;
+            return _prodUser;
         }
 
-        public void setUser(String user)
+        public void setProdUser(String prodUser)
         {
-            _user = user;
+            _prodUser = prodUser;
         }
 
         public String getPassword()
@@ -4849,7 +4849,7 @@ public class PanoramaPublicController extends SpringActionController
         @Override
         public boolean doPost(DoiForm form, BindException errors) throws DataCiteException
         {
-            _doi = DataCiteService.create(form.isTestMode());
+            _doi = DataCiteService.create(form.isTestMode(), _expAnnot);
             _expAnnot.setDoi(_doi.getDoi());
             ExperimentAnnotationsManager.updateDoi(_expAnnot);
             return true;

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
@@ -16,9 +16,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Class for creating, deleting or publishing Digital Object Identifiers (DOIs) with the DataCite API.
@@ -52,12 +50,12 @@ public class DataCiteService
      * @param test if true, the DataCite test API is used for creating the DOI
      */
     @NotNull
-    public static Doi create(boolean test) throws DataCiteException
+    public static Doi create(boolean test, ExperimentAnnotations expAnnot) throws DataCiteException
     {
         // curl -X POST -H "Content-Type: application/vnd.api+json" --user YOUR_REPOSITORY_ID:YOUR_PASSWORD -d @my_draft_doi.json https://api.test.datacite.org/dois
         DataCiteConfig config = getDataCiteConfig(test);
         METHOD method = METHOD.POST;
-        DataCiteResponse response = doRequest(config, getCreateDoiJson(config), method);
+        DataCiteResponse response = doRequest(config, DoiMetadata.from(expAnnot, config.getPrefix()).getJson(), method);
         if(response.success(method))
         {
             Doi doi = response.getDoi();
@@ -175,22 +173,6 @@ public class DataCiteService
                 conn.disconnect();
             }
         }
-    }
-
-    private static JSONObject getCreateDoiJson(DataCiteConfig config)
-    {
-        /* Example:
-         {
-           "data": {
-           "type": "dois",
-           "attributes": {
-              "prefix": "10.70027"
-             }
-           }
-         }
-         */
-        return new JSONObject().put("data", Objects.requireNonNull(new JSONObject().put("type", "dois"))
-                                                            .put("attributes", new JSONObject(Collections.singletonMap("prefix", config.getPrefix()))));
     }
 
     /**

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -563,7 +563,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
 
     private void assignDoi(ExperimentAnnotations targetExpt, boolean useTestDb) throws DataCiteException
     {
-        Doi doi = DataCiteService.create(useTestDb);
+        Doi doi = DataCiteService.create(useTestDb, targetExpt);
         targetExpt.setDoi(doi.getDoi());
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/view/manageDataCiteCredentials.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/manageDataCiteCredentials.jsp
@@ -15,7 +15,7 @@
     <table>
         <tr>
             <td  class='labkey-form-label'>User:</td>
-            <td><input size="50" type="text" name="user" value="<%=h(form.getUser())%>"></td>
+            <td><input size="50" type="text" name="prodUser" value="<%=h(form.getProdUser())%>"></td>
         </tr>
         <tr>
             <td  class='labkey-form-label'>Password:</td>


### PR DESCRIPTION
#### Rationale
When we create a draft (private) DOI, we do not include any metadata with it. Due to this, the UW libraries staff are unable to figure out which draft DOIs were created for Panorama Public. We should include at least the publisher name in the request to create a draft DOI.

#### Changes
- Include "publisher", "url", and "resourceTypeGeneral" fields in the request to create a draft DOI
- Rename DataCiteCredentialsForm field from 'user' to 'prodUser' since 'user' is disallowed in HasAllowBindParameter.defaultPredicate
