### PR TITLE
Add filesystem audit events for Panorama Public symlinks

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileImporter.java
@@ -85,8 +85,15 @@ public class PanoramaPublicFileImporter implements FolderImporter
                 Files.createDirectories(targetFiles.toPath());
             }
 
-            log.info("Moving files and creating sym links in folder " + ctx.getContainer().getPath());
-            PanoramaPublicSymlinkManager.get().moveAndSymLinkDirectory(expJob, sourceFiles, targetFiles, false, log);
+            if (expJob.isMoveAndSymlink())
+            {
+                log.info("Moving files to folder " + expJob.getContainer().getPath() + " and creating symlinks");
+            }
+            else
+            {
+                log.info("Copying files to folder " + expJob.getContainer().getPath());
+            }
+            PanoramaPublicSymlinkManager.get().moveAndSymLinkDirectory(expJob, sourceFiles, targetFiles, log);
 
             alignDataFileUrls(expJob.getUser(), ctx.getContainer(), log);
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileListener.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileListener.java
@@ -33,7 +33,7 @@ public class PanoramaPublicFileListener implements FileListener
     public int fileMoved(@NotNull File src, @NotNull File dest, @Nullable User user, @Nullable Container container)
     {
         // Update any symlinks targeting the file
-        PanoramaPublicSymlinkManager.get().fireSymlinkUpdate(src.toPath(), dest.toPath(), container);
+        PanoramaPublicSymlinkManager.get().fireSymlinkUpdate(src.toPath(), dest.toPath(), container, user);
 
         ExpData data = ExperimentService.get().getExpDataByURL(src, null);
         if (null != data)

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicListener.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicListener.java
@@ -75,13 +75,13 @@ public class PanoramaPublicListener implements ExperimentListener, ContainerMana
     {
         JournalManager.deleteProjectJournal(c, user);
 
-        PanoramaPublicSymlinkManager.get().beforeContainerDeleted(c);
+        PanoramaPublicSymlinkManager.get().beforeContainerDeleted(c, user);
     }
 
     @Override
     public void containerMoved(Container c, Container oldParent, User user)
     {
-        PanoramaPublicSymlinkManager.get().fireSymlinkUpdateContainer(oldParent, c);
+        PanoramaPublicSymlinkManager.get().fireSymlinkUpdateContainer(oldParent, c, user);
     }
 
     @Override
@@ -109,7 +109,7 @@ public class PanoramaPublicListener implements ExperimentListener, ContainerMana
                     // ce.getOldValue() and ce.getNewValue() are just the names of the old and new containers. We need the full path.
                     Path oldPath = parentPath.resolve((String) ce.getOldValue());
                     Path newPath = parentPath.resolve((String) ce.getNewValue());
-                    PanoramaPublicSymlinkManager.get().fireSymlinkUpdateContainer(oldPath.toString(), newPath.toString(), c);
+                    PanoramaPublicSymlinkManager.get().fireSymlinkUpdateContainer(oldPath.toString(), newPath.toString(), c, ce.user);
                 }
             }
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkHandler.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkHandler.java
@@ -1,9 +1,12 @@
 package org.labkey.panoramapublic;
 
+import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
+
 import java.io.IOException;
 import java.nio.file.Path;
 
 public interface PanoramaPublicSymlinkHandler
 {
-    void handleSymlink(Path link, Path target) throws IOException;
+    void handleSymlink(Path link, Path target, Container container, User user) throws IOException;
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -405,26 +404,7 @@ public class PanoramaPublicSymlinkManager
     // this will return the container for "/Panorama Public/TestProject V.1"
     private Container getContainerForFilePath(Path path)
     {
-        org.labkey.api.util.Path lkPath = org.labkey.api.util.Path.rootPath;
-
-        Path defaultRootPath = FileContentService.get().getSiteDefaultRoot().toPath();
-        if (path.startsWith(defaultRootPath))
-        {
-            Path rel = defaultRootPath.relativize(path);
-
-            Iterator<Path> iter = rel.iterator();
-            while (iter.hasNext())
-            {
-                Path next = iter.next();
-                if (FileContentService.FILES_LINK.equals(next.getFileName().toString()))
-                {
-                    break;
-                }
-                lkPath = lkPath.resolve(org.labkey.api.util.Path.parse(next.toString()));
-            }
-        }
-
-        return org.labkey.api.util.Path.rootPath.equals(lkPath) ? null : ContainerManager.getForPath(lkPath);
+        return FileContentService.get().getContainersForFilePath(path).stream().findFirst().orElse(null);
     }
 
     private void verifyFileTreeSymlinks(File source, Map<String, String> linkInvalidTarget, Map<String, String> linkWithSymlinkTarget) throws IOException

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
@@ -4,11 +4,14 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.audit.AuditLogService;
+import org.labkey.api.audit.provider.FileSystemAuditProvider;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ContainerService;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.security.User;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
@@ -23,6 +26,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,13 +58,13 @@ public class PanoramaPublicSymlinkManager
     }
 
 
