### PR TITLE
Issue 48499: Use preferred SecurityPolicyManager.savePolicy() variant

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -269,7 +269,7 @@ public class SkylineToolsStoreController extends SpringActionController
             for (User u : users)
                 policy.addRoleAssignment(u, role);
 
-        SecurityPolicyManager.savePolicy(policy);
+        SecurityPolicyManager.savePolicy(policy, User.getAdminServiceUser());
 
         return c;
     }
@@ -319,7 +319,7 @@ public class SkylineToolsStoreController extends SpringActionController
         if (from == null || to == null)
             return;
 
-        SecurityPolicyManager.savePolicy(copyPolicy(to, from.getPolicy()));
+        SecurityPolicyManager.savePolicy(copyPolicy(to, from.getPolicy()), User.getAdminServiceUser());
     }
 
     public static SkylineTool[] sortToolsByCreateDate(SkylineTool[] tools)
@@ -1359,7 +1359,7 @@ public class SkylineToolsStoreController extends SpringActionController
                 for (User u : newToolEditors)
                     policy.addRoleAssignment(u, RoleManager.getRole(EditorRole.class));
                 policy = filterPolicy(policy, toolOwnersUsers, new Role[]{RoleManager.getRole(EditorRole.class), RoleManager.getRole(FolderAdminRole.class)});
-                SecurityPolicyManager.savePolicy(policy);
+                SecurityPolicyManager.savePolicy(policy, User.getAdminServiceUser());
 
                 Container toolStoreContainer = tool != null ? tool.getContainerParent() : getContainer();
 

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -436,7 +436,7 @@ public class PanoramaPublicController extends SpringActionController
                 // Assign project admin role to the group.
                 MutableSecurityPolicy policy = new MutableSecurityPolicy(SecurityPolicyManager.getPolicy(container));
                 policy.addRoleAssignment(group, ProjectAdminRole.class);
-                SecurityPolicyManager.savePolicy(policy);
+                SecurityPolicyManager.savePolicy(policy, getUser());
 
                 // Add the journal
                 _journal = new Journal();
@@ -6599,7 +6599,7 @@ public class PanoramaPublicController extends SpringActionController
             {
                 newPolicy.addRoleAssignment(publicDataUser.getUser(), ReaderRole.class);
             }
-            SecurityPolicyManager.savePolicy(newPolicy);
+            SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
         }
 
         private void addDownloadDataWebpart(Container container)

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/AssignSubmitterPermissionJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/AssignSubmitterPermissionJob.java
@@ -119,7 +119,7 @@ public class AssignSubmitterPermissionJob extends PipelineJob
                 logger.info(String.format("'%s', %s: %s - %s", container.getPath(), userType, user.getEmail(), "assigning"));
                 MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(container, container.getPolicy());
                 newPolicy.addRoleAssignment(user, PanoramaPublicSubmitterRole.class, false);
-                SecurityPolicyManager.savePolicy(newPolicy);
+                SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
                 return true;
             }
             else

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -544,7 +544,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         assignPanoramaPublicSubmitterRole(newPolicy, log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(),
                 formSubmitter); // User that submitted the form. Can be different from the user selected as the data submitter
 
-        SecurityPolicyManager.savePolicy(newPolicy);
+        SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
 
         addToSubmittersGroup(target.getProject(), log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(), formSubmitter);
     }
@@ -654,7 +654,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
     {
         MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(target, target.getPolicy());
         newPolicy.addRoleAssignment(reader, ReaderRole.class);
-        SecurityPolicyManager.savePolicy(newPolicy);
+        SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
     }
 
     public static String createPassword()

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -354,7 +354,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
                 {
                     throw new PipelineJobException("Error creating a new account for reviewer", e);
                 }
-                assignReader(reviewer, targetExperiment.getContainer());
+                assignReader(reviewer, targetExperiment.getContainer(), user);
                 js.getJournalExperiment().setReviewer(reviewer.getUserId());
                 SubmissionManager.updateJournalExperiment(js.getJournalExperiment(), user);
 
@@ -370,7 +370,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         {
             // Assign Site:Guests to reader role
             log.info("Making folder public.");
-            assignReader(SecurityManager.getGroup(Group.groupGuests), targetExperiment.getContainer());
+            assignReader(SecurityManager.getGroup(Group.groupGuests), targetExperiment.getContainer(), user);
         }
         return new Pair<>(null, null);
     }
