### PR TITLE
TestResults: Improve failure detail page

### DIFF
--- a/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
+++ b/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
@@ -4,8 +4,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
-import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.notification.EmailMessage;
 import org.labkey.api.notification.EmailService;
@@ -16,7 +14,6 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
-import org.labkey.api.util.Path;
 import org.labkey.api.view.ActionURL;
 import org.labkey.testresults.model.BackgroundColor;
 import org.labkey.testresults.model.RunDetail;
@@ -272,10 +269,10 @@ public class SendTestResultsEmail implements org.quartz.Job
                     for (RunDetail run : problemRuns)
                     {
                         message.append("\n<td style='width: 60px; overflow: hidden; padding: 3px; border: 1px solid #ccc;'>");
-                        if (problems.isFail(run, test))
+                        if (problems.hasFailure(run, test))
                             message.append("\n<span style='font-weight: 600; color: red;'>X</span>");
-                        boolean leakMem = problems.isMemoryLeak(run, test);
-                        boolean leakHandle = problems.isHandleLeak(run, test);
+                        boolean leakMem = problems.hasMemoryLeak(run, test);
+                        boolean leakHandle = problems.hasHandleLeak(run, test);
                         String leakType = "";
                         if (leakMem && leakHandle)
                             leakType = "Memory and handle leak";
@@ -285,7 +282,7 @@ public class SendTestResultsEmail implements org.quartz.Job
                             leakType = "Handle leak";
                         if (!leakType.isEmpty())
                             message.append("\n<span style='font-weight: 600; color: orange;' title='" + leakType + "'>X</span>");
-                        if (problems.isHang(run, test))
+                        if (problems.hasHang(run, test))
                             message.append("\n<span style='font-weight: 600; color: navy;'>X</span>");
                         message.append("\n</td>");
                     }

--- a/testresults/src/org/labkey/testresults/model/RunDetail.java
+++ b/testresults/src/org/labkey/testresults/model/RunDetail.java
@@ -371,13 +371,6 @@ public class RunDetail implements Comparable<RunDetail>
         }*/
     }
 
-    public boolean hasHang() {
-        if (passes != null && passes.length > 0 && getPostTime() != null && passes[passes.length-1].getTimestamp() != null) {
-            return getPostTime().getTime() - passes[passes.length-1].getTimestamp().getTime() > HANG_MILLISECONDS;
-        }
-        return false;
-    }
-
     @Override
     public int compareTo(RunDetail other) {
         if (this.posttime != null && other.posttime != null)

--- a/testresults/src/org/labkey/testresults/view/TestsDataBean.java
+++ b/testresults/src/org/labkey/testresults/view/TestsDataBean.java
@@ -58,7 +58,6 @@ public class TestsDataBean
 
     public TestsDataBean(RunDetail[] runs, User[] users) {
         setRuns(runs);
-        statRuns = setStatRuns();
         setUsers(users);
     }
 
@@ -122,27 +121,43 @@ public class TestsDataBean
         return statRuns;
     }
 
-    public Map<String, Map<String, Double>> getLanguageBreakdown(Map<String, List<TestFailDetail>> topFailures){
-                Map<String, Map<String, Double>> m = new TreeMap<>();
-        for (String f: topFailures.keySet()) {
-            double total = 0.0;
-            if (!m.containsKey(f))
-                m.put(f, new TreeMap<>());
-            List<TestFailDetail> l = topFailures.get(f);
-            for (TestFailDetail detail: l) {
-                if (detail != null) {
-                    if (!m.get(f).containsKey(detail.getLanguage()))
-                        m.get(f).put(detail.getLanguage(), 0.0);
-                    m.get(f).put(detail.getLanguage(), m.get(f).get(detail.getLanguage()) + 1);
-                    total += 1;
+    public Map<String, Map<String, Double>> getLanguageBreakdown(Map<String, List<TestFailDetail>> topFailures)
+    {
+        // Test name -> Language -> Percentage
+        Map<String, Map<String, Double>> result = new TreeMap<>();
+        Map<String, Double> allTestsBreakdown = new TreeMap<>();
+
+        for (Map.Entry<String, List<TestFailDetail>> failure : topFailures.entrySet())
+        {
+            String testName = failure.getKey();
+            Map<String, Double> testBreakdown = result.computeIfAbsent(testName, k -> new TreeMap<>());
+
+            for (TestFailDetail detail : failure.getValue())
+            {
+                if (detail == null)
+                {
+                    continue;
                 }
-            }
-            for (String language: m.get(f).keySet()) {
-                m.get(f).put(language, m.get(f).get(language) / total);
+
+                String language = detail.getLanguage();
+                allTestsBreakdown.put(language, allTestsBreakdown.getOrDefault(language, 0d) + 1);
+                testBreakdown.put(language, testBreakdown.getOrDefault(language, 0d) + 1);
             }
         }
 
-        return m;
+        if (!allTestsBreakdown.isEmpty())
+        {
+            result.put("", allTestsBreakdown);
+        }
+
+        // Convert counts to percentages.
+        for (Map<String, Double> testBreakdown : result.values())
+        {
+            final Double testTotal = testBreakdown.values().stream().mapToDouble(d -> d).sum();
+            testBreakdown.replaceAll((lang, count) -> count / testTotal);
+        }
+
+        return result;
     }
 
     public double round(double value, int places) {

--- a/testresults/src/org/labkey/testresults/view/failureDetail.jsp
+++ b/testresults/src/org/labkey/testresults/view/failureDetail.jsp
@@ -359,7 +359,9 @@ $(document).ready(function() {
         }
 
         if (this.value === "failures") {
-            $("#show-stack-traces").trigger("change");
+            $("#show-stack-traces").prop("disabled", false).trigger("change");
+        } else {
+            $("#show-stack-traces").prop("disabled", true);
         }
 
         $("#failurestatstable").trigger("update");


### PR DESCRIPTION
#### Rationale
In the TestResults module, it is difficult to look at leaks and hangs for specific tests over time, so we needed to add a way to do that.

#### Changes
* Improved test failure details page to be able to show leaks and hangs (in addition to failures).
* Now that the test failure details page shows leaks/hangs, the main page links to it on tests that have those problems.