### PR TITLE
Don't kill folder import

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileImporter.java
@@ -61,12 +61,6 @@ public class PanoramaPublicFileImporter implements FolderImporter
             return;
         }
 
-        if (null == job)
-        {
-            log.error("Pipeline job not found.");
-            return;
-        }
-
         if (job instanceof CopyExperimentPipelineJob expJob)
         {
             File targetFiles = new File(targetRoot.getPath(), FileContentService.FILES_LINK);


### PR DESCRIPTION
#### Rationale
I'm not exactly sure what the folder import flow is, but this seems to kill lots of folder imports (bad for passing daily suites on a dev machine).

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
