### PR TITLE
Panorama Public updates and bug fixes

### DIFF
--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -216,7 +216,7 @@
                 <url>/panoramapublic-showExperimentAnnotations.view?id=${ExperimentAnnotationsId}</url>
             </column>
             <column columnName="ShortAccessURL">
-                <columnTitle>Access Link</columnTitle>
+                <columnTitle>Permanent Link</columnTitle>
                 <fk>
                     <fkColumnName>EntityId</fkColumnName>
                     <fkDbSchema>core</fkDbSchema>

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -2406,7 +2406,7 @@ public class PanoramaPublicController extends SpringActionController
             }
             else
             {
-                errors.reject(ERROR_MSG, "Please enter a short access URL.");
+                errors.reject(ERROR_MSG, "Please enter a permanent link.");
             }
 
             if (_experimentAnnotations.isIncludeSubfolders())
@@ -2723,7 +2723,7 @@ public class PanoramaPublicController extends SpringActionController
         private final List<Journal> _journalList;
         private final List<DataLicense> _dataLicenseList;
         private final ExperimentAnnotations _experimentAnnotations;
-        private final boolean _accessUrlEditable; // flag which determines if the "Short Access URL" field in the form is editable
+        private final boolean _accessUrlEditable; // flag which determines if the "Permanent Link" field in the form is editable
 
         public PublishExperimentFormBean(PublishExperimentForm form, List<Journal> journalList, List<DataLicense> dataLicenseList, ExperimentAnnotations experimentAnnotations)
         {
@@ -2732,7 +2732,7 @@ public class PanoramaPublicController extends SpringActionController
             _dataLicenseList = dataLicenseList;
             _experimentAnnotations = experimentAnnotations;
             JournalSubmission js = SubmissionManager.getJournalSubmission(experimentAnnotations.getId(), form.getJournalId(), experimentAnnotations.getContainer());
-            // "Short Access URL" field in the form should not be editable if one or more copies of this experiment already exist in the journal project
+            // "Permanent Link" field in the form should not be editable if one or more copies of this experiment already exist in the journal project
             _accessUrlEditable = js == null ? true : js.getCopiedSubmissions().size() == 0;
         }
 
@@ -8546,7 +8546,7 @@ public class PanoramaPublicController extends SpringActionController
             // We expect this action to be invoked in the Panorama Public copy of an experiment, so there should be a shortUrl.
             if (expAnnot.getShortUrl() == null)
             {
-                errors.reject(ERROR_MSG, "Experiment does not have a short access URL. Catalog entry cannot be added.");
+                errors.reject(ERROR_MSG, "Experiment does not have a permanent link. Catalog entry cannot be added.");
                 return new SimpleErrorView(errors);
             }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -6633,6 +6633,7 @@ public class PanoramaPublicController extends SpringActionController
         private final String _accessUrl;
         private final boolean _isPublic;
         private final boolean _isPeerReviewed;
+        private final DataLicense _license;
 
         public PublicationDetailsBean(PublicationDetailsForm form, ExperimentAnnotations copiedExperiment)
         {
@@ -6640,6 +6641,7 @@ public class PanoramaPublicController extends SpringActionController
             _isPublic = copiedExperiment.isPublic();
             _isPeerReviewed = copiedExperiment.isPeerReviewed();
             _accessUrl = copiedExperiment.getShortUrl().renderShortURL();
+            _license = copiedExperiment.getDataLicense();
         }
 
         public PublicationDetailsForm getForm()
@@ -6660,6 +6662,11 @@ public class PanoramaPublicController extends SpringActionController
         public String getAccessUrl()
         {
             return _accessUrl;
+        }
+
+        public DataLicense getLicense()
+        {
+            return _license;
         }
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -155,7 +155,10 @@ public class PanoramaPublicNotification
         {
             messageBody.append(NL).append("* Citation: ").append(escape(journalCopy.getCitation()));
         }