-    private void handleContainerSymlinks(File source, PanoramaPublicSymlinkHandler handler)
+    private void handleContainerSymlinks(File source, PanoramaPublicSymlinkHandler handler, Container container, User user)
     {
         for (File file : Objects.requireNonNull(source.listFiles()))
         {
             if (file.isDirectory())
             {
-                handleContainerSymlinks(file, handler);
+                handleContainerSymlinks(file, handler, container, user);
             }
             else
             {
@@ -69,7 +73,7 @@ public class PanoramaPublicSymlinkManager
                 {
                     try {
                         Path target = Files.readSymbolicLink(filePath);
-                        handler.handleSymlink(filePath, target);
+                        handler.handleSymlink(filePath, target, container, user);
                     } catch (IOException x) {
                         _log.error("Unable to resolve symlink target for symlink at " + filePath);
                     }
@@ -78,7 +82,7 @@ public class PanoramaPublicSymlinkManager
         }
     }
 
-    public void handleContainerSymlinks(Container container, PanoramaPublicSymlinkHandler handler)
+    public void handleContainerSymlinks(Container container, User user, PanoramaPublicSymlinkHandler handler)
     {
         FileContentService fcs = FileContentService.get();
         if (null != fcs)
@@ -86,19 +90,19 @@ public class PanoramaPublicSymlinkManager
             File root = fcs.getFileRoot(container);
             if (null != root)
             {
-                handleContainerSymlinks(root, handler);
+                handleContainerSymlinks(root, handler, container, user);
             }
         }
     }
 
-    private void handleAllSymlinks(Set<Container> containers, PanoramaPublicSymlinkHandler handler)
+    private void handleAllSymlinks(Set<Container> containers, User user, PanoramaPublicSymlinkHandler handler)
     {
         for (Container container : containers)
         {
             Set<Container> tree = ContainerManager.getAllChildren(container);
             for (Container node : tree)
             {
-                handleContainerSymlinks(node, handler);
+                handleContainerSymlinks(node, user, handler);
             }
         }
     }
@@ -112,7 +116,7 @@ public class PanoramaPublicSymlinkManager
         return File.separator + path + File.separator;
     }
 
-    public void beforeContainerDeleted(Container container)
+    public void beforeContainerDeleted(Container container, User user)
     {
         if (PanoramaPublicManager.canBeSymlinkTarget(container)) // Fire the event only if the container being deleted is in the Panorama Public project.
         {
@@ -121,7 +125,7 @@ public class PanoramaPublicSymlinkManager
             ExperimentAnnotations expAnnot = ExperimentAnnotationsManager.getExperimentIncludesContainer(container);
             if (null != expAnnot)
             {
-                fireSymlinkCopiedExperimentDelete(expAnnot, container);
+                fireSymlinkCopiedExperimentDelete(expAnnot, container, user);
             }
         }
     }
@@ -132,7 +136,7 @@ public class PanoramaPublicSymlinkManager
      * @param container container being deleted. This could be a subfolder of the experiment container if the experiment
      *                  is configured to include subfolders.
      */
