### PR TITLE
Suppress NPE on dev machines not configured for test results

### DIFF
--- a/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
+++ b/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
@@ -69,6 +69,12 @@ public class SendTestResultsEmail implements org.quartz.Job
     {
         // Sends email for all runs since 8:01 the previous morning, at 8am every morning
         Container parent = ContainerManager.getHomeContainer().getChild("development");
+        if (parent == null)
+        {
+            LOG.debug("No /home/development container found, skipping email generation");
+            return new Pair<>("", "");
+        }
+
         //parent = ContainerManager.getForPath(new Path(new String[]{"home"})); // DEV ONLY, localhost container path
 
         List<Container> containers = ContainerManager.getAllChildren(parent, from);


### PR DESCRIPTION
#### Rationale
```
ERROR ErrorLogger              2024-03-04T08:00:00,013 QuartzScheduler_Worker-8 : Job (TestResultsGroup.TestResultsEmailTrigger threw an exception.
org.quartz.SchedulerException: Job threw an unhandled exception.
	at org.quartz.core.JobRunShell.run(JobRunShell.java:213) [quartz-2.3.2.jar:?]
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) [quartz-2.3.2.jar:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.labkey.api.data.Container.getId()" because "c" is null
	at org.labkey.api.data.ContainerManager._getAllChildrenFromCache(ContainerManager.java:1990) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.ContainerManager.getAllChildren(ContainerManager.java:2100) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.ContainerManager.getAllChildren(ContainerManager.java:994) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.ContainerManager.getAllChildren(ContainerManager.java:973) ~[api-24.4-SNAPSHOT.jar:?]
	at org.labkey.testresults.SendTestResultsEmail.getHTMLEmail(SendTestResultsEmail.java:74) ~[testresults-24.4-SNAPSHOT.jar:?]
	at org.labkey.testresults.SendTestResultsEmail.execute(SendTestResultsEmail.java:319) ~[testresults-24.4-SNAPSHOT.jar:?]
	at org.labkey.testresults.SendTestResultsEmail.execute(SendTestResultsEmail.java:341) ~[testresults-24.4-SNAPSHOT.jar:?]
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202) ~[quartz-2.3.2.jar:?]
```

#### Changes
* Bail out if the expected container doesn't exist