-
+        if (madePublic)
+        {
+            messageBody.append(NL).append("The data will be available under the ").append(journalCopy.getDataLicense().getDisplayName()).append(" license.");
+        }
         if (journalCopy.hasPxid())
         {
             messageBody.append(NL2);
@@ -205,11 +208,9 @@ public class PanoramaPublicNotification
         messageBody.append(NL2).append("Best regards,");
         messageBody.append(NL).append(getUserName(journalAdmin));
 
-        messageBody.append(NL2).append("---").append(NL2);
-        appendActionSubmitterDetails(user, messageBody);
-
         if (addCopyLink)
         {
+            messageBody.append(NL2).append("---");
             messageBody.append(NL).append("For Panorama administrators:").append(" ").append(link("Copy Link", je.getShortCopyUrl().renderShortURL()));
         }
 
@@ -308,11 +309,6 @@ public class PanoramaPublicNotification
         }
     }
 
-    private static void appendActionSubmitterDetails(User user, StringBuilder text)
-    {
-        text.append("Requested by: ").append(getUserDetails(user));
-    }
-
     public static String getUserName(User user)
     {
         return !StringUtils.isBlank(user.getFullName()) ? user.getFullName() : user.getFriendlyName();
@@ -326,7 +322,7 @@ public class PanoramaPublicNotification
     private static String getContainerLink(Container container)
     {
         ActionURL url = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(container);
-        return link(container.getPath(), url.getEncodedLocalURIString());
+        return link(container.getPath(), url.getURIString());
     }
 
     public static String bolditalics(String text)
@@ -437,7 +433,9 @@ public class PanoramaPublicNotification
         {
             message.append(NL2)
                     .append("When you are ready to make the data public you can click the \"Make Public\" button in your data folder or click this link: ")
-                    .append(bold(link("Make Data Public", PanoramaPublicController.getMakePublicUrl(targetExperiment.getId(), targetExperiment.getContainer()).getEncodedLocalURIString())));
+                    .append(bold(link("Make Data Public",
+                            PanoramaPublicController.getMakePublicUrl(targetExperiment.getId(), targetExperiment.getContainer()).getURIString()
+                            )));
         }
 
         message.append(NL2).append("Best regards,");

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -157,7 +157,7 @@ public class PanoramaPublicNotification
         }
         if (madePublic)
         {
-            messageBody.append(NL).append("The data will be available under the ").append(journalCopy.getDataLicense().getDisplayName()).append(" license.");
+            messageBody.append(NL2).append("The data will be available under the ").append(journalCopy.getDataLicense().getDisplayName()).append(" license.");
         }
         if (journalCopy.hasPxid())
         {
@@ -287,7 +287,7 @@ public class PanoramaPublicNotification
         text.append(NL2);
         text.append(italics("Submission details:"));
         text.append(NL).append("* Source folder: ").append(getContainerLink(exptAnnotations.getContainer()));
-        text.append(NL).append("* Permanent URL: ").append(link(journalExperiment.getShortAccessUrl().renderShortURL()));
+        text.append(NL).append("* Permanent link: ").append(link(journalExperiment.getShortAccessUrl().renderShortURL()));
         text.append(NL).append("* Reviewer account requested: ").append(bold(submission.isKeepPrivate() ? "Yes" : "No"));
         text.append(NL).append("* PX ID requested: ").append(bold(submission.isPxidRequested() ? "Yes" : "No"));
         if (submission.isIncompletePxSubmission())
@@ -386,8 +386,8 @@ public class PanoramaPublicNotification
         {
             message.append("Thank you for your request to submit data to ").append(journalName).append(". ");
         }
-        message.append(String.format("Your data has been %s, and the permanent URL (%s)", recopy ? "recopied" : "copied", accessUrlLink))
-                .append(String.format(" now links to the %scopy on %s.", recopy ? "new " : "", journalName))
+        message.append(String.format("Your data has been %s, and the permanent link (%s)", recopy ? "recopied" : "copied", accessUrlLink))
+                .append(String.format(" now points to the %scopy on %s.", recopy ? "new " : "", journalName))
                 .append(" Please take a moment to verify that the copy is accurate.");
 
         if(reviewer != null)
@@ -423,9 +423,9 @@ public class PanoramaPublicNotification
         }
 
         message.append(NL2)
