### PR TITLE
Migrate User.isInSiteAdminGroup() -> User.hasSiteAdminPermission()

### DIFF
--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -1210,7 +1210,7 @@ public class LincsController extends SpringActionController
             statusButton.setActionType(ActionButton.Action.GET);
             buttonBar.add(statusButton);
 
-            if (getUser().isInSiteAdminGroup())
+            if (getUser().hasSiteAdminPermission())
             {
                 ActionURL updateStatusUrl = new ActionURL(UpdatePspJobStatusAction.class, getViewContext().getContainer());
                 ActionButton updateButton = new ActionButton(updateStatusUrl, "Update Status");
@@ -1231,7 +1231,7 @@ public class LincsController extends SpringActionController
             DetailsView detailsView = new DetailsView(dr, pspJob.getId());
             view.addView(detailsView);
 
-            if(pspJob.getPipelineJobId() != null && getUser().isInSiteAdminGroup())
+            if(pspJob.getPipelineJobId() != null && getUser().hasSiteAdminPermission())
             {
                 ActionURL pipelineJobUrl = PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlDetails(getContainer(), pspJob.getPipelineJobId());
                 view.addView(new HtmlView(PageFlowUtil.link("View Pipeline Job. Status: " + PipelineService.get().getStatusFile(pspJob.getPipelineJobId()).getStatus()).href(pipelineJobUrl).toString()));

--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -145,7 +145,7 @@ public class LincsDataTable extends FilteredTable
                 if(pspJob == null)
                 {
                     out.write("PSP job not found for runId: " + runId);
-                    if(userSchema.getUser().isInSiteAdminGroup())
+                    if(userSchema.getUser().hasSiteAdminPermission())
                     {
                         ActionURL url = new ActionURL(LincsController.SubmitPspJobAction.class, getContainer());
                         url.addParameter("runId", runId);

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/SpecLibInfoTableInfo.java
@@ -106,7 +106,7 @@ public class SpecLibInfoTableInfo extends PanoramaPublicTable
                 @Override
                 public Object getValue(RenderContext ctx)
                 {
-                    if (ctx.getViewContext().getUser().isInSiteAdminGroup())
+                    if (ctx.getViewContext().getUser().hasSiteAdminPermission())
                     {
                         // Show the password only to site admins
                         return super.getValue(ctx);


### PR DESCRIPTION
#### Rationale
Calling `User.isInSiteAdminGroup()` will return incorrect results for users and groups assigned directly to the role as well as impersonation scenarios.