-    private void fireSymlinkCopiedExperimentDelete(ExperimentAnnotations expAnnot, Container container)
+    private void fireSymlinkCopiedExperimentDelete(ExperimentAnnotations expAnnot, Container container, User user)
     {
         if (expAnnot.getDataVersion() != null && !ExperimentAnnotationsManager.isCurrentVersion(expAnnot))
         {
@@ -153,17 +157,19 @@ public class PanoramaPublicSymlinkManager
             if (nextHighestVersion != null)
             {
                 Container versionContainer = nextHighestVersion.getContainer();
-                handleContainerSymlinks(versionContainer, (link, target) -> {
+                handleContainerSymlinks(versionContainer, user, (link, target, c, u) -> {
                     if (!target.startsWith(deletedContainerPath))
                     {
                         return;
                     }
                     Files.move(target, link, REPLACE_EXISTING); // Move the files back to the next highest version of the experiment
+                    addReplaceSymlinkWithTargetAuditEvent(link, target, c, u);
+
                     _log.info("File moved from " + target + " to " + link);
 
                     // This should update the symlinks in the submitted folder as well as
                     // symlinks in versions older than this one to point to the files in the next highest version.
-                    fireSymlinkUpdate(target, link, container);
+                    fireSymlinkUpdate(target, link, container, user);
                 });
             }
         }
@@ -180,12 +186,14 @@ public class PanoramaPublicSymlinkManager
         }
         if (null != sourceContainer)
         {
-            handleContainerSymlinks(sourceContainer, (link, target) -> {
+            handleContainerSymlinks(sourceContainer, user, (link, target, c, u) -> {
                 if (!target.startsWith(deletedContainerPath))
                 {
                     return;
                 }
                 Files.move(target, link, REPLACE_EXISTING);
+                addReplaceSymlinkWithTargetAuditEvent(link, target, c, u);
+
                 _log.info("File moved from " + target + " to " + link);
 
                 // Symlinks in the source container point to -> current version container on Panorama Public
@@ -197,7 +205,7 @@ public class PanoramaPublicSymlinkManager
         }
     }
 
-    public void fireSymlinkUpdateContainer(Container oldContainer, Container newContainer)
+    public void fireSymlinkUpdateContainer(Container oldContainer, Container newContainer, User user)
     {
         // Update symlinks to new target
         FileContentService fcs = FileContentService.get();
@@ -205,12 +213,12 @@ public class PanoramaPublicSymlinkManager
         {
             if (fcs.getFileRoot(oldContainer) != null && fcs.getFileRoot(newContainer) != null)
             {
-                fireSymlinkUpdateContainer(fcs.getFileRoot(oldContainer).getPath(), fcs.getFileRoot(newContainer).getPath(), oldContainer);
+                fireSymlinkUpdateContainer(fcs.getFileRoot(oldContainer).getPath(), fcs.getFileRoot(newContainer).getPath(), oldContainer, user);
             }
         }
     }
 
-    public void fireSymlinkUpdateContainer(String oldContainer, String newContainer, Container container)
+    public void fireSymlinkUpdateContainer(String oldContainer, String newContainer, Container container, User user)
     {
         if (PanoramaPublicManager.canBeSymlinkTarget(container))
         {
@@ -218,7 +226,7 @@ public class PanoramaPublicSymlinkManager
             String newContainerPath = normalizeContainerPath(newContainer);
 
             Set<Container> containers = getSymlinkContainers(container);
-            handleAllSymlinks(containers, (link, target) -> {
+            handleAllSymlinks(containers, user, (link, target, c, u) -> {
                 if (String.valueOf(target).contains(oldContainerPath))
                 {
                     Path newTarget = Path.of(target.toString().replace(oldContainerPath, newContainerPath));
@@ -226,6 +234,7 @@ public class PanoramaPublicSymlinkManager
                     {
                         Files.delete(link);
                         Files.createSymbolicLink(link, newTarget);
+                        addLinkUpdatedAuditEvent(link, newTarget, c, u);
                     }
                     catch (IOException e)
                     {
@@ -236,13 +245,41 @@ public class PanoramaPublicSymlinkManager
         }
     }
 
-    public void fireSymlinkUpdate(Path oldTarget, Path newTarget, Container container)
+    private void addLinkUpdatedAuditEvent(Path link, Path newTarget, Container linkContainer, User user)
+    {
+        addFileAuditEvent(link, linkContainer, user, "Updated symlink target to " + newTarget);
+    }
+
+    private void addReplaceSymlinkWithTargetAuditEvent(Path link, Path target, Container linkContainer, User user)
+    {
+        addFileAuditEvent(link, linkContainer, user, "Replaced symlink with target file " + target);
+    }
+
+    private void addReplaceTargetWithSymlinkAuditEvent(Path link, Path target, Container container, User user)
+    {
+        addFileAuditEvent(link, container, user, "Replaced target file with symlink to " + target);
+    }
+
+    private void addFileAuditEvent(Path link, Container container, User user, String comment)
+    {
+        FileSystemAuditProvider.FileSystemAuditEvent event =  new FileSystemAuditProvider.FileSystemAuditEvent(
+                container != null ? container.getId() : null, comment);
+        event.setFile(link.toString());
+        AuditLogService.get().addEvent(user, event);
+    }
+
+    public void fireSymlinkUpdate(Path oldTarget, Path newTarget, Container container, User user)
+    {
+        fireSymlinkUpdate(oldTarget, newTarget, container, user, null);
+    }
+
+    public void fireSymlinkUpdate(Path oldTarget, Path newTarget, Container container, User user, @Nullable Logger log)
     {
         if (PanoramaPublicManager.canBeSymlinkTarget(container)) // Only files in the Panorama Public project can be symlink targets.
         {
             Set<Container> containers = getSymlinkContainers(container);
 
-            handleAllSymlinks(containers, (link, target) -> {
+            handleAllSymlinks(containers, user, (link, target, c, u) -> {
                 if (!target.equals(oldTarget))
                     return;
 
@@ -250,6 +287,11 @@ public class PanoramaPublicSymlinkManager
                 {
                     Files.delete(link);
                     Files.createSymbolicLink(link, newTarget);
+                    addLinkUpdatedAuditEvent(link, newTarget, c, u);
+                    if (log != null)
+                    {
+                        log.info("Target for symlink " + link + " updated to " + newTarget);
+                    }
                 }
                 catch (IOException e)
                 {
@@ -259,7 +301,7 @@ public class PanoramaPublicSymlinkManager
         }
     }
 
-    public void moveAndSymLinkDirectory(CopyExperimentPipelineJob job, File source, File target, boolean createSourceSymLinks, @Nullable Logger log) throws IOException
+    public void moveAndSymLinkDirectory(CopyExperimentPipelineJob job, File source, File target, @Nullable Logger log) throws IOException
     {
         if (null == log)
         {
@@ -283,7 +325,7 @@ public class PanoramaPublicSymlinkManager
                         log.debug("Directory created: " + targetPath);
                     }
 
-                    moveAndSymLinkDirectory(job, file, targetPath.toFile(), createSourceSymLinks, log);
+                    moveAndSymLinkDirectory(job, file, targetPath.toFile(), log);
                 }
                 else
                 {
@@ -313,6 +355,7 @@ public class PanoramaPublicSymlinkManager
 
                         // Copy the file to panorama public
                         Files.copy(filePath, targetPath, REPLACE_EXISTING);
+                        log.debug("Copied file " + filePath + " to " + targetPath);
                         fcs.fireFileCreateEvent(targetPath, job.getUser(), job.getContainer());
 
                         continue;
@@ -321,33 +364,67 @@ public class PanoramaPublicSymlinkManager
                     // Symbolic link should move the target file over. This would be for a re-copy to public.
                     if (Files.isSymbolicLink(filePath))
                     {
+                        log.debug("Source file is a symlink: " + filePath);
+
                         Path oldPath = Files.readSymbolicLink(filePath);
                         Files.move(oldPath, targetPath, REPLACE_EXISTING);
+                        log.debug("Moved symlink target  " + oldPath + " to " + targetPath);
                         fcs.fireFileCreateEvent(targetPath, job.getUser(), job.getContainer());
 
-                        fireSymlinkUpdate(oldPath, targetPath, job.getContainer()); // job container is the target container on Panorama Public
-                        log.debug("File moved from " + oldPath + " to " + targetPath);
+                        fireSymlinkUpdate(oldPath, targetPath, job.getContainer(), // job container is the target container on Panorama Public
+                                job.getUser(), log);
 
                         Path symlink = Files.createSymbolicLink(oldPath, targetPath);
-                        log.debug("Symlink created: " + symlink);
+                        Container oldTargetContainer = getContainerForFilePath(oldPath);
+                        if (oldTargetContainer != null)
+                        {
+                            // The target of the symlink has been moved from a previous version on Panorama Public to the
+                            // new version on Panorama Public, and a symink has been created in the previous version container.
+                            // Add an audit event in the previous version container.
+                            addReplaceTargetWithSymlinkAuditEvent(symlink, targetPath, oldTargetContainer, job.getUser());
+                        }
+                        log.debug("Replaced old target with symlink: " + symlink);
                     }
                     else
                     {
                         Files.move(filePath, targetPath, REPLACE_EXISTING);
+                        log.debug("Moved file " + filePath + " to " + targetPath);
                         fcs.fireFileCreateEvent(targetPath, job.getUser(), job.getContainer());
 
                         Files.createSymbolicLink(filePath, targetPath);
+                        log.debug("Created symlink " + filePath + " targeting " + targetPath);
                         // We don't need to update any symlinks here since the source container should not have any symlink targets.
-                    }
-
-                    if (createSourceSymLinks)
-                    {
-                        Path symlink = Files.createSymbolicLink(filePath, targetPath);
-                        log.debug("Symlink created: " + symlink);
                     }
                 }
             }
         }
+    }
+
+    // Get the container for the given file path.
+    // Example: if the file path is C:\Users\vsharma\WORK\LabKey\build\deploy\files\Panorama Public\TestProject V.1\@files\Study9S_Site52_v1.sky.zip
+    // this will return the container for "/Panorama Public/TestProject V.1"
+    private Container getContainerForFilePath(Path path)
+    {
+        org.labkey.api.util.Path lkPath = org.labkey.api.util.Path.rootPath;
+
+        Path defaultRootPath = FileContentService.get().getSiteDefaultRoot().toPath();
+        if (path.startsWith(defaultRootPath))
+        {
+            Path rel = defaultRootPath.relativize(path);
+
+            Iterator<Path> iter = rel.iterator();
+            while (iter.hasNext())
+            {
+                Path next = iter.next();
+                if (FileContentService.FILES_LINK.equals(next.getFileName().toString()))
+                {
+                    break;
+                }
+                lkPath = lkPath.resolve(org.labkey.api.util.Path.parse(next.toString()));
+            }
+        }
+
+        return org.labkey.api.util.Path.rootPath.equals(lkPath) ? null : ContainerManager.getForPath(lkPath);
     }
 
     private void verifyFileTreeSymlinks(File source, Map<String, String> linkInvalidTarget, Map<String, String> linkWithSymlinkTarget) throws IOException

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -206,7 +206,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             if (null != targetRoot)
             {
                 Path targetFileRoot = Path.of(targetRoot.toString(), File.separator);
-                PanoramaPublicSymlinkManager.get().handleContainerSymlinks(source, (sourceFile, targetFile) -> {
+                PanoramaPublicSymlinkManager.get().handleContainerSymlinks(source, null, (sourceFile, targetFile, c, u) -> {
 
                     // valid path
                     if (!FileUtil.isFileAndExists(targetFile))
@@ -241,7 +241,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         }
     }
 
-    private void cleanupExportDirectory(User user, File directory) throws IOException
+    private void cleanupExportDirectory(User user, File directory)
     {
         List<? extends ExpData> datas = ExperimentService.get().getExpDatasUnderPath(directory.toPath(), null, true);
         for (ExpData data : datas)
@@ -255,12 +255,12 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
     private void alignSymlinks(PipelineJob job, CopyExperimentJobSupport jobSupport)
     {
         if (jobSupport.getPreviousVersionName() != null)
+    {
+        FileContentService fcs = FileContentService.get();
+        if (fcs != null)
         {
-            FileContentService fcs = FileContentService.get();
-            if (fcs != null)
-            {
                 PanoramaPublicSymlinkManager.get().fireSymlinkUpdateContainer(jobSupport.getPreviousVersionName(),
-                        fcs.getFileRoot(job.getContainer()).getPath(), job.getContainer());
+                        fcs.getFileRoot(job.getContainer()).getPath(), job.getContainer(), job.getUser());
             }
         }
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/copyExperimentForm.jsp
@@ -164,7 +164,7 @@
                     autoScroll: true,
                     title : '',
                     border: true,
-                    width: 450,
+                    width: 650,
                     height:150,
                     listeners: {
                         select: function(node, record, index, eOpts){
@@ -220,7 +220,7 @@
                     fieldLabel: "Reviewer Email Prefix",
                     value: <%=q(form.getReviewerEmailPrefix())%>,
                     name: 'reviewerEmailPrefix',
-                    width: 450,
+                    width: 650,
                     afterBodyEl: '<span style="font-size: 0.9em;">A new LabKey user account email_prefix(unique numeric suffix)@proteinms.net will be created. </span>',
                     msgTarget : 'under'
                 },


### PR DESCRIPTION
#### Rationale
We would like to add filesystem audit events: 
- When a file is moved from the submitted folder to the copy on Panorama Public, and a symlink is created in the submitted folder.
- When the target of a symlink in the submitted folder is moved from the previous copy on Panorama Public to a new copy
  - add an event in the previous copy that the file has been moved, and replaced with a symlink
  - add an event in the submitted folder that the symlink target has been updated. 
- When a Panorama Public copy is deleted, add events in the submitted folder for each symlink that is replaced with the target file from the Panorama Public copy.

#### Related Pull Requests
* https://github.com/LabKey/MacCossLabModules/pull/344

#### Changes
- added filesystem events
- added additional logging
- removed unused boolean parameter createSourceSymLinks in PanoramaPublicSymlinkManager.moveAndSymLinkDirectory()
