### PR TITLE
Miscellaneous Panorama Public fixes

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDoc.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDoc.java
@@ -53,7 +53,7 @@ public class SkylineDoc extends SkylineDocValidation<SkylineDocSampleFile>
             jsonObject.put("container", getRunContainer().getPath());
             if (experimentContainer != null)
             {
-                String relPath = "/" + experimentContainer.getParsedPath().relativize(getRunContainer().getParsedPath()).getName();
+                String relPath = "/" + experimentContainer.getParsedPath().relativize(getRunContainer().getParsedPath()).toString();
                 jsonObject.put("rel_container", relPath);
             }
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -68,9 +68,9 @@
     ActionURL deleteUrl = PanoramaPublicController.getDeleteExperimentURL(getContainer(), annot.getId(), getContainer().getStartURL(getUser()));
 
     ActionURL publishUrl = PanoramaPublicController.getSubmitExperimentURL(annot.getId(), getContainer());
-    Container experimentContainer = annot.getContainer();
-    boolean isAdminUser = experimentContainer.hasPermission(getUser(), AdminPermission.class);
-    final boolean canEdit = (!annot.isJournalCopy() && isAdminUser) || getUser().hasSiteAdminPermission();
+    // If the user is a folder admin they should be able to edit the experiment metadata. Data submitters are never admins
+    // in the Panorama Public copy, so the ability to edit will be limited to site admins and the Panorama Public project admin.
+    final boolean canEdit = getContainer().hasPermission(getUser(), AdminPermission.class);
     // User needs to be the folder admin to publish an experiment.
     final boolean canPublish = annotDetails.isCanPublish();
     final boolean showingFullDetails = annotDetails.isFullDetails();

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxValidationStatus.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxValidationStatus.jsp
@@ -203,12 +203,13 @@
             if (outdated) {
                 let text = 'These validation results are outdated.';
                 if (latest) {
-                    text += ' Please click the button below to re-run validation.'
-
                     allComponents.unshift({
-                        xtype: 'component',
-                        style: {margin: '10px 0 15px; 0'},
-                        html: '<%=button("Rerun Validation").href(PanoramaPublicController.getSubmitPxValidationJobUrl(experimentAnnotations, getContainer())).usePost().build().getHtmlString()%>'
+                        xtype: 'button',
+                        text: 'Rerun Validation',
+                        style: {'margin': '10px'},
+                        handler: function() {
+                            LABKEY.Utils.postToAction(LABKEY.ActionURL.buildURL('panoramapublic', 'submitPxValidationJob', LABKEY.ActionURL.getContainer(), {'id': <%=experimentAnnotationsId%>}));
+                        }
                     });
                 }
                 else {


### PR DESCRIPTION
- "Rerun Validation" button on the data validation page was not working.
- Relative path on the data validation page for Skyline docs in sub-folders displayed only the folder name.
- Allow folder admins to edit experiment metadata in the Panorama Public copy of a dataset. This will allow us to make edits while impersonating the Panorama Public project admin.
