### PR TITLE
Remove 'Clear Variables' button on Peptide and Protein search results grid

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -349,32 +349,21 @@
             if (activeTab === expSearchPanelItemId) {
                 parseUrlQueryParams()
             }
-            if (activeTab === proteinSearchPanelItemId) {
-
-                if (context[proteinNameItemId] === undefined) {
-                    context[proteinNameItemId] = '';
-                }
-                proteinParameters[proteinNameItemId] = context[proteinNameItemId];
+            if (context[proteinNameItemId] || context[proteinNameItemId] === '') {
+                proteinParameters[proteinNameItemId] =  context[proteinNameItemId];
                 document.getElementById(proteinNameItemId).value = context[proteinNameItemId];
-
-                if (context[exactProteinMatchesItemId]) {
-                    proteinParameters[exactMatch] =  context[exactProteinMatchesItemId];
-                    context[exactProteinMatchesItemId] === "true" ? (document.getElementById(exactProteinMatchesItemId).checked = true) : (document.getElementById(exactProteinMatchesItemId).checked = false);
-                }
             }
-
-            if (activeTab === peptideSearchPanelItemId) {
-
-                if (context[peptideSequenceItemId] === undefined) {
-                    context[peptideSequenceItemId] = '';
-                }
+            if (context[exactProteinMatchesItemId]) {
+                proteinParameters[exactMatch] =  context[exactProteinMatchesItemId];
+                context[exactProteinMatchesItemId] === "true" ? (document.getElementById(exactProteinMatchesItemId).checked = true) : (document.getElementById(exactProteinMatchesItemId).checked = false);
+            }
+            if (context[peptideSequenceItemId] || context[peptideSequenceItemId] === '') {
                 peptideParameters[peptideSequenceItemId] =  context[peptideSequenceItemId];
                 document.getElementById(peptideSequenceItemId).value = context[peptideSequenceItemId];
-
-                if (context[exactPeptideMatchesItemId]) {
-                    peptideParameters[exactMatch] =  context[exactPeptideMatchesItemId];
-                    document.getElementById(exactPeptideMatchesItemId).checked = context[exactPeptideMatchesItemId] === "true";
-                }
+            }
+            if (context[exactPeptideMatchesItemId]) {
+                peptideParameters[exactMatch] =  context[exactPeptideMatchesItemId];
+                document.getElementById(exactPeptideMatchesItemId).checked = context[exactPeptideMatchesItemId] === "true";
             }
         }
 
@@ -418,7 +407,7 @@
                     pageId: 'DefaultDashboard',
                     success: function (wp) {
                         let expWebpart = wp.body.filter(webpart => webpart.name === "Targeted MS Experiment List");
-                        if (expWebpart.length === 1) {
+                        if (expWebpart.length === 1 && proteinParameters[proteinNameItemId] !== undefined) {
                             let wp = new LABKEY.QueryWebPart({
                                 renderTo: 'webpart_'+ expWebpart[0].webPartId,
                                 title: 'Panorama Public Experiments',
@@ -458,7 +447,7 @@
                     pageId: 'DefaultDashboard',
                     success: function (wp) {
                         let expWebpart = wp.body.filter(webpart => webpart.name === "Targeted MS Experiment List");
-                        if (expWebpart.length === 1) {
+                        if (expWebpart.length === 1 && peptideParameters[peptideSequenceItemId] !== undefined) {
                             let wp = new LABKEY.QueryWebPart({
                                 renderTo: 'webpart_'+ expWebpart[0].webPartId,
                                 title: 'Panorama Public Experiments',

--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -431,6 +431,10 @@
                                             document.getElementsByClassName('lk-region-context-action')[i].textContent = txt;
                                         }
                                     }
+                                    let clrVar = document.getElementsByClassName('labkey-button ctx-clear-var');
+                                    if (clrVar && clrVar.length === 1) {
+                                        clrVar[0].style.visibility = 'hidden';
+                                    }
                                 }
                             });
                         }
@@ -466,6 +470,10 @@
                                             }
                                             document.getElementsByClassName('lk-region-context-action')[i].textContent = txt;
                                         }
+                                    }
+                                    let clrVar = document.getElementsByClassName('labkey-button ctx-clear-var');
+                                    if (clrVar && clrVar.length === 1) {
+                                        clrVar[0].style.visibility = 'hidden';
                                     }
                                 }
                             });

--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -349,21 +349,32 @@
             if (activeTab === expSearchPanelItemId) {
                 parseUrlQueryParams()
             }
