### PR TITLE
Panorama Public updates and fixes

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -5673,7 +5673,7 @@ public class PanoramaPublicController extends SpringActionController
                     else
                     {
                         // This is not the current version; Display a link to the current version
-                        ExperimentAnnotations maxExpt = publishedVersions.stream().filter(e -> e.getDataVersion().equals(maxVersion)).findFirst().orElse(null);
+                        ExperimentAnnotations maxExpt = publishedVersions.stream().filter(e -> e.getDataVersion() != null && e.getDataVersion().equals(maxVersion)).findFirst().orElse(null);
                         _versionsUrl = maxExpt != null ? PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(maxExpt.getContainer()) : null;
                         _isCurrentVersion = false;
                     }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileImporter.java
@@ -87,13 +87,13 @@ public class PanoramaPublicFileImporter implements FolderImporter
 
             if (expJob.isMoveAndSymlink())
             {
-                log.info("Moving files to folder " + expJob.getContainer().getPath() + " and creating symlinks");
+                log.info("Moving files to folder " + ctx.getContainer().getPath() + " and creating symlinks");
             }
             else
             {
-                log.info("Copying files to folder " + expJob.getContainer().getPath());
+                log.info("Copying files to folder " + ctx.getContainer().getPath());
             }
-            PanoramaPublicSymlinkManager.get().moveAndSymLinkDirectory(expJob, sourceFiles, targetFiles, log);
+            PanoramaPublicSymlinkManager.get().moveAndSymLinkDirectory(expJob, ctx.getContainer(), sourceFiles, targetFiles, log);
 
             alignDataFileUrls(expJob.getUser(), ctx.getContainer(), log);
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -169,9 +169,10 @@ public class PanoramaPublicNotification
             messageBody.append(String.format(" on ProteomeXchange by a %s administrator.", journal.getName()));
         }
 
-        messageBody.append(NL2).append("If you haven't already done so, you can add a brief description and an image to showcase your work in the slideshow on PanoramaWeb.")
-                               .append(" To provide an entry for the slideshow you can click the \"Panorama Public Catalog Entry\" icon located under the experiment title")
-                               .append(" in the \"Targeted MS Experiment\" panel in your folder.")
+        messageBody.append(NL2).append("If you haven't already done so, you can provide a brief description and an image to showcase your work in the slideshow on PanoramaWeb.")
+                               .append(" To add an entry for the slideshow, click the \"Panorama Public Catalog Entry\" icon located under the experiment title")
+                               .append(" in the \"Targeted MS Experiment\" panel in your data folder at ")
+                               .append(link(journalCopy.getShortUrl().renderShortURL())).append(".")
                                .append(" Or, you can click this link: ")
                                .append(bold(link("Add Catalog Entry", PanoramaPublicController.getAddCatalogEntryUrl(journalCopy).getURIString())));
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -168,6 +168,13 @@ public class PanoramaPublicNotification
             messageBody.append(madePublic ? " will be made public" : " will be updated");
             messageBody.append(String.format(" on ProteomeXchange by a %s administrator.", journal.getName()));
         }
