### PR TITLE
Use 'SystemUtils' to identify test OS

### DIFF
--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -1,6 +1,7 @@
 package org.labkey.test.tests.panoramapublic;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
@@ -81,9 +82,7 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         // The SQLite driver for the Chromatogram library code chokes on paths with certain characters on OSX. We don't have
         // any real deployments on OSX, so just avoid using those characters on dev machines and rely on TeamCity
         // to keep things happy on the platforms we actually use on production
-        String osName = System.getProperty("os.name").toLowerCase();
-        boolean isMacOs = osName.startsWith("mac os x");
-        if (isMacOs)
+        if (SystemUtils.IS_OS_MAC)
         {
             return baseName;
         }


### PR DESCRIPTION
#### Rationale
Individual tests shouldn't be parsing system properties. `SystemUtils` provides a reliable way to check what OS the test is running on.

#### Related Pull Requests
* N/A

#### Changes
* Use 'SystemUtils' to identify test OS