-            if (context[proteinNameItemId] || context[proteinNameItemId] === '') {
-                proteinParameters[proteinNameItemId] =  context[proteinNameItemId];
+            if (activeTab === proteinSearchPanelItemId) {
+
+                if (context[proteinNameItemId] === undefined) {
+                    context[proteinNameItemId] = '';
+                }
+                proteinParameters[proteinNameItemId] = context[proteinNameItemId];
                 document.getElementById(proteinNameItemId).value = context[proteinNameItemId];
+
+                if (context[exactProteinMatchesItemId]) {
+                    proteinParameters[exactMatch] =  context[exactProteinMatchesItemId];
+                    context[exactProteinMatchesItemId] === "true" ? (document.getElementById(exactProteinMatchesItemId).checked = true) : (document.getElementById(exactProteinMatchesItemId).checked = false);
+                }
             }
-            if (context[exactProteinMatchesItemId]) {
-                proteinParameters[exactMatch] =  context[exactProteinMatchesItemId];
-                context[exactProteinMatchesItemId] === "true" ? (document.getElementById(exactProteinMatchesItemId).checked = true) : (document.getElementById(exactProteinMatchesItemId).checked = false);
-            }
-            if (context[peptideSequenceItemId] || context[peptideSequenceItemId] === '') {
+
+            if (activeTab === peptideSearchPanelItemId) {
+
+                if (context[peptideSequenceItemId] === undefined) {
+                    context[peptideSequenceItemId] = '';
+                }
                 peptideParameters[peptideSequenceItemId] =  context[peptideSequenceItemId];
                 document.getElementById(peptideSequenceItemId).value = context[peptideSequenceItemId];
-            }
-            if (context[exactPeptideMatchesItemId]) {
-                peptideParameters[exactMatch] =  context[exactPeptideMatchesItemId];
-                document.getElementById(exactPeptideMatchesItemId).checked = context[exactPeptideMatchesItemId] === "true";
+
+                if (context[exactPeptideMatchesItemId]) {
+                    peptideParameters[exactMatch] =  context[exactPeptideMatchesItemId];
+                    document.getElementById(exactPeptideMatchesItemId).checked = context[exactPeptideMatchesItemId] === "true";
+                }
             }
         }
 
@@ -432,7 +443,7 @@
                                         }
                                     }
                                     let clrVar = document.getElementsByClassName('labkey-button ctx-clear-var');
-                                    if (clrVar && clrVar.length === 1) {
+                                    if (clrVar && clrVar.length === 1 && clrVar[0].textContent === "Clear Variables") {
                                         clrVar[0].remove();
                                     }
                                 }
@@ -472,7 +483,7 @@
                                         }
                                     }
                                     let clrVar = document.getElementsByClassName('labkey-button ctx-clear-var');
-                                    if (clrVar && clrVar.length === 1) {
+                                    if (clrVar && clrVar.length === 1 && clrVar[0].textContent === "Clear Variables") {
                                         clrVar[0].remove();
                                     }
                                 }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -433,7 +433,7 @@
                                     }
                                     let clrVar = document.getElementsByClassName('labkey-button ctx-clear-var');
                                     if (clrVar && clrVar.length === 1) {
-                                        clrVar[0].style.visibility = 'hidden';
+                                        clrVar[0].remove();
                                     }
                                 }
                             });
@@ -473,7 +473,7 @@
                                     }
                                     let clrVar = document.getElementsByClassName('labkey-button ctx-clear-var');
                                     if (clrVar && clrVar.length === 1) {
-                                        clrVar[0].style.visibility = 'hidden';
+                                        clrVar[0].remove();
                                     }
                                 }
                             });

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
@@ -146,14 +146,16 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         goToProjectHome();
         PanoramaPublicSearchWebPart panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         DataRegionTable table = panoramaPublicSearch.gotoProteinSearch().setProtein("").search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
         checker().verifyEquals("Incorrect protein searched with partial match", 0, table.getDataRowCount());
 
         log("Protein : Partial match and results across folder");
         clickAndWait(Locator.id("clear-all-button-id-protein"));
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("R").search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Protein: R"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
         checker().verifyEquals("Incorrect protein searched with partial match", 2, table.getDataRowCount());
@@ -175,7 +177,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         goToProjectHome();
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("00706094|Alpha").setProteinExactMatch(true).search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Protein: 00706094|Alpha", "Exact Matches Only"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -190,7 +193,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         goToProjectHome();
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("00706094Alpha").setProteinExactMatch(true).search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
 
         checker().verifyEquals("Incorrect protein searched with exact match", 0, table.getDataRowCount());
     }
@@ -202,14 +206,16 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         goToProjectHome();
         PanoramaPublicSearchWebPart panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         DataRegionTable table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("").search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
         checker().verifyEquals("Incorrect peptide searched with partial match", 0, table.getDataRowCount());
 
         log("Peptide : Partial match and results across folder");
         clickAndWait(Locator.id("clear-all-button-id-peptide"));
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("VL").search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Peptide Sequence: VL"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
         checker().verifyEquals("Incorrect peptide searched with partial match", 2, table.getDataRowCount());
