### PR TITLE
Show the "Make Public" button in the Panorama Public copy of a dataset

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -5487,10 +5487,7 @@ public class PanoramaPublicController extends SpringActionController
                 }
                 else
                 {
-                    // This is a journal copy, then lookup the source experiment to get the last submitted record.
-                    ExperimentAnnotations sourceExpt = ExperimentAnnotationsManager.get(_experimentAnnotations.getSourceExperimentId());
-                    _lastSubmittedRecord = sourceExpt != null ? SubmissionManager.getNewestJournalSubmission(sourceExpt) : null;
-
+                    _lastSubmittedRecord = SubmissionManager.getSubmissionForJournalCopy(_experimentAnnotations);
                     _journalCopy = _experimentAnnotations;
                 }
             }
@@ -5571,11 +5568,6 @@ public class PanoramaPublicController extends SpringActionController
                     && (!hasVersion() || isCurrentVersion()) // If this is a Panorama Public copy, and there are multiple versions, then this is the current version
                     && _journalCopy != null // There exists a copy of the data on Panorama Public
                     && !(_journalCopy.isPublic() && _journalCopy.hasCompletePublicationInfo());  // The copy is not already public with a PubMed Id
-        }
-
-        private boolean hasPendingSubmission()
-        {
-            return _lastSubmittedRecord != null && _lastSubmittedRecord.hasPendingSubmission();
         }
 
         public String getPublishButtonText()

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -55,6 +55,8 @@ import org.labkey.panoramapublic.query.JournalManager;
 import org.labkey.panoramapublic.query.modification.ModificationsView;
 import org.labkey.panoramapublic.query.speclib.SpecLibView;
 import org.labkey.panoramapublic.security.CopyTargetedMSExperimentRole;
+import org.labkey.panoramapublic.security.PanoramaPublicSubmitterPermission;
+import org.labkey.panoramapublic.security.PanoramaPublicSubmitterRole;
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentWebPart;
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentsWebPart;
 
@@ -104,8 +106,10 @@ public class PanoramaPublicModule extends SpringModule
         service.registerPipelineProvider(new CopyExperimentPipelineProvider(this));
         service.registerPipelineProvider(new PxValidationPipelineProvider(this));
 
-        // Register the CopyExperimentRole
+        // Register Panorama Public specific roles and permissions
         RoleManager.registerRole(new CopyTargetedMSExperimentRole());
+        RoleManager.registerRole(new PanoramaPublicSubmitterRole());
+        RoleManager.registerPermission(new PanoramaPublicSubmitterPermission());
 
         // Add a link in the admin console to manage journals.
         ActionURL url = new ActionURL(PanoramaPublicController.JournalGroupsAdminViewAction.class, ContainerManager.getRoot());