@@ -544,7 +544,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         assignPanoramaPublicSubmitterRole(newPolicy, log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(),
                 formSubmitter); // User that submitted the form. Can be different from the user selected as the data submitter
 
-        SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
+        SecurityPolicyManager.savePolicy(newPolicy, pipelineJobUser);
 
         addToSubmittersGroup(target.getProject(), log, targetExperiment.getSubmitterUser(), targetExperiment.getLabHeadUser(), formSubmitter);
     }
@@ -650,11 +650,11 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         return newUser.getUser();
     }
 
-    private void assignReader(UserPrincipal reader, Container target)
+    private void assignReader(UserPrincipal reader, Container target, User pipelineJobUser)
     {
         MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(target, target.getPolicy());
         newPolicy.addRoleAssignment(reader, ReaderRole.class);
-        SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
+        SecurityPolicyManager.savePolicy(newPolicy, pipelineJobUser);
     }
 
     public static String createPassword()

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
@@ -286,14 +286,14 @@ public class JournalManager
         ShortURLRecord shortAccessURLRecord;
         try
         {
-            shortAccessURLRecord = shortUrlService.saveShortURL(shortUrl, longURL, user);
+            shortAccessURLRecord = shortUrlService.saveShortURL(shortUrl, longURL, User.getAdminServiceUser());
         }
         catch(UnauthorizedException e)
         {
             throw new ValidationException("Error saving link \"" + shortUrl + "\". It may already be in use. Error message was: " + e.getMessage());
         }
 
-        if(journalGroup != null)
+        if (journalGroup != null)
         {
             MutableSecurityPolicy policy = new MutableSecurityPolicy(SecurityPolicyManager.getPolicy(shortAccessURLRecord));
             // Add a role assignment to let another group manage the URL. This grants permission to the journal

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
@@ -286,7 +286,7 @@ public class JournalManager
         ShortURLRecord shortAccessURLRecord;
         try
         {
-            shortAccessURLRecord = shortUrlService.saveShortURL(shortUrl, longURL, User.getAdminServiceUser());
+            shortAccessURLRecord = shortUrlService.saveShortURL(shortUrl, longURL, user);
         }
         catch(UnauthorizedException e)
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
@@ -241,7 +241,7 @@ public class JournalManager
             }
         }
         newPolicy.addRoleAssignment(journalGroup, CopyTargetedMSExperimentRole.class, false);
-        SecurityPolicyManager.savePolicy(newPolicy);
+        SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
     }
 
     private static void removePermission(Container folder, UserPrincipal journalGroup)
@@ -260,7 +260,7 @@ public class JournalManager
                 newPolicy.addRoleAssignment(journalGroup, role);
             }
         }
-        SecurityPolicyManager.savePolicy(newPolicy);
+        SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
     }
 
     public static void addJournalPermissions(ExperimentAnnotations exptAnnotations, UserPrincipal journalGroup, User user)
@@ -299,7 +299,7 @@ public class JournalManager
             // Add a role assignment to let another group manage the URL. This grants permission to the journal
             // to change where the URL redirects you to after they copy the data
             policy.addRoleAssignment(journalGroup, EditorRole.class);
-            SecurityPolicyManager.savePolicy(policy);
+            SecurityPolicyManager.savePolicy(policy, User.getAdminServiceUser());
         }
         return shortAccessURLRecord;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
@@ -283,7 +283,7 @@ public class SubmissionManager
         if (!isEditor)
         {
             policy.addRoleAssignment(user, EditorRole.class);
-            SecurityPolicyManager.savePolicy(policy);
+            SecurityPolicyManager.savePolicy(policy, User.getAdminServiceUser());
         }
     }
 


### PR DESCRIPTION
#### Rationale
We're uneven in terms of the validation and auditing we do for saving SecurityPolicies and related updates, and want to be more consistent.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4704

#### Changes
* Let modules register ContainerSecurableResourceProviders instead of having Container know about them all
* Remove the `savePolicy` and `createContainer` methods that don't take a user, check permissions, or log for audit purposes
* Introduce `User.getAdminServiceUser()` for `sudo` like scenarios or when we're doing an operation not initiated by a user, like bootstrapping the server
* Update callers