### PR TITLE
Increase length of keywords column of panoramapublic.experimentannotations table

### DIFF
--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-23.000-23.001.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-23.000-23.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE panoramapublic.experimentannotations ALTER COLUMN keywords TYPE TEXT;

--- a/panoramapublic/resources/schemas/panoramapublic.xml
+++ b/panoramapublic/resources/schemas/panoramapublic.xml
@@ -94,7 +94,9 @@
             <column columnName="SourceExperimentId"/>
             <column columnName="SourceExperimentPath"/>
             <column columnName="ShortUrl"/>
-            <column columnName="Keywords"/>
+            <column columnName="Keywords">
+                <inputRows>2</inputRows>
+            </column>
             <column columnName="LabHead">
                 <fk>
                     <fkColumnName>UserId</fkColumnName>

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -88,7 +88,7 @@ public class PanoramaPublicModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 22.006;
+        return 23.001;
     }
 
     @Override

--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentInsertPage.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentInsertPage.java
@@ -86,7 +86,7 @@ public class TargetedMsExperimentInsertPage extends InsertPage
     {
         public Locator.XPathLocator expTitle = body.append(Locator.tagWithName("textarea", "title"));
         public Locator.XPathLocator expAbstract = body.append(Locator.tagWithName("textarea", "abstract"));
-        public Locator.XPathLocator keywords = body.append(Locator.input("keywords"));
+        public Locator.XPathLocator keywords = body.append(Locator.tagWithName("textarea","keywords"));
         public Locator.XPathLocator submitterAffiliation = body.append(Locator.input("submitterAffiliation"));
         public Locator.XPathLocator organismInputDiv = body.append(Locator.id("input-picker-div-organism")
                 .descendant(Locator.tagWithClass("span", "twitter-typeahead"))


### PR DESCRIPTION
#### Rationale
Change the type of the keywords column from VARCHAR(200) TO TEXT to accommodate longer strings.
Exception report: https://www.labkey.org/_mothership/mothership-showStackTraceDetail.view?exceptionStackTraceId=34514 

