### PR TITLE
Migrate HtmlView(String) callers

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -445,7 +445,7 @@ public class SkylineToolsStoreController extends SpringActionController
             {
                 // Make sure that the tool store module is enabled in the folder where the user is trying
                 // to insert the new tool.
-                return new HtmlView("The Skyline Tool Store is not available in this folder.");
+                return HtmlView.of("The Skyline Tool Store is not available in this folder.");
             }
 
             if (httpServletRequest.getMethod().equalsIgnoreCase("post") &&

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -63,6 +63,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.targetedms.SkylineAnnotation;
 import org.labkey.api.targetedms.TargetedMSService;
+import org.labkey.api.util.DOM;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
@@ -1234,7 +1235,7 @@ public class LincsController extends SpringActionController
             if(pspJob.getPipelineJobId() != null && getUser().hasSiteAdminPermission())
             {
                 ActionURL pipelineJobUrl = PageFlowUtil.urlProvider(PipelineStatusUrls.class).urlDetails(getContainer(), pspJob.getPipelineJobId());
-                view.addView(new HtmlView(PageFlowUtil.link("View Pipeline Job. Status: " + PipelineService.get().getStatusFile(pspJob.getPipelineJobId()).getStatus()).href(pipelineJobUrl).toString()));
+                view.addView(new HtmlView(PageFlowUtil.link("View Pipeline Job. Status: " + PipelineService.get().getStatusFile(pspJob.getPipelineJobId()).getStatus()).href(pipelineJobUrl)));
             }
 
             view.setTitle("PSP Job Details");
@@ -1372,13 +1373,11 @@ public class LincsController extends SpringActionController
                 return new SimpleErrorView(errors);
             }
 
-            StringBuilder sb = new StringBuilder();
-            sb.append("<p>").append("Status for job: " + pspJob.getId() +", PSP job Id: ").append(PageFlowUtil.filter(pspJob.getPspJobId()))
-                    .append(", Run Id: ")
-                    .append(pspJob.getRunId()).append("</p>");
-            sb.append("<br>JSON Output:</br>");
-            sb.append("<p><pre>").append(PageFlowUtil.filter(jsonStatus)).append("</pre></p>");
-            view.addView(new HtmlView(sb.toString()));
+            view.addView(new HtmlView(
+                    DOM.P(
+                        DOM.P("Status for job: " + pspJob.getId() +", PSP job Id: " + pspJob.getPspJobId() + ", Run Id: " + pspJob.getRunId()),
+                        DOM.BR("JSON Output:"),
+                        DOM.P(DOM.PRE(jsonStatus)))));
             view.setTitle("PSP job status");
             view.setFrame(WebPartView.FrameType.PORTAL);
             return view;

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -1376,7 +1376,8 @@ public class LincsController extends SpringActionController
             view.addView(new HtmlView(
                     DOM.P(
                         DOM.P("Status for job: " + pspJob.getId() +", PSP job Id: " + pspJob.getPspJobId() + ", Run Id: " + pspJob.getRunId()),
-                        DOM.BR("JSON Output:"),
+                        "JSON Output:",
+                        DOM.BR(),
                         DOM.P(DOM.PRE(jsonStatus)))));
             view.setTitle("PSP job status");
             view.setFrame(WebPartView.FrameType.PORTAL);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -714,14 +714,7 @@ public class PanoramaPublicController extends SpringActionController
             VBox view = new VBox();
             if (errors.getErrorCount() > 0)
             {
-                HtmlStringBuilder html = HtmlStringBuilder.of();
-                for(ObjectError error: errors.getAllErrors())
-                {
-                    HtmlString errHtml = createHtmlFragment(SPAN(cl("labkey-error"), error.getDefaultMessage()));
-                    html.append(errHtml);
-                }
-                html.append(createHtml(BR()));
-                view.addView(new HtmlView(html));
+                view.addView(new HtmlView(ERRORS(errors)));
             }
 
             view.addView(new HtmlView(

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -124,6 +124,7 @@ import org.labkey.api.util.DOM;
 import org.labkey.api.util.ExceptionUtil;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.Link;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
@@ -711,16 +712,16 @@ public class PanoramaPublicController extends SpringActionController
             }
 
             VBox view = new VBox();
-            if(errors.getErrorCount() > 0)
+            if (errors.getErrorCount() > 0)
             {
-                StringBuilder html = new StringBuilder();
+                HtmlStringBuilder html = HtmlStringBuilder.of();
                 for(ObjectError error: errors.getAllErrors())
                 {
                     HtmlString errHtml = createHtmlFragment(SPAN(cl("labkey-error"), error.getDefaultMessage()));
-                    errHtml.appendTo(html);
+                    html.append(errHtml);
                 }
-                BR().appendTo(html);
-                view.addView(new HtmlView(HtmlString.unsafe(html.toString())));
+                html.append(createHtml(BR()));
+                view.addView(new HtmlView(html));
             }
 
             view.addView(new HtmlView(
@@ -4668,7 +4669,7 @@ public class PanoramaPublicController extends SpringActionController
                 pxInfo.setVersion(PxXmlManager.getNextVersion(js.getJournalExperimentId()));
                 writer.write(pxInfo);
 
-                return new HtmlView(HtmlString.unsafe(summaryHtml.toString()));
+                return HtmlView.unsafe(summaryHtml.toString());
             }
             else
             {

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -549,7 +549,7 @@ public class SignUpController extends SpringActionController
                 }
                 else
                 {
-                    return new HtmlView(PageFlowUtil.filter(message));
+                    return HtmlView.of(message);
                 }
             }
         }


### PR DESCRIPTION
#### Rationale
We're eliminating uses of a deprecated constructor.

#### Changes
* Switch to HtmlString or explicitly calling `unsafe()`