### PR TITLE
Fix column name mismatch

### DIFF
--- a/lincs/resources/schemas/dbscripts/postgresql/lincs-22.000-22.001.sql
+++ b/lincs/resources/schemas/dbscripts/postgresql/lincs-22.000-22.001.sql
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- Column names in the lincsmetadata table on PanoramaWeb and PanoramaWeb-DR do not match the metadata in lincs.xml.
+-- Schema has lincsmetadata.file whereas in the metadata it is lincsmedata.FileName.
+-- It is highly unlikely that the LINCS module in deployed on any other servers. But if it is, rename the column.
+DO $$
+BEGIN
+  IF EXISTS(SELECT *
+    FROM information_schema.columns
+    WHERE table_name='lincsmetadata' and column_name='filename')
+  THEN
+    ALTER TABLE lincs.lincsmetadata RENAME COLUMN filename TO file;
+END IF;
+END $$;

--- a/lincs/resources/schemas/lincs.xml
+++ b/lincs/resources/schemas/lincs.xml
@@ -38,7 +38,7 @@
                     <fkTable>Users</fkTable>
                 </fk>
             </column>
-            <column columnName="FileName"/>
+            <column columnName="File"/>
             <column columnName="Token"/>
             <column columnName="Label"/>
         </columns>

--- a/lincs/src/org/labkey/lincs/LincsModule.java
+++ b/lincs/src/org/labkey/lincs/LincsModule.java
@@ -74,7 +74,7 @@ public class LincsModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 19.10;
+        return 22.001;
     }
 
     @Override


### PR DESCRIPTION
Column names in the lincsmetadata table on PanoramaWeb and PanoramaWeb-DR do not match the metadata in lincs.xml. In the database the table has a 'file' column whereas in the metadata the column name is 'FileName'.  I do not know when or why the column was renamed on PanoramaWeb.  But it showed up as an error when PanoramaWeb-DR was upgraded to 22.11. 

The file/filename column contains the name of the .sky.zip file, and isn't actually used in the code. This table was used by the LINCS project members to enter additional, plate-level metadata for uploaded Skyline documents. 

Changes:
- Change the column name in lincs.xml
- It is unlikely that the LINCS module in deployed on any other servers. But if it is, rename the column.