-                .append("The permanent URL (").append(accessUrlLink).append(")")
+                .append("The permanent link (").append(accessUrlLink).append(")")
                 .append(" is the unique identifier of your data on ").append(journalName).append(".")
-                .append(" You can put the permanent URL")
+                .append(" You can put the permanent link")
                 .append(targetExperiment.hasPxid() ? " and the ProteomeXchange ID " : " ")
                 .append("in your manuscript. ");
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -155,7 +155,7 @@ public class PanoramaPublicNotification
         {
             messageBody.append(NL).append("* Citation: ").append(escape(journalCopy.getCitation()));
         }
-        if (madePublic)
+        if (madePublic && journalCopy.getDataLicense() != null)
         {
             messageBody.append(NL2).append("The data will be available under the ").append(journalCopy.getDataLicense().getDisplayName()).append(" license.");
         }
@@ -433,9 +433,7 @@ public class PanoramaPublicNotification
         {
             message.append(NL2)
                     .append("When you are ready to make the data public you can click the \"Make Public\" button in your data folder or click this link: ")
-                    .append(bold(link("Make Data Public",
-                            PanoramaPublicController.getMakePublicUrl(targetExperiment.getId(), targetExperiment.getContainer()).getURIString()
-                            )));
+                    .append(bold(link("Make Data Public", PanoramaPublicController.getMakePublicUrl(targetExperiment.getId(), targetExperiment.getContainer()).getURIString())));
         }
 
         message.append(NL2).append("Best regards,");

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -19,10 +19,12 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.panoramapublic.datacite.DataCiteException;
+import org.labkey.panoramapublic.datacite.DataCiteService;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
 import org.labkey.panoramapublic.model.JournalExperiment;
 import org.labkey.panoramapublic.model.Submission;
+import org.labkey.panoramapublic.proteomexchange.ProteomeXchangeService;
 import org.labkey.panoramapublic.query.JournalManager;
 import org.labkey.panoramapublic.query.SubmissionManager;
 
@@ -412,7 +414,7 @@ public class PanoramaPublicNotification
         if(targetExperiment.hasPxid())
         {
             message.append(NL2)
-                    .append("The ProteomeXchange ID reserved for your data is:")
+                    .append("The ProteomeXchange ID reserved for the data is:")
                     .append(NL).append(targetExperiment.getPxid())
                     .append(" (").append(link(pxdLink(targetExperiment.getPxid()))).append(")");
 
@@ -420,6 +422,12 @@ public class PanoramaPublicNotification
             {
                 message.append(NL).append("The data will be submitted as \"supported by repository but incomplete data and/or metadata\" when it is made public on ProteomeXchange.");
             }
+        }
+
+        if (targetExperiment.hasDoi())
+        {
+            // Display the complete link: https://support.datacite.org/docs/datacite-doi-display-guidelines
+            message.append(NL2).append("The DOI for the data is: ").append(link(getDoiLink(targetExperiment)));
         }
 
         message.append(NL2)
@@ -452,15 +460,22 @@ public class PanoramaPublicNotification
         message.append(NL).append(String.format("* %s to folder: ", recopy ? "Recopied": "Copied")).append(getContainerLink(targetExperiment.getContainer()));
         if (targetExperiment.hasDoi())
         {
-            message.append(NL).append("* DOI: ").append(link(targetExperiment.getDoi(), "https://doi.org/" + PageFlowUtil.encode(targetExperiment.getDoi())));
+            // Display the complete link: https://support.datacite.org/docs/datacite-doi-display-guidelines
+            message.append(NL).append("* DOI: ").append(link(getDoiLink(targetExperiment)));
         }
 
         return message.toString();
     }
 
+    @NotNull
+    private static String getDoiLink(ExperimentAnnotations targetExperiment)
+    {
+        return DataCiteService.toUrl(targetExperiment.getDoi());
+    }
+
     private static String pxdLink(String pxdAccession)
     {
-        return "http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=" + pxdAccession;
+        return ProteomeXchangeService.toUrl(pxdAccession);
     }
 
     public static class TestCase extends Assert

--- a/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/datacite/DataCiteService.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.old.JSONObject;
 import org.labkey.api.data.PropertyManager;
