### PR TITLE
Fix broken PanoramaPublic tests

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
@@ -35,7 +35,6 @@ import org.labkey.api.util.FileType;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.FileSystemFile;
-import org.labkey.panoramapublic.PanoramaPublicManager;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 
 import java.io.File;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
@@ -101,6 +101,7 @@ public class ExperimentExportTask extends PipelineJob.Task<ExperimentExportTask.
                 FolderArchiveDataTypes.WIKIS_AND_THEIR_ATTACHMENTS, // "Wikis and their attachments",
                 FolderArchiveDataTypes.CONTAINER_SPECIFIC_MODULE_PROPERTIES, // "Container specific module properties",
                 FolderArchiveDataTypes.EXPERIMENTS_AND_RUNS, // "Experiments and runs"
+                FolderArchiveDataTypes.EXPERIMENT_RUNS,
                 FolderArchiveDataTypes.LIST_DESIGN, // "Lists"
                 FolderArchiveDataTypes.LIST_DATA,
                 TargetedMSService.QC_FOLDER_DATA_TYPE


### PR DESCRIPTION
#### Rationale
PanoramaPublic tests are failing due to the changes in this PR: https://github.com/LabKey/platform/pull/4468
[Issue 47818: Ability to export folder archives with only metadata](https://www.labkey.org/issues/home/Developer/issues/details.view?issueId=47818)
We need to include runs in the ExperimentExportTask of the PanoramaPublic pipeline.

Related PR is in a fork of LabKey/platform - https://github.com/LabKey/platform/pull/4564

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4562


