### PR TITLE
Migrate AjaxCompletion and callers

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -23,7 +23,7 @@ import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.json.old.JSONObject;
+import org.json.JSONObject;
 import org.labkey.api.action.ApiResponse;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.ConfirmAction;
@@ -3849,7 +3849,7 @@ public class PanoramaPublicController extends SpringActionController
     public static class CompleteInstrumentAction extends ReadOnlyApiAction<CompletionFieldForm>
     {
         @Override
-        public ApiResponse execute(CompletionFieldForm completionForm, BindException errors) throws Exception
+        public ApiResponse execute(CompletionFieldForm completionForm, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
             List<JSONObject> completions = new ArrayList<>();
@@ -3879,7 +3879,7 @@ public class PanoramaPublicController extends SpringActionController
     public static class CompleteOrganismAction extends ReadOnlyApiAction<CompletionFieldForm>
     {
         @Override
-        public ApiResponse execute(CompletionFieldForm completionForm, BindException errors) throws Exception
+        public ApiResponse execute(CompletionFieldForm completionForm, BindException errors)
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
             List<JSONObject> completions = new ArrayList<>();

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/NcbiUtils.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/NcbiUtils.java
@@ -59,9 +59,9 @@ public class NcbiUtils
 
     private static final Logger LOG = LogHelper.getLogger(NcbiUtils.class, "Messages about using the NCBI utilities");
 
-    public static List<org.json.old.JSONObject> getCompletions(String token) throws PxException
+    public static List<JSONObject> getCompletions(String token) throws PxException
     {
-        List<org.json.old.JSONObject> completions = new ArrayList<>();
+        List<JSONObject> completions = new ArrayList<>();
 
         HttpURLConnection conn = null;
         try


### PR DESCRIPTION
#### Rationale
We want to use the new `org.json.JSON*` library