### PR TITLE
Issue 45903: Report Skyline document downloads to Google Analytics 4

### DIFF
--- a/lincs/resources/web/lincs/lincs.js
+++ b/lincs/resources/web/lincs/lincs.js
@@ -12,7 +12,7 @@ function externalHeatmapViewerLink(container, fileName, elementId, assayType)
 
     var morpheusUrl = getMorpheusUrl(fileUrl, assayType);
 
-    var analyticsEvt = " onclick=\"_gaq.push(['_trackEvent', 'Lincs', 'Morpheus', '" + fileName + "']);\" ";
+    var analyticsEvt = " onclick=\"try {_gaq.push(['_trackEvent', 'Lincs', 'Morpheus', '" + fileName + "']);} catch (err) {} try {gtag.event('Lincs', {eventAction: 'Morpheus', fileName: '" + fileName + "'});} catch (err) {}\" ";
 
     Ext4.Ajax.request({
         url: fileUrl,

--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -278,10 +278,10 @@ public class LincsDataTable extends FilteredTable
                 // Tell the browser to wait 400ms before going to the download.  This is to ensure
                 // that the GA tracking request goes through. Some browsers will interrupt the tracking
                 // request if the download opens on the same page.
-                String timeout = addWaitTime ? "setTimeout(function(){location.href=that.href;},400);return false;" : "";
+                String timeout = addWaitTime ? "that=this; setTimeout(function(){location.href=that.href;},400);return false;" : "";
 
                 // Universal Analytics - remove after conversion to GA4 is complete
-                String onClickScript = "try {that=this; _gaq.push(['_trackEvent', 'Lincs', " + PageFlowUtil.qh(eventAction) + ", " + PageFlowUtil.qh(fileName) + "]); } catch (err) {}";
+                String onClickScript = "try {_gaq.push(['_trackEvent', 'Lincs', " + PageFlowUtil.qh(eventAction) + ", " + PageFlowUtil.qh(fileName) + "]); } catch (err) {}";
                 // GA4 variant
                 onClickScript += "try {gtag('event', 'Lincs', {eventAction: " + PageFlowUtil.qh(eventAction) + ", fileName: " + PageFlowUtil.qh(fileName) + "}); } catch(err) {}";
                 onClickScript += timeout;

--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -279,8 +279,13 @@ public class LincsDataTable extends FilteredTable
                 // that the GA tracking request goes through. Some browsers will interrupt the tracking
                 // request if the download opens on the same page.
                 String timeout = addWaitTime ? "setTimeout(function(){location.href=that.href;},400);return false;" : "";
-                String script = "if(_gaq) {that=this; _gaq.push(['_trackEvent', 'Lincs', '" + eventAction + "', '" + fileName + "']); " + timeout + "}";
-                return script;
+
+                // Universal Analytics - remove after conversion to GA4 is complete
+                String onClickScript = "try {that=this; _gaq.push(['_trackEvent', 'Lincs', " + PageFlowUtil.qh(eventAction) + ", " + PageFlowUtil.qh(fileName) + "]); } catch (err) {}";
+                // GA4 variant
+                onClickScript += "try {gtag('event', 'Lincs', {eventAction: " + PageFlowUtil.qh(eventAction) + ", fileName: " + PageFlowUtil.qh(fileName) + "}); } catch(err) {}";
+                onClickScript += timeout;
+                return onClickScript;
             }
             return null;
         }


### PR DESCRIPTION
#### Rationale
We have a couple of places where our generated HTML is submitting special events to Google Analytics. We're switching to GA4 as Google has deprecated the old style.

#### Changes
* Co-submit to Universal Analytics and GA4