### PR TITLE
Panorama Public search updates

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -205,6 +205,23 @@
         document.getElementById(exactPeptideMatchesItemId).checked = false;
     };
 
+    let createFilter = function(itemId, filterText) {
+        let arr = filterText.split(',');
+        let filterArr = [];
+        for (let i = 0; i < arr.length; i++)
+        {
+            filterArr.push(arr[i].trim());
+        }
+        if (filterArr.length > 1)
+        {
+            return LABKEY.Filter.create(itemId, filterArr.join(';'), LABKEY.Filter.Types.CONTAINS_ONE_OF);
+        }
+        else
+        {
+            return LABKEY.Filter.create(itemId, filterText, LABKEY.Filter.Types.CONTAINS);
+        }
+    };
+
     let handleRendering = function (onTabClick) {
 
         let expAnnotationFilters = [];
@@ -228,19 +245,19 @@
                 let instrument = document.getElementById(instrumentItemId).value;
 
                 if (author) {
-                    expAnnotationFilters.push(LABKEY.Filter.create(authorsItemId, author, LABKEY.Filter.Types.CONTAINS));
+                    expAnnotationFilters.push(createFilter(authorsItemId, author));
                     updateUrlFilters(null, authorsItemId, author);
                 }
                 if (title) {
-                    expAnnotationFilters.push(LABKEY.Filter.create(titleItemId, title, LABKEY.Filter.Types.CONTAINS));
+                    expAnnotationFilters.push(createFilter(titleItemId, title));
                     updateUrlFilters(null, titleItemId, title);
                 }
                 if (organism) {
-                    expAnnotationFilters.push(LABKEY.Filter.create(organismItemId, organism, LABKEY.Filter.Types.CONTAINS));
+                    expAnnotationFilters.push(createFilter(organismItemId, organism));
                     updateUrlFilters(null, organismItemId, organism);
                 }
                 if (instrument) {
-                    expAnnotationFilters.push(LABKEY.Filter.create(instrumentItemId, instrument, LABKEY.Filter.Types.CONTAINS));
+                    expAnnotationFilters.push(createFilter(instrumentItemId, instrument));
                     updateUrlFilters(null, instrumentItemId, instrument);
                 }
             }
@@ -283,19 +300,19 @@
         else {
             let context = getFiltersFromUrl();
             if (context[authorsItemId]) {
-                expAnnotationFilters.push(LABKEY.Filter.create(authorsItemId, context[authorsItemId], LABKEY.Filter.Types.CONTAINS));
+                expAnnotationFilters.push(createFilter(authorsItemId, context[authorsItemId]));
                 document.getElementById(authorsItemId).value = context[authorsItemId];
             }
             if (context[titleItemId]) {
-                expAnnotationFilters.push(LABKEY.Filter.create(titleItemId, context[titleItemId], LABKEY.Filter.Types.CONTAINS));
+                expAnnotationFilters.push(createFilter(titleItemId, context[titleItemId]));
                 document.getElementById(titleItemId).value = context[titleItemId];
             }
             if (context[organismItemId]) {
-                expAnnotationFilters.push(LABKEY.Filter.create(organismItemId, context[organismItemId], LABKEY.Filter.Types.CONTAINS));
+                expAnnotationFilters.push(createFilter(organismItemId, context[organismItemId]));
                 document.getElementById(organismItemId).value = context[organismItemId];
             }
             if (context[instrumentItemId]) {
-                expAnnotationFilters.push(LABKEY.Filter.create(instrumentItemId, context[instrumentItemId], LABKEY.Filter.Types.CONTAINS));
+                expAnnotationFilters.push(createFilter(instrumentItemId, context[instrumentItemId]));
                 document.getElementById(instrumentItemId).value = context[instrumentItemId];
             }
             if (context[proteinNameItemId]) {

--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -166,10 +166,10 @@
 
     $ (function() {
         let instrUrl = LABKEY.ActionURL.buildURL('PanoramaPublic', 'completeInstrument.api');
-        initAutoComplete(instrUrl, "input-picker-div-instrument", true);
+        initAutoComplete(instrUrl, "input-picker-div-instrument", true, true /* allow free input */);
 
         let organismUrl = LABKEY.ActionURL.buildURL('PanoramaPublic', 'completeOrganism.api');
-        initAutoComplete(organismUrl, "input-picker-div-organism", false);
+        initAutoComplete(organismUrl, "input-picker-div-organism", false, true /* allow free input */);
 
         document.getElementById(expSearchPanelItemId).addEventListener("click", function() {
             activeTab = expSearchPanelItemId;

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
@@ -92,7 +92,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         checker().verifyEquals("Incorrect result", AUTHOR_FIRST_NAME + " " + AUTHOR_LAST_NAME + ",", table.getDataAsText(0, "Authors"));
 
         table = panoramaPublicSearch
-                .setOrganism("Arab")
+                .setOrganism("Homo")
                 .setAuthor("")
                 .setInstrument("Thermo")
                 .search();

--- a/panoramapublic/webapp/PanoramaPublic/js/ExpAnnotAutoComplete.js
+++ b/panoramapublic/webapp/PanoramaPublic/js/ExpAnnotAutoComplete.js
@@ -141,6 +141,20 @@ function createInputElement(renderId, store, showDefaults, freeInput)
     el.on('itemAdded', function() {
         clearInputText(el);
     });
+
+    if (freeInput === true)
+    {
+        const input = el.tagsinput('input');
+        if (input)
+        {
+            // Trigger the 'Enter' keypress event so that the input is tag-ified. This should only be done
+            // if we are accepting free input.
+            // https://stackoverflow.com/questions/49429848/bootstrap-taginput-is-not-making-its-text-as-tag-after-focus-out-of-taginput-fie
+            input.on('blur', function(){
+                $(this).trigger(jQuery.Event('keypress', {which: 13}));
+            });
+        }
+    }
 }
 
 function clearInputText(tagsInputEl)


### PR DESCRIPTION
#### Changes
- Accept free input search terms in the Instrument and Organism fields (e.g. "Orbitrap" to look for all instrument models with orbitrap in the name). 
- If the input field looses focus, trigger the Enter keypress event so that any entered text is converted into a tag.
- Create a "Contains One Of" filter for comma-separated search terms in "Experiment Search" search fields.
- Remove sorting on the local organism store. 