@@ -230,7 +236,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         goToProjectHome();
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("GFCGLSQPK").setPeptideExactMatch(true).search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Exact Matches Only", "Peptide Sequence: GFCGLSQPK"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -245,7 +252,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         goToProjectHome();
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("XYZ").setPeptideExactMatch(true).search();
-        waitForElement(Locator.tagWithClass("span", "ctx-clear-var"));
+        waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
+        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
 
         checker().verifyEquals("Incorrect peptide searched with exact match", 0, table.getDataRowCount());
     }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
@@ -147,7 +147,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         PanoramaPublicSearchWebPart panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         DataRegionTable table = panoramaPublicSearch.gotoProteinSearch().setProtein("").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
         checker().verifyEquals("Incorrect protein searched with partial match", 0, table.getDataRowCount());
 
         log("Protein : Partial match and results across folder");
@@ -155,7 +156,9 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("R").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
+
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Protein: R"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
         checker().verifyEquals("Incorrect protein searched with partial match", 2, table.getDataRowCount());
@@ -178,7 +181,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("00706094|Alpha").setProteinExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Protein: 00706094|Alpha", "Exact Matches Only"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -194,7 +198,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("00706094Alpha").setProteinExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
 
         checker().verifyEquals("Incorrect protein searched with exact match", 0, table.getDataRowCount());
     }
@@ -207,7 +212,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         PanoramaPublicSearchWebPart panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         DataRegionTable table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
         checker().verifyEquals("Incorrect peptide searched with partial match", 0, table.getDataRowCount());
 
         log("Peptide : Partial match and results across folder");
@@ -215,7 +221,9 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("VL").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
+
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Peptide Sequence: VL"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
         checker().verifyEquals("Incorrect peptide searched with partial match", 2, table.getDataRowCount());
@@ -237,7 +245,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("GFCGLSQPK").setPeptideExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Exact Matches Only", "Peptide Sequence: GFCGLSQPK"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -253,7 +262,8 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         panoramaPublicSearch = new PanoramaPublicSearchWebPart(getDriver(), "Panorama Public Search");
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("XYZ").setPeptideExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
-        assertElementNotVisible(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
+        assertTextNotPresent("Clear Variables");
 
         checker().verifyEquals("Incorrect peptide searched with exact match", 0, table.getDataRowCount());
     }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
@@ -148,7 +148,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         DataRegionTable table = panoramaPublicSearch.gotoProteinSearch().setProtein("").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
         checker().verifyEquals("Incorrect protein searched with partial match", 0, table.getDataRowCount());
 
         log("Protein : Partial match and results across folder");
@@ -157,7 +157,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("R").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Protein: R"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -182,7 +182,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("00706094|Alpha").setProteinExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Protein: 00706094|Alpha", "Exact Matches Only"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -199,7 +199,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         table = panoramaPublicSearch.gotoProteinSearch().setProtein("00706094Alpha").setProteinExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
 
         checker().verifyEquals("Incorrect protein searched with exact match", 0, table.getDataRowCount());
     }
@@ -213,7 +213,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         DataRegionTable table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
         checker().verifyEquals("Incorrect peptide searched with partial match", 0, table.getDataRowCount());
 
         log("Peptide : Partial match and results across folder");
@@ -222,7 +222,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("VL").search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Peptide Sequence: VL"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -246,7 +246,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("GFCGLSQPK").setPeptideExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
 
         checker().verifyEquals("Invalid filter values displayed", Arrays.asList("Exact Matches Only", "Peptide Sequence: GFCGLSQPK"),
                 getTexts(DataRegionTable.Locators.contextAction().findElements(table)));
@@ -263,7 +263,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         table = panoramaPublicSearch.gotoPeptideSearch().setPeptide("XYZ").setPeptideExactMatch(true).search();
         waitForElement(Locator.tagWithClass("div", "lk-region-context-action"));
         assertElementNotPresent(Locator.tagWithClass("span", "ctx-clear-var"));
-        assertTextNotPresent("Clear Variables");
+        assertElementNotPresent("'Clear Variables' button is present", Locator.tagContainingText("span", "Clear Variables"));
 
         checker().verifyEquals("Incorrect peptide searched with exact match", 0, table.getDataRowCount());
     }


### PR DESCRIPTION
#### Rationale
Clicking on 'Clear Variables' button on Peptide and Protein search results grid is showing underlying parameterized query view.

#### Changes
* Hide 'clear variables' button on Peptide and Protein search results grid