### PR TITLE
Overwrite the Content-Disposition header in DownloadToolAction for Skyline compatibility

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -1114,6 +1114,7 @@ public class SkylineToolsStoreController extends SpringActionController
             if (resource == null || !resource.isFile())
                 throw new NotFoundException("Resource could not be found: " + path.toString());
 
+            // Issue 49580: https://www.labkey.org/MacCoss/Issue%20Tracker/issues-details.view?issueId=49580
             // Add our own 'Content-Disposition' header so that it overwrites the one set in
             // ResponseHelper.setContentDisposition(HttpServletResponse response, ContentDispositionType type, @NotNull String filename)
             // Skyline expects the 'Content-Disposition' header value to look like this: filename="MSstatsShiny.zip".


### PR DESCRIPTION
#### Rationale
Skyline expects the 'Content-Disposition' response header value to look like this: filename="MSstatsShiny.zip".  Otherwise, external tool installation in Skyline does not work.

#### Changes
- Use `PageFlowUtil.streamFile` instead of returning `HttpRedirectView` in `DownloadToolAction`
- Pass 'Content-Disposition' header value to `PageFlowUtil.streamFile` so that it overwrites the value already set.
