### PR TITLE
Migrate labkey-client-api to use a modern JSON library: JSON-java

### DIFF
--- a/lincs/build.gradle
+++ b/lincs/build.gradle
@@ -5,11 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation ("com.googlecode.json-simple:json-simple:${jsonSimpleVersion}")
-            {
-                // exclude this because it gets in the way of our own JSON object implementations from server/api
-                exclude group: "org.json", module:"json"
-            }
+    implementation ("com.googlecode.json-simple:json-simple:1.1.1")
 
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:targetedms", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:targetedms", depProjectConfig: 'published', depExtension: 'module')

--- a/panoramapublic/build.gradle
+++ b/panoramapublic/build.gradle
@@ -8,16 +8,28 @@ plugins {
 dependencies {
     implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
     BuildUtils.addExternalDependency(
-            project,
-            new ExternalDependency(
-                    "org.xerial:sqlite-jdbc:3.7.2",
-                    "SQLite JDBC Driver",
-                    "bitbucket.org",
-                    "https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home",
-                    ExternalDependency.APACHE_2_LICENSE_NAME,
-                    ExternalDependency.APACHE_2_LICENSE_URL,
-                    "SQLite JDBC Driver"
-            )
+        project,
+        new ExternalDependency(
+            "org.xerial:sqlite-jdbc:3.7.2",
+            "SQLite JDBC Driver",
+            "bitbucket.org",
+            "https://bitbucket.org/xerial/sqlite-jdbc/wiki/Home",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "SQLite JDBC Driver"
+        )
+    )
+    BuildUtils.addExternalDependency(
+        project,
+        new ExternalDependency(
+            "com.googlecode.json-simple:json-simple:1.1.1",
+            "json-simple",
+            "json-simple",
+            "http://code.google.com/p/json-simple/",
+            ExternalDependency.APACHE_2_LICENSE_NAME,
+            ExternalDependency.APACHE_2_LICENSE_URL,
+            "Simple JSON library (deprecated)"
+        )
     )
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "jspImplementation", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteResponse.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteResponse.java
@@ -36,14 +36,13 @@ class DataCiteResponse
 
     public boolean success(DataCiteService.METHOD method)
     {
-        switch (method)
+        return switch (method)
         {
-            case GET: case PUT: return _responseCode == 200;
-            case POST: return _responseCode == 201;
-            case DELETE: return _responseCode == 204;
-            default:
-                throw new IllegalStateException("Unexpected method: " + method);
-        }
+            case GET, PUT -> _responseCode == 200;
+            case POST -> _responseCode == 201;
+            case DELETE -> _responseCode == 204;
+            default -> throw new IllegalStateException("Unexpected method: " + method);
+        };
     }
 
     public Doi getDoi() throws DataCiteException


### PR DESCRIPTION
#### Rationale
labkey-client-api was using an old, unsupported JSON library