### PR TITLE
Fix Skyline external tool download link

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
@@ -684,7 +684,7 @@ a { text-decoration: none; }
             });
         }
 
-        window.location.href = "<%=h(urlFor(SkylineToolsStoreController.DownloadToolAction.class))%>id=" + toolId;
+        window.location.href = <%= q(urlFor(SkylineToolsStoreController.DownloadToolAction.class).addParameter("id", tool.getRowId())) %>;
     }
 
     function popToolOwners() {


### PR DESCRIPTION
#### Rationale
Download link on the Skyline external tool details page is broken.