+import org.labkey.api.util.Link;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 
 import java.io.DataOutputStream;
@@ -233,6 +234,23 @@ public class DataCiteService
             throw new DataCiteException("DataCite " + (test ? "test " : "") + "configuration is missing the following properties: " + StringUtils.join(missing, ","));
         }
         return config;
+    }
+
+    public static String toUrl(@NotNull String doi)
+    {
+        // Regular expression for modern DOIs is /^10.\d{4,9}/[-._;()/:A-Z0-9]+$/i  (https://www.crossref.org/blog/dois-and-matching-regular-expressions/)
+        // DOI example from Panorama Public: 10.6069/9cd7-b485; Prefix: 10.6069, Suffix: 9cd7-b485
+        // The suffix part of the DOI can be anything (https://support.datacite.org/docs/doi-basics#suffix)
+        // BUT, auto-generated DOI suffixes contain only a-z, 0-9 and -.  (https://support.datacite.org/docs/what-characters-should-i-use-in-the-suffix-of-my-doi)
+        // So we don't need to URI-encode the DOI.
+        return "https://doi.org/" + doi;
+    }
+
+    public static Link.LinkBuilder toLink(@NotNull String doi)
+    {
+        // Display the complete link: https://support.datacite.org/docs/datacite-doi-display-guidelines
+        String url = toUrl(doi);
+        return new Link.LinkBuilder(url).href(url).rel("noopener noreferrer");
     }
 
     /**

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -519,7 +519,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
 
         // Assign the PanoramaPublicSubmitterRole so that the submitter or lab head is able to make the copied folder public, and add publication information.
         assignPanoramaPublicSubmitterRole(newPolicy, log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(),
-                targetExperiment.getLabHeadUser(), formSubmitter); // User that submitted the form. Can be different from the user selected as the data submitter
+                formSubmitter); // User that submitted the form. Can be different from the user selected as the data submitter
 
         addToSubmittersGroup(target.getProject(), log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(), formSubmitter);
 
@@ -539,7 +539,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
     private void assignPanoramaPublicSubmitterRole(MutableSecurityPolicy policy, Logger log, User... users)
     {
         Arrays.stream(users).filter(Objects::nonNull).forEach(user -> {
-            log.info("Assigning " + PanoramaPublicSubmitterRole.class.getName() + " to " + user.getEmail());
+            log.info("Assigning " + PanoramaPublicSubmitterRole.class.getSimpleName() + " to " + user.getEmail());
             policy.addRoleAssignment(user, PanoramaPublicSubmitterRole.class, false);
         });
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -460,14 +460,14 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         targetExperiment = ExperimentAnnotationsManager.save(targetExperiment, user);
 
         // Update the target of the short access URL to the journal's copy of the experiment.
-        log.info("Updating access URL to point to the new copy of the data.");
+        log.info("Updating permanent link to point to the new copy of the data.");
         try
         {
             SubmissionManager.updateAccessUrlTarget(js.getShortAccessUrl(), targetExperiment, user);
         }
         catch (ValidationException e)
         {
-            throw new PipelineJobException("Error updating the target of the short access URL '" + js.getShortAccessUrl().getShortURL() + "' to '"
+            throw new PipelineJobException("Error updating the target of the permanent link '" + js.getShortAccessUrl().getShortURL() + "' to '"
                     + targetExperiment.getContainer().getPath() + "'", e);
         }
 
@@ -862,7 +862,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             throw new PipelineJobException("Error saving shortUrl '" + versionedShortUrl + "'", e);
         }
 
-        log.info("Setting the short access URL on the previous copy to " + newShortUrl.getShortURL());
+        log.info("Setting the permanent link on the previous copy to " + newShortUrl.getShortURL());
         previousCopy.setShortUrl(newShortUrl);
         if (previousCopy.getDoi() != null)
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
@@ -25,6 +25,7 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.util.PageFlowUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -172,6 +173,11 @@ public class ProteomeXchangeService
                 || !response.contains("info=There were a total of 0 different CV errors or warnings.")
                 || !response.contains("info=There was a total of 0 non-CV warnings.")
                 || !response.contains("info=There was a total of 0 non-CV errors.");
+    }
+
+    public static String toUrl(@NotNull String pxdAccession)
+    {
+        return "http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=" + PageFlowUtil.encode(pxdAccession);
     }
 }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
@@ -155,7 +155,7 @@ public class PxHtmlWriter extends PxWriter
         {
             list.addItem("PX Version", String.valueOf(version), false);
         }
-        list.addItem("Access URL", getAccessUrlString(accessUrl), accessUrl == null);
+        list.addItem("Permanent Link", getAccessUrlString(accessUrl), accessUrl == null);
         list.end();
         trNoFilter("Dataset identifier", list.getHtml());
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
@@ -22,6 +22,7 @@ import org.labkey.panoramapublic.PanoramaPublicController;
 import org.labkey.panoramapublic.PanoramaPublicManager;
 import org.labkey.panoramapublic.PanoramaPublicSchema;
 import org.labkey.panoramapublic.model.speclib.SpecLibInfo;
+import org.labkey.panoramapublic.proteomexchange.ProteomeXchangeService;
 import org.labkey.panoramapublic.query.ContainerJoin;
 import org.labkey.panoramapublic.query.PanoramaPublicTable;
 import org.labkey.panoramapublic.query.SpecLibInfoManager;
@@ -75,7 +76,7 @@ public class SpecLibInfoTableInfo extends PanoramaPublicTable
                     String accession =  ctx.get(colInfo.getFieldKey(), String.class);
                     if (accession != null && accession.matches(PanoramaPublicController.EditSpecLibInfoAction.PXD))
                     {
-                        return "http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=" + accession;
+                        return ProteomeXchangeService.toUrl(accession);
                     }
                     return super.renderURL(ctx);
                 }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -45,6 +45,8 @@
 <%@ page import="org.labkey.panoramapublic.view.publish.CatalogEntryWebPart" %>
 <%@ page import="org.labkey.panoramapublic.model.CatalogEntry" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
+<%@ page import="org.labkey.panoramapublic.proteomexchange.ProteomeXchangeService" %>
+<%@ page import="org.labkey.panoramapublic.datacite.DataCiteService" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%!
@@ -316,13 +318,13 @@
     <%if(annot.getPxid() != null){%>
     <%if(addSep) {%> <span style="margin-right:10px;margin-left:10px;">|</span> <%}%>
     <span class="link">
-        <strong>ProteomeXchange: </strong><a href="http://proteomecentral.proteomexchange.org/cgi/GetDataset?ID=<%=h(annot.getPxid())%>" target="_blank"><%=h(annot.getPxid())%></a>
+        <strong>ProteomeXchange: </strong><%= link(annot.getPxid()).href(ProteomeXchangeService.toUrl(annot.getPxid())).target("_blank").rel("noopener noreferrer").clearClasses() %>
     </span>
     <% addSep = true; }%>
     <%if(annot.hasDoi()){%>
     <%if(addSep) {%> <span style="margin-right:10px;margin-left:10px;">|</span> <%}%>
     <span class="link">
-        <strong>doi:</strong><a href="https://doi.org/<%=h(annot.getDoi())%>" target="_blank"><%=h(annot.getDoi())%></a>
+        <strong>doi: </strong><%= DataCiteService.toLink(annot.getDoi()).target("_blank").clearClasses() %>
     </span>
     <%}%>
 </div>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -152,7 +152,7 @@
     }
     String labHeadName = annotDetails.getLabHeadName();
     String accessUrl = accessUrlRecord == null ? null : accessUrlRecord.renderShortURL();
-    String linkText = accessUrl == null ? null : (annot.isJournalCopy() ? "Link" : (journalCopyPending ? "Access link" : journal.getName() + " link"));
+    String linkText = accessUrl == null ? null : "Permanent Link";
     DataLicense license = annot.getDataLicense();
 %>
 <style>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
@@ -31,7 +31,12 @@
 
         var items = [];
         if (<%=!bean.isPublic()%>) {
-            items.push({xtype: 'component', style: 'margin: 5px 0 5px 0', html: 'Data at ' + <%=qh(bean.getAccessUrl())%> + ' will be made public.'});
+            let html = 'Data at ' + <%=qh(bean.getAccessUrl())%> + ' will be made public.';
+            if (<%= bean.getLicense() != null %>) {
+                html += ' It will be available under the ' + <%=qh(bean.getLicense().getDisplayName())%> + ' license.';
+            }
+            items.push({xtype: 'component', style: 'margin: 5px 0 5px 0', html: html});
+
         }
         if (<%=form.hasPubmedId()%>) {
             items.push({xtype: 'component', html: '<b>PubMed ID:</b> ' + <%=qh(form.getPubmedId())%>});

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp
@@ -73,8 +73,6 @@
     <% } else { %>
     You are giving access to <%=h(journal)%> to make a copy of your data.
     <% } %>
-    The access link is: <%=h(ShortURLRecord.renderShortURL(form.getShortAccessUrl()))%>.
-    <br>
     <%if(form.isKeepPrivate()) {%>
     Your data on <%=h(journal)%> will be kept private
     <%if(!form.isResubmit()) { %> and a reviewer account will be provided to you.<% } else {%>
@@ -82,6 +80,9 @@
     <%} else { %>
     Your data on <%=h(journal)%> will be made public.
     <% } %>
+    <br>
+    The permanent link for the data is: <%=h(ShortURLRecord.renderShortURL(form.getShortAccessUrl()))%>.
+    <br>
     <%if(form.isGetPxid()) { %>
         <br><br>
         <%if(!form.isResubmit()) { %>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/publishExperimentForm.jsp
@@ -221,7 +221,7 @@
                 <%if (!bean.isAccessUrlEditable()) { %>
                 {
                     xtype: 'displayfield',
-                    fieldLabel: "Short Access URL",
+                    fieldLabel: "Permanent Link",
                     value: <%=q(shortAccessUrl)%>
                 },
                 {
@@ -234,7 +234,7 @@
                     xtype: 'textfield',
                     name: 'shortAccessUrl',
                     value: <%=q(shortAccessUrl)%>,
-                    fieldLabel: 'Access Link',
+                    fieldLabel: 'Permanent Link',
                     beforeBodyEl: '<span class="urlPart">' + urlFixedPre + '</span>',
                     afterBodyEl: urlFixedPost + accessUrlMessage,
                     msgTarget : 'side',

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -39,6 +39,8 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
 {
     static String PANORAMA_PUBLIC = "Panorama Public " + TRICKY_CHARACTERS_FOR_PROJECT_NAMES;
     static final String PANORAMA_PUBLIC_GROUP = "panoramapublictest";
+    static final String PANORAMA_PUBLIC_SUBMITTERS = "Panorama Public Submitters";
+    static final String REVIEWERS = "Reviewers";
 
     static final String ADMIN_USER = "admin@panoramapublic.test";
     static final String SUBMITTER = "submitter@panoramapublic.test";
@@ -94,6 +96,10 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         DataRegionTable expListTable = DataRegionTable.findDataRegionWithinWebpart(this, "Targeted MS Experiment List");
         assertEquals(0, expListTable.getDataRowCount()); // Table should be empty since we have not yet copied any experiments.
         portalHelper.addWebPart("Messages");
+
+        // Add a "Panorama Public Submitter" and a "Reviewers" permissions group
+        _permissionsHelper.createProjectGroup(REVIEWERS, PANORAMA_PUBLIC);
+        _permissionsHelper.createProjectGroup(PANORAMA_PUBLIC_SUBMITTERS, PANORAMA_PUBLIC);
     }
 
     @NotNull


### PR DESCRIPTION
#### Changes
- Add submitters to the "Panorama Public Submitters" group. Add reviewer to "Reviewers" group. These groups exist on panoramaweb.org.
- Replaced "Access URL / Link" with "Permanent Link".
- Added text about license (e.g. CC-BY) in the confirm view when data is made public.
- Fixed container links and "Make Public" link in notifications.  These have to be absolute URLs.
- Added DOI in the message body of the data-copied notification.
- Display DOI as a complete link as recommended by the DataCite DOI Display Guidelines (https://support.datacite.org/docs/datacite-doi-display-guidelines).