--- a/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterPermission.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterPermission.java
@@ -1,0 +1,11 @@
+package org.labkey.panoramapublic.security;
+
+import org.labkey.api.security.permissions.AbstractPermission;
+
+public class PanoramaPublicSubmitterPermission extends AbstractPermission
+{
+    public PanoramaPublicSubmitterPermission()
+    {
+        super("Make submitted data public", "Allows a user to make their submitted data public, and add publication information.");
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterRole.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterRole.java
@@ -1,9 +1,12 @@
 package org.labkey.panoramapublic.security;
 
+import org.labkey.api.data.Container;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.roles.AbstractRole;
+import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
+import org.labkey.panoramapublic.query.JournalManager;
 
 public class PanoramaPublicSubmitterRole extends AbstractRole
 {
@@ -19,6 +22,14 @@ public class PanoramaPublicSubmitterRole extends AbstractRole
     @Override
     public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
     {
-        return false; // Do not show in the permission UI
+        if (super.isApplicable(policy, resource))
+        {
+            // Show the role on the permissions page of subfolders of the Panorama Public project that have an experiment.
+            Container project = ((Container)resource).getProject();
+            return project != null
+                    && JournalManager.isJournalProject(project)
+                    && ExperimentAnnotationsManager.getExperimentInContainer((Container) resource) != null;
+        }
+        return false;
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterRole.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterRole.java
@@ -22,7 +22,7 @@ public class PanoramaPublicSubmitterRole extends AbstractRole
     @Override
     public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
     {
-        if (super.isApplicable(policy, resource))
+        if (super.isApplicable(policy, resource)) // Superclass verifies that the resource is a Container.
         {
             // Show the role on the permissions page of subfolders of the Panorama Public project that have an experiment.
             Container project = ((Container)resource).getProject();

--- a/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterRole.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/security/PanoramaPublicSubmitterRole.java
@@ -1,0 +1,24 @@
+package org.labkey.panoramapublic.security;
+
+import org.labkey.api.security.SecurableResource;
+import org.labkey.api.security.SecurityPolicy;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.security.roles.AbstractRole;
+
+public class PanoramaPublicSubmitterRole extends AbstractRole
+{
+    public PanoramaPublicSubmitterRole()
+    {
+        super("Panorama Public Submitter", "Can make their data public, and add publication information.",
+                ReadPermission.class,
+                PanoramaPublicSubmitterPermission.class
+        );
+        excludeGuests();
+    }
+
+    @Override
+    public boolean isApplicable(SecurityPolicy policy, SecurableResource resource)
+    {
+        return false; // Do not show in the permission UI
+    }
+}

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -111,9 +111,9 @@
     Journal journal = null;
     boolean journalCopyPending = false;
     ShortURLRecord accessUrlRecord = annot.getShortUrl(); // Will have a value if this is a journal copy of an experiment.
-    JournalSubmission js = annotDetails.getLastPublishedRecord(); // Will be non-null if this experiment is in a user (not journal) project.
+    JournalSubmission js = annotDetails.getLastSubmittedRecord();
     String publishButtonText = "Submit";
-    if (js != null)
+    if (js != null && !annot.isJournalCopy())
     {
         journal = JournalManager.getJournal(js.getJournalId());
         Submission submission = js.getLatestSubmission();

--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
@@ -7,6 +7,7 @@ import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebElement;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TargetedMsExperimentWebPart extends BodyWebPart <TargetedMsExperimentWebPart.ElementCache>
 {
@@ -45,16 +46,17 @@ public class TargetedMsExperimentWebPart extends BodyWebPart <TargetedMsExperime
 
     public void clickResubmit()
     {
-        WebElement resubmitLink = elementCache().resubmitLink; // Locator.linkContainingText("Resubmit");
-        assertNotNull("Expected to see a \"Resubmit\" button", resubmitLink);
-        getWrapper().clickAndWait(resubmitLink);
+        clickLink(elementCache().resubmitLink, "Expected to see a \"Resubmit\" button");
+    }
+
+    public boolean hasResubmitLink()
+    {
+        return elementCache().resubmitLink.isDisplayed();
     }
 
     public void clickMoreDetails()
     {
-        WebElement link = elementCache().moreDetailsLink;
-        assertNotNull("Expected to find a 'More Details' link", link);
-        getWrapper().clickAndWait(link);
+        clickLink(elementCache().moreDetailsLink, "Expected to find a 'More Details' link");
     }
 
     public String getAccessLink()
@@ -70,6 +72,27 @@ public class TargetedMsExperimentWebPart extends BodyWebPart <TargetedMsExperime
         return element != null ? element.getText() : null;
     }
 
+    public boolean hasMakePublicButton()
+    {
+        return elementCache().makePublicButton.isDisplayed();
+    }
+
+    public void clickMakePublic()
+    {
+        clickLink(elementCache().makePublicButton, "Expected to see a \"Make Public\" button");
+    }
+
+    public void clickAddPublication()
+    {
+        clickLink(elementCache().addPublicationButton, "Expected to see a \"Add Publication\" button");
+    }
+
+    private void clickLink(WebElement link, String message)
+    {
+        assertTrue(message , link.isDisplayed());
+        getWrapper().clickAndWait(link);
+    }
+
     @Override
     protected TargetedMsExperimentWebPart.ElementCache newElementCache()
     {
@@ -82,5 +105,7 @@ public class TargetedMsExperimentWebPart extends BodyWebPart <TargetedMsExperime
         private final WebElement moreDetailsLink = Locator.linkContainingText("More Details").findWhenNeeded(this);
         private final WebElement accessUrlTag = Locator.tagWithAttribute("span", "id", "accessUrl").childTag("a").findWhenNeeded(this);
         private final WebElement dataVersionTag = Locator.tagWithAttribute("span", "id", "publishedDataVersion").descendant("span").findOptionalElement(this).orElse(null);
+        private final WebElement makePublicButton = Locator.linkContainingText("Make Public").findWhenNeeded(this);
+        private final WebElement addPublicationButton = Locator.linkContainingText("Add Publication").findWhenNeeded(this);
     }
 }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -211,6 +211,15 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         copyExperimentAndVerify(projectName, folderName, subfolderName, experimentTitle, null, false, true, destinationFolder);
     }
 
+    void makeCopy(String projectName, String folderName, String experimentTitle, String destinationFolder, boolean recopy, boolean deleteOldCopy)
+    {
+        if(isImpersonating())
+        {
+            stopImpersonating();
+        }
+        makeCopy(projectName, folderName, experimentTitle, recopy, deleteOldCopy, destinationFolder);
+    }
+
     void copyExperimentAndVerify(String projectName, String folderName, @Nullable String subfolderName, String experimentTitle,
                                  @Nullable Integer version, boolean recopy, boolean deleteOldCopy, String destinationFolder)
     {

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
@@ -1,0 +1,183 @@
+package org.labkey.test.tests.panoramapublic;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.Locator;
+import org.labkey.test.categories.External;
+import org.labkey.test.categories.MacCossLabModules;
+import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
+import org.labkey.test.util.ApiPermissionsHelper;
+import org.labkey.test.util.Ext4Helper;
+import org.labkey.test.util.PermissionsHelper;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category({External.class, MacCossLabModules.class})
+@BaseWebDriverTest.ClassTimeout(minutes = 5)
+public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
+{
+    private static final String SKY_FILE_1 = "MRMer.zip";
+    private static final String ADMIN_2 = "admin_2@panoramapublic.test";
+
+    @Test
+    public void testExperimentCopy()
+    {
+        // Set up our source folder. We will create an experiment and submit it to our "Panorama Public" project.
+        String projectName = getProjectName();
+        String folderName = "Folder 1";
+        String targetFolder = "Test Copy 1";
+        String experimentTitle = "This is an experiment to test making data public";
+        setupSourceFolder(projectName, folderName, SUBMITTER);
+
+        createFolderAdmin(projectName, folderName, ADMIN_2);
+
+        impersonate(SUBMITTER);
+        updateSubmitterAccountInfo("One");
+
+        // Import a Skyline document to the folder
+        importData(SKY_FILE_1, 1);
+
+        // Add the "Targeted MS Experiment" webpart and submit
+        TargetedMsExperimentWebPart expWebPart = createExperimentCompleteMetadata(experimentTitle);
+        expWebPart.clickSubmit();
+        submitWithoutPXId();
+        goToDashboard();
+        assertTextPresent("Copy Pending!");
+
+        // Copy the experiment to the Panorama Public project
+        makeCopy(projectName, folderName, experimentTitle, targetFolder, false, false);
+
+        // Verify that the submitter can make the data public
+        verifyMakePublic(PANORAMA_PUBLIC, targetFolder, SUBMITTER, true);
+        // Verify that a folder admin in the source folder, who is not the submitter or lab head will not see the
+        // "Make Public" button in the Panorama Public copy.
+        verifyMakePublic(PANORAMA_PUBLIC, targetFolder, ADMIN_2, false);
+
+        // Resubmit the folder.  This is still possible since the Panorama Public copy is not yet associated with a publication.
+        goToProjectFolder(projectName, folderName);
+        impersonate(SUBMITTER);
+        goToDashboard();
+        expWebPart.clickResubmit();
+        resubmitWithoutPxd();
+        goToDashboard();
+        assertTextPresent("Copy Pending!");
+
+        // Re-copy the experiment to the Panorama Public project. Do not delete the previous copy
+        makeCopy(projectName, folderName, experimentTitle, targetFolder, true, false);
+
+        // Verify that the "Make Public button is not visible in the older copy of the data.
+        String v1Folder = targetFolder + " V.1";
+        verifyMakePublic(PANORAMA_PUBLIC, v1Folder, SUBMITTER, true);
+        // Verify that the submitter can make data public, and add publication details
+        verifyMakePublic(PANORAMA_PUBLIC, targetFolder, SUBMITTER, true, true);
+        verifyMakePublic(PANORAMA_PUBLIC, v1Folder, ADMIN_2, false);
+
+        // Data has been made public, and publication link and citation have been added.  User should not able to resubmit
+        goToProjectFolder(projectName, folderName);
+        impersonate(SUBMITTER);
+        goToDashboard();
+        expWebPart = new TargetedMsExperimentWebPart(this);
+        assertFalse("Data has been made public, and a publication link has been added. Resubmit button should not be displayed.", expWebPart.hasResubmitLink());
+    }
+
+    private void resubmitWithoutPxd()
+    {
+        clickAndWait(Locator.linkContainingText("Submit without a ProteomeXchange ID"));
+        waitForText("Resubmit Request to ");
+        click(Ext4Helper.Locators.ext4Button(("Resubmit")));
+        waitForText("Confirm resubmission request to");
+        click(Locator.lkButton("OK")); // Confirm to proceed with the submission.
+        waitForText("Request resubmitted to");
+        click(Locator.linkWithText("Back to Experiment Details")); // Navigate to the experiment details page.
+    }
+
+    private void verifyMakePublic(String projectName, String folderName, String user, boolean isSubmitter)
+    {
+        verifyMakePublic(projectName, folderName, user, isSubmitter, false);
+    }
+
+    private void verifyMakePublic(String projectName, String folderName, String user, boolean isSubmitter, boolean addPublication)
+    {
+        if (isImpersonating())
+        {
+            stopImpersonating(true);
+        }
+        goToProjectFolder(projectName, folderName);
+        impersonate(user);
+        goToDashboard();
+        TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
+
+        String version = expWebPart.getDataVersion();
+        boolean isCurrent = version == null || "Current".equals(version);
+        if (isCurrent && isSubmitter)
+        {
+            assertTrue("Data submitter should see a \"Make Public\" button in the current copy of the data on Panorama Public",
+                    expWebPart.hasMakePublicButton());
+
+            makeDataPublic();
+            if (addPublication)
+            {
+                addPublication();
+            }
+        }
+        else
+        {
+            assertFalse(String.format("Data copy is %scurrent. User is %sthe submitter. \"Make Public\" button should not be displayed.",
+                    isCurrent ? "" : "not ", isSubmitter ? "" : "not "),
+                    expWebPart.hasMakePublicButton());
+        }
+        stopImpersonating();
+    }
+
+    private void makeDataPublic()
+    {
+        makePublic(true);
+    }
+
+    private void addPublication()
+    {
+        makePublic(false);
+    }
+
+    private void makePublic(boolean unpublishedData)
+    {
+        TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
+
+        if (unpublishedData)
+        {
+            expWebPart.clickMakePublic();
+            assertTextPresent("Publication Details");
+            _ext4Helper.checkCheckbox(Ext4Helper.Locators.checkbox(this, "Unpublished:"));
+        }
+        else
+        {
+            expWebPart.clickAddPublication();
+            assertTextPresent("Publication Details");
+            setFormElement(Locator.input("link"), "http://panorama-publication-test.org");
+            setFormElement(Locator.tagWithName("textarea", "citation"), "Paper citation goes here");
+        }
+
+        clickButton("Continue");
+        assertTextPresent("Confirm Publication Details");
+        clickButton("OK");
+        if (unpublishedData)
+        {
+            assertTextPresent("Data on Panorama Public", "was made public.");
+        }
+        else
+        {
+            assertTextPresent("Publication details were updated for data on Panorama Public");
+        }
+        clickButton("Back to Folder");
+    }
+
+    private void createFolderAdmin(String projectName, String folderName, String user)
+    {
+        ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
+        _userHelper.deleteUser(user);
+        _userHelper.createUser(user);
+        permissionsHelper.addMemberToRole(user, "Folder Administrator", PermissionsHelper.MemberType.user, projectName + "/" + folderName);
+    }
+}


### PR DESCRIPTION
#### Rationale
Folders submitted to Panorama Public have a "Make Public" button that is displayed after the folder is copied to Panorama Public. Clicking the button makes the copied folder, in the Panorama Public project, public and allows the user to add publication information.  It would be useful to have this button in the Panorama Public copy, and give the submitter permissions to make their data public from the folder in Panorama Public.

#### Related Pull Requests
https://github.com/LabKey/MacCossLabModules/pull/135

#### Changes
- The PanoramaPublicSubmitterRole is assigned to the submitter and lab head users when a folder is copied to Panorama Public. The "Make Public" button is displayed in the Panorama Public copy if the logged in user has PanoramaPublicSubmitterPermission
- Added test
- Bug fixes
  - Fixed link to user details page in the data validation summary panel 
  - Deleting the previous copy of a folder did not work if the folder had sub-folders
