### PR TITLE
Signup module updates

### DIFF
--- a/signup/resources/schemas/signup.xml
+++ b/signup/resources/schemas/signup.xml
@@ -28,14 +28,26 @@
             <column columnName="organization"/>
             <column columnName="key"/>
             <column columnName="container"/>
-            <column columnName="labkeyuserid"/>
+            <column columnName="labkeyuserid">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+            </column>
         </columns>
     </table>
     <table tableDbType="TABLE" tableName="movedusers" >
         <columns>
             <column columnName="_ts"/>
             <column columnName="id"/>
-            <column columnName="labkeyuserid"/>
+            <column columnName="labkeyuserid">
+                <fk>
+                    <fkColumnName>UserId</fkColumnName>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>UsersData</fkTable>
+                </fk>
+            </column>
             <column columnName="oldgroup"/>
             <column columnName="newgroup"/>
         </columns>

--- a/signup/src/org/labkey/signup/SignUpAdmin.jsp
+++ b/signup/src/org/labkey/signup/SignUpAdmin.jsp
@@ -55,7 +55,7 @@
 <!--Creates drop down list of all containers-->
 <h4 style="padding:0px; margin: 0px;">Add new user group rule</h4>
 <form <%=formAction(AddPropertyAction.class, Method.Post)%>><labkey:csrf/>
-    <select id="containerId" name="containerId" onchange="loadGroups(this.value)">
+    <select id="folderId" name="folderId" onchange="loadGroups(this.value)">
         <option disabled selected> -- select an option -- </option>
         <%for(Container c: list) {
         m.put(String.valueOf(c.getRowId()), SecurityManager.getGroups(c.getProject(), false));%> <!--Adds container and associated groups to map-->
@@ -82,7 +82,7 @@
             <tr>
                 <td><%=h(c.getPath())%></td>
                 <td><%=h(property.get(SignUpModule.SIGNUP_GROUP_NAME))%></td>
-                <td><%=link("Remove", urlFor(RemovePropertyAction.class).addParameter("containerId", c.getRowId())).usePost()%></td>
+                <td><%=link("Remove", urlFor(RemovePropertyAction.class).addParameter("folderId", c.getRowId())).usePost()%></td>
             </tr>
         <%}
     }%>

--- a/signup/src/org/labkey/signup/SignUpSchema.java
+++ b/signup/src/org/labkey/signup/SignUpSchema.java
@@ -34,14 +34,11 @@ import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.UserIdQueryForeignKey;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.User;
-import org.labkey.api.security.UserUrls;
 import org.labkey.api.security.permissions.AdminPermission;
-import org.labkey.api.util.PageFlowUtil;
-import org.labkey.api.util.StringExpression;
-import org.labkey.api.util.StringExpressionFactory;
 import org.labkey.api.view.ActionURL;
 
 import java.io.IOException;
@@ -85,12 +82,7 @@ public class SignUpSchema extends UserSchema
                 ContainerForeignKey.initColumn(result.getMutableColumn(FieldKey.fromParts("Container")), this);
 
             var userIdCol = result.getMutableColumn(FieldKey.fromParts("labkeyUserId"));
-            userIdCol.setDisplayColumnFactory(colInfo -> {
-                DataColumn col = new DataColumn(colInfo);
-                StringExpression strExpr = StringExpressionFactory.create(PageFlowUtil.urlProvider(UserUrls.class).getUserDetailsURL(getContainer(), null) + "userId=${labkeyUserId}");
-                col.setURLExpression(strExpr);
-                return col;
-            });
+            userIdCol.setFk(new UserIdQueryForeignKey(this, true));
 
             if(name.equals(TABLE_MOVED_USERS))
             {


### PR DESCRIPTION

#### Changes
- Links in the the labkeyuserid column were broken. Added UserIdQueryForeignKey to the column.
- Changed "containerId" parameter name to "folderId" since containerId is not allowed (HasAllowBindParameter.disallowed). AddPropertyAction and RemovePropertyAction were broken as a result because the value of containerId was not getting passed though. 
- ConfirmAction is now a FormViewAction. User is presented with a form where they provide a valid password. A new labkey user is created and assigned the password.
   - Code was copied from LoginController.attemptSetPassword(). Should it be moved to SecurityManager or AuthenticationManager?
   - Consider moving DbLoginManager from platform.core.main to platform.api.main so that we can get the PasswordRule on the server.
