### PR TITLE
Issue 47195: Enterprise pipeline temp directories are not always cleaned up

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -120,6 +120,16 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
         return PipelineJobService.get().getTaskPipeline(new TaskId(CopyExperimentPipelineJob.class));
     }
 
+    @Override
+    protected void finallyCleanUpLocalDirectory()
+   {
+       // Wait until the final task is complete before deleting anything from the temp export location
+       if (getActiveTaskId() == null)
+       {
+           super.finallyCleanUpLocalDirectory();
+       }
+   }
+
     public static File getLogFileFor(PipeRoot root, ExperimentAnnotations experimentAnnotations) throws IOException
     {
         File rootDir = root.getLogDirectory();

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -120,16 +120,6 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
         return PipelineJobService.get().getTaskPipeline(new TaskId(CopyExperimentPipelineJob.class));
     }
 
-    @Override
-    protected void finallyCleanUpLocalDirectory()
-   {
-       // Wait until the final task is complete before deleting anything from the temp export location
-       if (getActiveTaskId() == null)
-       {
-           super.finallyCleanUpLocalDirectory();
-       }
-   }
-
     public static File getLogFileFor(PipeRoot root, ExperimentAnnotations experimentAnnotations) throws IOException
     {
         File rootDir = root.getLogDirectory();

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -10,11 +10,13 @@ import org.labkey.test.categories.External;
 import org.labkey.test.categories.MacCossLabModules;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentInsertPage;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentWebPart;
+import org.labkey.test.pages.pipeline.PipelineStatusDetailsPage;
 import org.labkey.test.util.APIContainerHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.PermissionsHelper;
+import org.labkey.test.util.PipelineStatusTable;
 import org.labkey.test.util.PortalHelper;
 
 import java.util.List;
@@ -276,6 +278,13 @@ public class PanoramaPublicTest extends PanoramaPublicBaseTest
         assertTextPresent("Read permissions are required in all subfolders to include data from subfolders");
         assertElementPresent(Locator.linkWithText("Back To Folder"));
         assertElementPresent(Locator.linkWithText("Exclude Subfolders"));
+
+        // TODO/REVIEW find a better place to put this check...
+        // Issue #47195 log file not copied
+        goToProjectFolder(PANORAMA_PUBLIC, targetFolder);
+        PipelineStatusTable pipelineStatusTable = goToDataPipeline();
+        PipelineStatusDetailsPage pipelineStatusDetailsPage = pipelineStatusTable.clickStatusLink(0);
+        assertTrue("Copy Job's log file not set to pipeline root", pipelineStatusDetailsPage.getFilePath().contains("@files"));  //Proxy check to see if Job's log file is set to the pipeline root.
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47195

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4110

#### Changes
* Pushed down finallyCleanUp check
* Add check to test to verify Copy Job's log file location