+
+        messageBody.append(NL2).append("If you haven't already done so, you can add a brief description and an image to showcase your work in the slideshow on PanoramaWeb.")
+                               .append(" To provide an entry for the slideshow you can click the \"Panorama Public Catalog Entry\" icon located under the experiment title")
+                               .append(" in the \"Targeted MS Experiment\" panel in your folder.")
+                               .append(" Or, you can click this link: ")
+                               .append(bold(link("Add Catalog Entry", PanoramaPublicController.getAddCatalogEntryUrl(journalCopy).getURIString())));
+
         if (doiError != null)
         {
             messageBody.append(NL2);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
@@ -156,6 +156,7 @@ public class PanoramaPublicSymlinkManager
             if (nextHighestVersion != null)
             {
                 Container versionContainer = nextHighestVersion.getContainer();
+                // Handle symlinks in the versionContainer as well as any of its sub-containers that target files in the container being deleted.
                 handleAllSymlinks(Set.of(versionContainer), user, (link, target, c, u) -> {
                     if (!target.startsWith(deletedContainerPath))
                     {
@@ -185,6 +186,7 @@ public class PanoramaPublicSymlinkManager
         }
         if (null != sourceContainer)
         {
+            // Handle symlinks in the sourceContainer as well as any of its sub-containers that target files in the container being deleted.
             handleAllSymlinks(Set.of(sourceContainer), user, (link, target, c, u) -> {
                 if (!target.startsWith(deletedContainerPath))
                 {

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -84,6 +84,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -146,7 +147,6 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             // Update the row in panoramapublic.ExperimentAnnotations - set the shortURL and version
             ExperimentAnnotations targetExperiment = updateExperimentAnnotations(container, sourceExperiment, js, previousCopy, jobSupport, user, log);
 
-
             // If there is a Panorama Public data catalog entry associated with the previous copy of the experiment, move it to the
             // new container.
             moveCatalogEntry(previousCopy, targetExperiment, user);
@@ -182,6 +182,9 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             {
                 verifySymlinks(previousCopy.getContainer(), container, false);
             }
+
+            // Assign the ProteomeXchange ID and DOI at the end so that we don't we don't create these identifiers again in case the task has to be rerun due a previous error.
+            assignExternalIdentifiers(targetExperiment, previousCopy, jobSupport, log);
 
             // Create notifications. Do this at the end after everything else is done.
             PanoramaPublicNotification.notifyCopied(sourceExperiment, targetExperiment, jobSupport.getJournal(), js.getJournalExperiment(), currentSubmission,
@@ -425,6 +428,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
                 try
                 {
                     assignPxId(targetExperiment, jobSupport.usePxTestDb());
+                    log.info("Assigned ProteomeXchange ID: " + targetExperiment.getPxid());
                 }
                 catch(ProteomeXchangeServiceException e)
                 {
@@ -462,14 +466,12 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         {
             throw new PipelineJobException("ExperimentAnnotations row does not exist in target folder: '" + targetContainer.getPath() + "'");
         }
+
         targetExperiment.setShortUrl(js.getShortAccessUrl());
         Integer currentVersion = ExperimentAnnotationsManager.getMaxVersionForExperiment(sourceExperiment.getId());
         int version =  currentVersion == null ? 1 : currentVersion + 1;
         log.info("Setting version on new experiment to " + version);
         targetExperiment.setDataVersion(version);
-
-        assignPxId(jobSupport, log, targetExperiment, previousCopy);
-        assignDoi(jobSupport, log, targetExperiment, previousCopy);
 
         targetExperiment = ExperimentAnnotationsManager.save(targetExperiment, user);
 
@@ -488,6 +490,14 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         return targetExperiment;
     }
 
+
+    private void assignExternalIdentifiers(ExperimentAnnotations targetExperiment, ExperimentAnnotations previousCopy, CopyExperimentJobSupport jobSupport,
+                                           Logger log) throws PipelineJobException
+    {
+        assignPxId(jobSupport, log, targetExperiment, previousCopy);
+        assignDoi(jobSupport, log, targetExperiment, previousCopy);
+    }
+
     private void updatePermissions(User formSubmitter, ExperimentAnnotations targetExperiment, ExperimentAnnotations sourceExperiment, ExperimentAnnotations previousCopy,
                                    Journal journal, User pipelineJobUser, Logger log)
     {
@@ -498,37 +508,43 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
 
         // Give read permissions to the authors (all users that are folder admins)
         log.info("Adding read permissions to all users that are folder admins in the source folder.");
-        List<User> sourceFolderAdmins = getUsersWithRole(sourceExperiment.getContainer(), RoleManager.getRole(FolderAdminRole.class));
+        Set<User> allReaders = new HashSet<>(getUsersWithRole(sourceExperiment.getContainer(), RoleManager.getRole(FolderAdminRole.class)));
 
-        Container target = targetExperiment.getContainer();
-        MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(target, target.getPolicy());
-        for (User folderAdmin: sourceFolderAdmins)
-        {
-            newPolicy.addRoleAssignment(folderAdmin, ReaderRole.class);
-        }
-
-        // Assign the PanoramaPublicSubmitterRole so that the submitter or lab head is able to make the copied folder public, and add publication information.
-        assignPanoramaPublicSubmitterRole(newPolicy, log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(),
-                formSubmitter); // User that submitted the form. Can be different from the user selected as the data submitter
-
-        addToSubmittersGroup(target.getProject(), log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(), formSubmitter);
-
+        // If the submitter and lab head user are members of a permission group in the source folder, they will not
+        // be included in the set of users returned by getUsersWithRole(). So add them here
+        allReaders.add(formSubmitter);  // User that submitted the form. Can be different from the user selected as the data submitter
+        allReaders.add(targetExperiment.getSubmitterUser());
+        allReaders.add(targetExperiment.getLabHeadUser());
 
         if (previousCopy != null)
         {
             // Users that had read access to the previous copy should be given read access to the new copy. This will include the reviewer
             // account if one was created for the previous copy.
             log.info("Adding read permissions to all users that had read access to previous copy.");
-            List<User> previousCopyReaders = getUsersWithRole(previousCopy.getContainer(), RoleManager.getRole(ReaderRole.class));
-            previousCopyReaders.forEach(u -> newPolicy.addRoleAssignment(u, ReaderRole.class));
+            allReaders.addAll(getUsersWithRole(previousCopy.getContainer(), RoleManager.getRole(ReaderRole.class)));
         }
 
+        Container target = targetExperiment.getContainer();
+        MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(target, target.getPolicy());
+        allReaders.stream().filter(Objects::nonNull).forEach(u ->
+        {
+            log.info("Assigning " + ReaderRole.class.getSimpleName() + " to " + u.getEmail());
+            newPolicy.addRoleAssignment(u, ReaderRole.class);
+        });
+
+
+        // Assign the PanoramaPublicSubmitterRole so that the submitter or lab head is able to make the copied folder public, and add publication information.
+        assignPanoramaPublicSubmitterRole(newPolicy, log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(),
+                formSubmitter); // User that submitted the form. Can be different from the user selected as the data submitter
+
         SecurityPolicyManager.savePolicy(newPolicy);
+
+        addToSubmittersGroup(target.getProject(), log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(), formSubmitter);
     }
 
     private void assignPanoramaPublicSubmitterRole(MutableSecurityPolicy policy, Logger log, User... users)
     {
-        Arrays.stream(users).filter(Objects::nonNull).forEach(user -> {
+        Arrays.stream(users).filter(Objects::nonNull).collect(Collectors.toSet()).forEach(user -> {
             log.info("Assigning " + PanoramaPublicSubmitterRole.class.getSimpleName() + " to " + user.getEmail());
             policy.addRoleAssignment(user, PanoramaPublicSubmitterRole.class, false);
         });
@@ -540,7 +556,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         Group group = getGroup(groupName, project, log);
         if (group != null)
         {
-            Arrays.stream(users).filter(Objects::nonNull).forEach(user -> {
+            Arrays.stream(users).filter(Objects::nonNull).collect(Collectors.toSet()).forEach(user -> {
                 // This group already exists in the Panorama Public project on panoramaweb.org.
                 // CONSIDER: Make this configurable through the Panorama Public admin console.
                 addToGroup(user, group, log);
@@ -592,13 +608,13 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         return group;
     }
 
-    private List<User> getUsersWithRole(Container container, Role role)
+    private Set<User> getUsersWithRole(Container container, Role role)
     {
         SecurityPolicy securityPolicy = container.getPolicy();
         return securityPolicy.getAssignments().stream()
                 .filter(r -> r.getRole().equals(role)
                         && UserManager.getUser(r.getUserId()) != null) // Ignore user groups
-                .map(r -> UserManager.getUser(r.getUserId())).collect(Collectors.toList());
+                .map(r -> UserManager.getUser(r.getUserId())).collect(Collectors.toSet());
 
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -185,6 +185,11 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
 
             // Assign the ProteomeXchange ID and DOI at the end so that we don't we don't create these identifiers again in case the task has to be rerun due a previous error.
             assignExternalIdentifiers(targetExperiment, previousCopy, jobSupport, log);
+            targetExperiment = ExperimentAnnotationsManager.save(targetExperiment, user);
+            if (previousCopy != null)
+            {
+                ExperimentAnnotationsManager.save(previousCopy, user);
+            }
 
             // Create notifications. Do this at the end after everything else is done.
             PanoramaPublicNotification.notifyCopied(sourceExperiment, targetExperiment, jobSupport.getJournal(), js.getJournalExperiment(), currentSubmission,
@@ -392,6 +397,8 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
             {
                 log.info("Copying DOI from the previous copy of the data.");
                 targetExperiment.setDoi(previousCopy.getDoi());
+                log.info("Removing DOI from the previous copy");
+                previousCopy.setDoi(null);
             }
             else
             {
@@ -742,11 +749,6 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
 
         log.info("Setting the permanent link on the previous copy to " + newShortUrl.getShortURL());
         previousCopy.setShortUrl(newShortUrl);
-        if (previousCopy.getDoi() != null)
-        {
-            log.info("Removing DOI from the previous copy");
-            previousCopy.setDoi(null);
-        }
 
         ExperimentAnnotationsManager.save(previousCopy, user);
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
@@ -4,7 +4,6 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
 <%@ page import="org.labkey.api.portal.ProjectUrls" %>
-<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
@@ -33,7 +32,7 @@
         var items = [];
         if (<%=!bean.isPublic()%>) {
             let html = 'Data at ' + <%=qh(bean.getAccessUrl())%> + ' will be made public.';
-            html += <%= bean.getLicense() != null ? qh("It will be available under the " + bean.getLicense().getDisplayName() + ".") : HtmlString.EMPTY_STRING %>;
+            html += <%= qh(bean.getLicense() != null ? " It will be available under the " + bean.getLicense().getDisplayName() + " license." : "") %>;
             items.push({xtype: 'component', style: 'margin: 5px 0 5px 0', html: html});
         }
         if (<%=form.hasPubmedId()%>) {

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/confirmPublish.jsp
@@ -4,6 +4,7 @@
 <%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.panoramapublic.PanoramaPublicController" %>
 <%@ page import="org.labkey.api.portal.ProjectUrls" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 
@@ -32,11 +33,8 @@
         var items = [];
         if (<%=!bean.isPublic()%>) {
             let html = 'Data at ' + <%=qh(bean.getAccessUrl())%> + ' will be made public.';
-            if (<%= bean.getLicense() != null %>) {
-                html += ' It will be available under the ' + <%=qh(bean.getLicense().getDisplayName())%> + ' license.';
-            }
+            html += <%= bean.getLicense() != null ? qh("It will be available under the " + bean.getLicense().getDisplayName() + ".") : HtmlString.EMPTY_STRING %>;
             items.push({xtype: 'component', style: 'margin: 5px 0 5px 0', html: html});
-
         }
         if (<%=form.hasPubmedId()%>) {
             items.push({xtype: 'component', html: '<b>PubMed ID:</b> ' + <%=qh(form.getPubmedId())%>});

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -93,7 +93,7 @@ public class PanoramaPublicTest extends PanoramaPublicBaseTest
         impersonate(SUBMITTER);
         goToDashboard();
         expWebPart.clickResubmit();
-        resubmitWithoutPxd(true, true);
+        resubmitWithoutPxd(false, true);
         goToDashboard();
         assertTextPresent("Copy Pending!");
 


### PR DESCRIPTION
#### Changes
- Include text and link to add a catalog entry in the Panorama Public notification message.
- Assign PXD accession and DOI at the end of CopyExperimentFinalTask so that we don't create these identifiers again in case the task has to be rerun due to a previous error.
- Fix NPE in confirmPublish.jsp if data license is null.
- Fix NPE if the dataVersion of an experiment is null. This can happen if there is an error in the data copy pipeline job.
- Log names of users that were assigned Reader role in the Panorama Public copy. Always include the form submitter and users assigned as data submitter and lab head. 
- Added more file audit events. Set directory and file on audit event.  Fixed container path in log messages.
- When a Panorama Public container is deleted look at all containers and sub-containers that may have a symlink target in the container being deleted.