### PR TITLE
Update gradle plugin ids

### DIFF
--- a/testresults/distributions_disabled/skyline/build.gradle
+++ b/testresults/distributions_disabled/skyline/build.gradle
@@ -3,7 +3,7 @@ import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 
-apply plugin: 'org.labkey.distribution'
+apply plugin: 'org.labkey.build.distribution'
 
 Distribution.inheritDependencies(project, ":server:distributions:legacy")
 


### PR DESCRIPTION
#### Rationale
We added new plugin ids long ago. It's time to start using them so we can get rid of the old ones.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/190

#### Changes
* Update Gradle plugin ids