### PR TITLE
Include crosslink entries from unimod_xl.xml

### DIFF
--- a/panoramapublic/resources/unimod_xl.xml
+++ b/panoramapublic/resources/unimod_xl.xml
@@ -1,0 +1,1577 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright (C) 2002-2006 Unimod; this information may be copied, distributed and/or-->
+<!--modified under certain conditions, but it comes WITHOUT ANY WARRANTY; see the-->
+<!--accompanying Design Science License for more details-->
+<umod:unimod xmlns:umod="http://www.unimod.org/xmlns/schema/unimod_2"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://www.unimod.org/xmlns/schema/unimod_2 http://www.unimod.org/xmlns/schema/unimod_2/unimod_2.xsd"
+             majorVersion="2"
+             minorVersion="1">
+   <umod:elements>
+      <umod:elem title="H" full_name="Hydrogen" avge_mass="1.00794" mono_mass="1.007825035"/>
+      <umod:elem title="2H" full_name="Deuterium" avge_mass="2.014101779"
+                 mono_mass="2.014101779"/>
+      <umod:elem title="Li" full_name="Lithium" avge_mass="6.941" mono_mass="7.016003"/>
+      <umod:elem title="C" full_name="Carbon" avge_mass="12.0107" mono_mass="12"/>
+      <umod:elem title="13C" full_name="Carbon13" avge_mass="13.00335483"
+                 mono_mass="13.00335483"/>
+      <umod:elem title="N" full_name="Nitrogen" avge_mass="14.0067" mono_mass="14.003074"/>
+      <umod:elem title="15N" full_name="Nitrogen15" avge_mass="15.00010897"
+                 mono_mass="15.00010897"/>
+      <umod:elem title="O" full_name="Oxygen" avge_mass="15.9994" mono_mass="15.99491463"/>
+      <umod:elem title="18O" full_name="Oxygen18" avge_mass="17.9991603" mono_mass="17.9991603"/>
+      <umod:elem title="F" full_name="Fluorine" avge_mass="18.9984032" mono_mass="18.99840322"/>
+      <umod:elem title="Na" full_name="Sodium" avge_mass="22.98977" mono_mass="22.9897677"/>
+      <umod:elem title="P" full_name="Phosphorous" avge_mass="30.973761" mono_mass="30.973762"/>
+      <umod:elem title="S" full_name="Sulfur" avge_mass="32.065" mono_mass="31.9720707"/>
+      <umod:elem title="Cl" full_name="Chlorine" avge_mass="35.453" mono_mass="34.96885272"/>
+      <umod:elem title="K" full_name="Potassium" avge_mass="39.0983" mono_mass="38.9637074"/>
+      <umod:elem title="Ca" full_name="Calcium" avge_mass="40.078" mono_mass="39.9625906"/>
+      <umod:elem title="Fe" full_name="Iron" avge_mass="55.845" mono_mass="55.9349393"/>
+      <umod:elem title="Ni" full_name="Nickel" avge_mass="58.6934" mono_mass="57.9353462"/>
+      <umod:elem title="Zn" full_name="Zinc" avge_mass="65.409" mono_mass="63.9291448"/>
+      <umod:elem title="Se" full_name="Selenium" avge_mass="78.96" mono_mass="79.9165196"/>
+      <umod:elem title="Br" full_name="Bromine" avge_mass="79.904" mono_mass="78.9183361"/>
+      <umod:elem title="Ag" full_name="Silver" avge_mass="107.8682" mono_mass="106.905092"/>
+      <umod:elem title="Hg" full_name="Mercury" avge_mass="200.59" mono_mass="201.970617"/>
+      <umod:elem title="Au" full_name="Gold" avge_mass="196.96655" mono_mass="196.966543"/>
+      <umod:elem title="I" full_name="Iodine" avge_mass="126.90447" mono_mass="126.904473"/>
+      <umod:elem title="Mo" full_name="Molybdenum" avge_mass="95.94" mono_mass="97.9054073"/>
+      <umod:elem title="Cu" full_name="Copper" avge_mass="63.546" mono_mass="62.9295989"/>
+      <umod:elem title="e" full_name="electron" avge_mass="0.000549" mono_mass="0.000549"/>
+      <umod:elem title="B" full_name="Boron" avge_mass="10.811" mono_mass="11.0093055"/>
+      <umod:elem title="As" full_name="Arsenic" avge_mass="74.9215942" mono_mass="74.9215942"/>
+      <umod:elem title="Cd" full_name="Cadmium" avge_mass="112.411" mono_mass="113.903357"/>
+      <umod:elem title="Cr" full_name="Chromium" avge_mass="51.9961" mono_mass="51.9405098"/>
+      <umod:elem title="Co" full_name="Cobalt" avge_mass="58.933195" mono_mass="58.9331976"/>
+      <umod:elem title="Mn" full_name="Manganese" avge_mass="54.938045" mono_mass="54.9380471"/>
+      <umod:elem title="Mg" full_name="Magnesium" avge_mass="24.305" mono_mass="23.9850423"/>
+      <umod:elem title="Pd" full_name="Palladium" avge_mass="106.42" mono_mass="105.903478"/>
+      <umod:elem title="Al" full_name="Aluminium" avge_mass="26.9815386" mono_mass="26.9815386"/>
+      <umod:elem title="Pt" full_name="Platinum" avge_mass="195.084" mono_mass="194.964766"/>
+      <umod:elem title="Ru" full_name="Ruthenium" avge_mass="101.07" mono_mass="101.9043485"/>
+      <umod:elem title="Si" full_name="Silicon" avge_mass="28.085" mono_mass="27.9769271"/>
+   </umod:elements>
+   <umod:modifications>
+      <umod:mod title="Xlink:DMP" full_name="Dimethyl pimelimidate crosslink"
+                username_of_poster="mariana"
+                group_of_poster="users"
+                date_time_posted="2005-11-08 20:15:20"
+                date_time_modified="2018-09-13 11:37:44"
+                approved="0"
+                record_id="456">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term" classification="Cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="A">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-32.026215" avge_mass="-32.0419" flag="false"
+                              composition="H(-4) C(-1) O(-1)"
+                              description="Free monolink"
+                              code="F">
+               <umod:element symbol="H" number="-4"/>
+               <umod:element symbol="C" number="-1"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-32.026215" avge_mass="-32.0419" flag="false"
+                              composition="H(-4) C(-1) O(-1)"
+                              description="Free monolink"
+                              code="F">
+               <umod:element symbol="H" number="-4"/>
+               <umod:element symbol="C" number="-1"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="A">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="122.084398" avge_mass="122.1677" composition="H(10) C(7) N(2)">
+            <umod:element symbol="H" number="10"/>
+            <umod:element symbol="C" number="7"/>
+            <umod:element symbol="N" number="2"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>Imidoester Cross-linkers</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://assets.thermofisher.com/TFS-Assets/LSG/manuals/MAN0011314_ImidoesterCrsLnk_DMA_DMP_DMS_DTBP_UG.pdf</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>Packman, L.C. and Perhan, R.N. (1982). Quaternary Structures the Pyruvate Dehydrogenase Multienzyme Complex of Bacillus StearothermophilusStudies by a New Reversible Crosslinking Procedure with Bis(imidoesters). Biochem. 21, 5171-5175.</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url/>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>Hand, E.S., and Jencks, W.P. (1962). Mechanism of the reaction of imidoesters with amines. J. Am. Chem. Soc. 84, 3505-3514.</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url/>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:DST" full_name="Disuccinimidyl tartrate crosslinker"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-08-18 14:27:09"
+                date_time_modified="2018-09-13 11:39:16"
+                approved="0"
+                record_id="1892">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term"
+                           classification="Other cleavable cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="58.005479" avge_mass="58.0361" flag="false"
+                              composition="H(2) C(2) O(2)"
+                              description="Cleaved by sodium periodate"
+                              code="P">
+               <umod:element symbol="H" number="2"/>
+               <umod:element symbol="C" number="2"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere"
+                           classification="Other cleavable cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="58.005479" avge_mass="58.0361" flag="false"
+                              composition="H(2) C(2) O(2)"
+                              description="Cleaved by sodium periodate"
+                              code="P">
+               <umod:element symbol="H" number="2"/>
+               <umod:element symbol="C" number="2"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="113.995309" avge_mass="114.0563" composition="H(2) C(4) O(4)">
+            <umod:element symbol="H" number="2"/>
+            <umod:element symbol="C" number="4"/>
+            <umod:element symbol="O" number="4"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>ThermoFisher data sheet</umod:text>
+            <umod:source>PubMed PMID</umod:source>
+            <umod:url>https://assets.thermofisher.com/TFS-Assets/LSG/manuals/MAN0011282_DST_UG.pdf</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>212103</umod:text>
+            <umod:source>PubMed PMID</umod:source>
+            <umod:url>http://www.ncbi.nlm.nih.gov/pubmed/212103</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>3001048</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>http://www.ncbi.nlm.nih.gov/pubmed?term=Characterization%20of%20the%20cell%20surface%20receptor%20for%20a%20multi-lineage%20colony-stimulating%20factor%20%28CSF-2%20%29</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:DSS" full_name="disuccinimidyl suberate (DSS)"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-08-17 14:12:08"
+                date_time_modified="2018-09-13 11:40:08"
+                approved="0"
+                record_id="1876">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term" classification="Cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="A">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="A">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="138.06808" avge_mass="138.1638" composition="H(10) C(8) O(2)">
+            <umod:element symbol="H" number="10"/>
+            <umod:element symbol="C" number="8"/>
+            <umod:element symbol="O" number="2"/>
+         </umod:delta>
+         <umod:alt_name>bis[sulfosuccinimidyl] suberate (BS3)</umod:alt_name>
+         <umod:xref>
+            <umod:text>ThermoFisher data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://www.thermofisher.com/order/catalog/product/21655</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:DSSO"
+                full_name="disuccinimidyl sulfoxide CID cleavable cross-link"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2016-12-22 11:46:08"
+                date_time_modified="2018-09-13 11:41:15"
+                approved="0"
+                record_id="1842">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term"
+                           classification="CID cleavable cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="54.010565" avge_mass="54.0474" flag="false"
+                              composition="H(2) C(3) O"
+                              description="Sulfenic acid fragment"
+                              code="S"
+                              pairs_with="A">
+               <umod:element symbol="H" number="2"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="72.021129" avge_mass="72.0627" flag="false"
+                              composition="H(4) C(3) O(2)"
+                              description="Thiol fragment"
+                              code="T"
+                              pairs_with="A">
+               <umod:element symbol="H" number="4"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="103.9932" avge_mass="104.1277" flag="false"
+                              composition="H(4) C(3) O(2) S"
+                              description="Alkene fragment"
+                              code="A"
+                              pairs_with="ST">
+               <umod:element symbol="H" number="4"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="2"/>
+               <umod:element symbol="S" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="M">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="R">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere"
+                           classification="CID cleavable cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="M">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="54.010565" avge_mass="54.0474" flag="false"
+                              composition="H(2) C(3) O"
+                              description="Sulfenic acid fragment"
+                              code="S"
+                              pairs_with="A">
+               <umod:element symbol="H" number="2"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="72.021129" avge_mass="72.0627" flag="false"
+                              composition="H(4) C(3) O(2)"
+                              description="Thiol fragment"
+                              code="T"
+                              pairs_with="A">
+               <umod:element symbol="H" number="4"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="103.9932" avge_mass="104.1277" flag="false"
+                              composition="H(4) C(3) O(2) S"
+                              description="Alkene fragment"
+                              code="A"
+                              pairs_with="ST">
+               <umod:element symbol="H" number="4"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="2"/>
+               <umod:element symbol="S" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="R">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="158.003765" avge_mass="158.175" composition="H(6) C(6) O(3) S">
+            <umod:element symbol="H" number="6"/>
+            <umod:element symbol="C" number="6"/>
+            <umod:element symbol="O" number="3"/>
+            <umod:element symbol="S" number="1"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>Thermo Fisher data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://www.thermofisher.com/order/catalog/product/A33545</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>Kao et. al, Development of a Novel Cross-linking Strategy for Fast and Accurate Identification of Cross-linked Peptides of Protein Complexes, MCP</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url>http://dx.doi.org/10.1074/mcp.M110.002212</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:EGS" full_name="EGS cross-linker" username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-02-02 10:55:41"
+                date_time_modified="2018-09-13 11:45:26"
+                approved="0"
+                record_id="1844">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term"
+                           classification="Other cleavable cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="111.020795" avge_mass="111.0954" flag="false"
+                              composition="H(5) C(6) N(-1) O(3)"
+                              description="Hydroxylamine cleavage fragment"
+                              code="A"
+                              pairs_with="A">
+               <umod:element symbol="H" number="5"/>
+               <umod:element symbol="C" number="6"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="3"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere"
+                           classification="Other cleavable cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="111.020795" avge_mass="111.0954" flag="false"
+                              composition="H(5) C(6) N(-1) O(3)"
+                              description="Hydroxylamine cleavage fragment"
+                              code="A"
+                              pairs_with="A">
+               <umod:element symbol="H" number="5"/>
+               <umod:element symbol="C" number="6"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="3"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="226.047738" avge_mass="226.1828" composition="H(10) C(10) O(6)">
+            <umod:element symbol="H" number="10"/>
+            <umod:element symbol="C" number="10"/>
+            <umod:element symbol="O" number="6"/>
+         </umod:delta>
+         <umod:alt_name>Ethylene glycolbis(succinimidylsuccinate)</umod:alt_name>
+         <umod:xref>
+            <umod:text>Pierce data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://tools.thermofisher.com/content/sfs/manuals/MAN0011281_EGS_SulfoEGS_UG.pdf</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>36892</umod:text>
+            <umod:source>PubMed PMID</umod:source>
+            <umod:url>http://www.ncbi.nlm.nih.gov/pubmed?term=A%20new%20cleavable%20reagent%20for%20cross-linking%20and%20reversible%20immobilization%20of%20proteins</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:BuUrBu"
+                full_name="disuccinimidyl dibutyric urea CID cleavable cross-link"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-08-17 17:07:00"
+                date_time_modified="2024-01-26 11:11:12"
+                approved="0"
+                record_id="1884">
+         <umod:specificity hidden="1" site="Y" position="Anywhere"
+                           classification="CID cleavable cross-link"
+                           spec_group="3">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="M">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="85.052764" avge_mass="85.1045" flag="false"
+                              composition="H(7) C(4) N O"
+                              description="BuUr fragment"
+                              code="B"
+                              pairs_with="A">
+               <umod:element symbol="H" number="7"/>
+               <umod:element symbol="C" number="4"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="111.032028" avge_mass="111.0987" flag="false"
+                              composition="H(5) C(5) N O(2)"
+                              description="BuUr fragment"
+                              code="A"
+                              pairs_with="B">
+               <umod:element symbol="H" number="5"/>
+               <umod:element symbol="C" number="5"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="T" position="Anywhere"
+                           classification="CID cleavable cross-link"
+                           spec_group="3">
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="M">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="85.052764" avge_mass="85.1045" flag="false"
+                              composition="H(7) C(4) N O"
+                              description="BuUr fragment"
+                              code="B"
+                              pairs_with="A">
+               <umod:element symbol="H" number="7"/>
+               <umod:element symbol="C" number="4"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="111.032028" avge_mass="111.0987" flag="false"
+                              composition="H(5) C(5) N O(2)"
+                              description="Bu fragment"
+                              code="A"
+                              pairs_with="B">
+               <umod:element symbol="H" number="5"/>
+               <umod:element symbol="C" number="5"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="S" position="Anywhere"
+                           classification="CID cleavable cross-link"
+                           spec_group="3">
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="M">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="111.032028" avge_mass="111.0987" flag="false"
+                              composition="H(5) C(5) N O(2)"
+                              description="Bu fragment"
+                              code="A"
+                              pairs_with="B">
+               <umod:element symbol="H" number="5"/>
+               <umod:element symbol="C" number="5"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="85.052764" avge_mass="85.1045" flag="false"
+                              composition="H(7) C(4) N O"
+                              description="BuUr fragment"
+                              code="B"
+                              pairs_with="A">
+               <umod:element symbol="H" number="7"/>
+               <umod:element symbol="C" number="4"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term"
+                           classification="CID cleavable cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="M">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="111.032028" avge_mass="111.0987" flag="false"
+                              composition="H(5) C(5) N O(2)"
+                              description="Bu fragment"
+                              code="A"
+                              pairs_with="B">
+               <umod:element symbol="H" number="5"/>
+               <umod:element symbol="C" number="5"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="85.052764" avge_mass="85.1045" flag="false"
+                              composition="H(7) C(4) N O"
+                              description="BuUr fragment"
+                              code="B"
+                              pairs_with="A">
+               <umod:element symbol="H" number="7"/>
+               <umod:element symbol="C" number="4"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere"
+                           classification="CID cleavable cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="M">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="111.032028" avge_mass="111.0987" flag="false"
+                              composition="H(5) C(5) N O(2)"
+                              description="Bu fragment"
+                              code="A"
+                              pairs_with="B">
+               <umod:element symbol="H" number="5"/>
+               <umod:element symbol="C" number="5"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="2"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="85.052764" avge_mass="85.1045" flag="false"
+                              composition="H(7) C(4) N O"
+                              description="BuUr fragment"
+                              code="B"
+                              pairs_with="A">
+               <umod:element symbol="H" number="7"/>
+               <umod:element symbol="C" number="4"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="O" number="1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="196.084792" avge_mass="196.2032" composition="H(12) C(9) N(2) O(3)">
+            <umod:element symbol="H" number="12"/>
+            <umod:element symbol="C" number="9"/>
+            <umod:element symbol="N" number="2"/>
+            <umod:element symbol="O" number="3"/>
+         </umod:delta>
+         <umod:alt_name>Also known as DSBU</umod:alt_name>
+         <umod:xref>
+            <umod:text>Thermo Fisher data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://www.thermofisher.com/order/catalog/product/A35459</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>Anal. Chem. 2016, 88, 7930−7937, Integrated Workflow for Structural Proteomics Studies</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url>http://dx.doi.org/10.1021/acs.analchem.5b04853</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:DTBP" full_name="dimethyl 3,3\'-dithiobispropionimidate"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-08-18 10:39:47"
+                date_time_modified="2018-09-13 11:43:02"
+                approved="0"
+                record_id="1891">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term"
+                           classification="Other cleavable cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="84.99862" avge_mass="85.1276" flag="false"
+                              composition="H(3) C(3) N S"
+                              description="Cleaved and reduced"
+                              code="H">
+               <umod:element symbol="H" number="3"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="S" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact crosslink"
+                              code="I"/>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere"
+                           classification="Other cleavable cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact crosslink"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="84.99862" avge_mass="85.1276" flag="false"
+                              composition="H(3) C(3) N S"
+                              description="Cleaved and reduced"
+                              code="H">
+               <umod:element symbol="H" number="3"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="N" number="1"/>
+               <umod:element symbol="S" number="1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="172.01289" avge_mass="172.2711" composition="H(8) C(6) N(2) S(2)">
+            <umod:element symbol="H" number="8"/>
+            <umod:element symbol="C" number="6"/>
+            <umod:element symbol="N" number="2"/>
+            <umod:element symbol="S" number="2"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>Pierce data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>http://tools.thermofisher.com/content/sfs/manuals/MAN0011314_ImidoesterCrsLnk_DMA_DMP_DMS_DTBP_UG.pdf</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>770170</umod:text>
+            <umod:source>PubMed PMID</umod:source>
+            <umod:url/>
+         </umod:xref>
+         <umod:misc_notes>imidoester cross-linker</umod:misc_notes>
+      </umod:mod>
+      <umod:mod title="Xlink:DTSSP" full_name="dithiobis[succinimidylpropionate]"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-08-18 14:56:20"
+                date_time_modified="2018-09-13 11:43:33"
+                approved="0"
+                record_id="1893">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term"
+                           classification="Other cleavable cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="85.982635" avge_mass="86.1124" flag="false"
+                              composition="H(2) C(3) O S"
+                              description="Cleaved and reduced"
+                              code="H">
+               <umod:element symbol="H" number="2"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="1"/>
+               <umod:element symbol="S" number="1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact crosslink"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere"
+                           classification="Other cleavable cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact crosslink"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="85.982635" avge_mass="86.1124" flag="false"
+                              composition="H(2) C(3) O S"
+                              description="Cleaved and reduced"
+                              code="H">
+               <umod:element symbol="H" number="2"/>
+               <umod:element symbol="C" number="3"/>
+               <umod:element symbol="O" number="1"/>
+               <umod:element symbol="S" number="1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="173.980921" avge_mass="174.2406" composition="H(6) C(6) O(2) S(2)">
+            <umod:element symbol="H" number="6"/>
+            <umod:element symbol="C" number="6"/>
+            <umod:element symbol="O" number="2"/>
+            <umod:element symbol="S" number="2"/>
+         </umod:delta>
+         <umod:alt_name>Also known as DSP</umod:alt_name>
+         <umod:xref>
+            <umod:text>8457554</umod:text>
+            <umod:source>PubMed PMID</umod:source>
+            <umod:url>http://www.ncbi.nlm.nih.gov/pubmed/8457554</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>322714</umod:text>
+            <umod:source>PubMed PMID</umod:source>
+            <umod:url>http://www.ncbi.nlm.nih.gov/pubmed/322714</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>1262347</umod:text>
+            <umod:source>PubMed PMID</umod:source>
+            <umod:url>http://www.ncbi.nlm.nih.gov/pubmed/1262347</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>ThermoFisher data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://tools.thermofisher.com/content/sfs/manuals/MAN0011280_DTSSP_DSP_UG.pdf</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:SMCC"
+                full_name="succinimidyl 4-[N-maleimidomethyl]cyclohexane-1-carboxylate"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-08-18 16:12:11"
+                date_time_modified="2018-09-13 11:44:54"
+                approved="0"
+                record_id="1895">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term" classification="Cross-link"
+                           spec_group="3">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="C" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:delta mono_mass="219.089543" avge_mass="219.2365" composition="H(13) C(12) N O(3)">
+            <umod:element symbol="H" number="13"/>
+            <umod:element symbol="C" number="12"/>
+            <umod:element symbol="N" number="1"/>
+            <umod:element symbol="O" number="3"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>ThermoFisher data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://assets.thermofisher.com/TFS-Assets/LSG/manuals/MAN0011295_SMCC_SulfoSMCC_UG.pdf</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:BS2G" full_name="bis[sulfosuccinimidyl] glutarate"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2017-09-05 16:31:19"
+                date_time_modified="2018-09-13 11:36:20"
+                approved="0"
+                record_id="1909">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term" classification="Cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="A">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-121.073893" avge_mass="-121.135" flag="false"
+                              composition="H(-11) C(-4) N(-1) O(-3)"
+                              description="Tris quenched monolink"
+                              code="T">
+               <umod:element symbol="H" number="-11"/>
+               <umod:element symbol="C" number="-4"/>
+               <umod:element symbol="N" number="-1"/>
+               <umod:element symbol="O" number="-3"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-17.026549" avge_mass="-17.0305" flag="false"
+                              composition="H(-3) N(-1)"
+                              description="Ammonia quenched monolink"
+                              code="A">
+               <umod:element symbol="H" number="-3"/>
+               <umod:element symbol="N" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:delta mono_mass="96.021129" avge_mass="96.0841" composition="H(4) C(5) O(2)">
+            <umod:element symbol="H" number="4"/>
+            <umod:element symbol="C" number="5"/>
+            <umod:element symbol="O" number="2"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>ThermoFisher data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://assets.thermofisher.com/TFS-Assets/LSG/manuals/MAN0011542_BS3_d0d4_BS2G_d0d3_UG.pdf</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:SDA" full_name="NHS-Diazirine crosslinker"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2018-08-29 15:34:39"
+                date_time_modified="2018-09-13 11:35:22"
+                approved="0"
+                record_id="2000">
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term" classification="Cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="-28.006148" avge_mass="-28.0134" flag="false" composition="N(-2)"
+                              description="diazirine monolink"
+                              code="A">
+               <umod:element symbol="N" number="-2"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="-28.006148" avge_mass="-28.0134" flag="false" composition="N(-2)"
+                              description="diazirine monolink"
+                              code="A">
+               <umod:element symbol="N" number="-2"/>
+            </umod:NeutralLoss>
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+            <umod:NeutralLoss mono_mass="-18.010565" avge_mass="-18.0153" flag="false"
+                              composition="H(-2) O(-1)"
+                              description="Water quenched monolink"
+                              code="W">
+               <umod:element symbol="H" number="-2"/>
+               <umod:element symbol="O" number="-1"/>
+            </umod:NeutralLoss>
+         </umod:specificity>
+         <umod:delta mono_mass="82.041865" avge_mass="82.1005" composition="H(6) C(5) O">
+            <umod:element symbol="H" number="6"/>
+            <umod:element symbol="C" number="5"/>
+            <umod:element symbol="O" number="1"/>
+         </umod:delta>
+         <umod:xref>
+            <umod:text>Anal. Chem., 2016, 88 (16), pp 8239–8247</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url>https://pubs.acs.org/doi/full/10.1021/acs.analchem.7b00046</umod:url>
+         </umod:xref>
+         <umod:xref>
+            <umod:text>ThermoFisher data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://www.thermofisher.com/order/catalog/product/26173</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:Disulfide" full_name="Intact disulfide bridge"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2019-10-31 10:45:21"
+                date_time_modified="2019-11-20 14:28:36"
+                approved="0"
+                record_id="2020">
+         <umod:specificity hidden="1" site="C" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:delta mono_mass="-2.01565" avge_mass="-2.0159" composition="H(-2)">
+            <umod:element symbol="H" number="-2"/>
+         </umod:delta>
+      </umod:mod>
+      <umod:mod title="Xlink:EDC" full_name="carbodiimide crosslinker"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2019-10-23 14:22:59"
+                date_time_modified="2019-11-20 14:27:24"
+                approved="0"
+                record_id="2018">
+         <umod:specificity hidden="1" site="C-term" position="Protein C-term" classification="Cross-link"
+                           spec_group="4">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="N-term" position="Protein N-term" classification="Cross-link"
+                           spec_group="3">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Cross-link"
+                           spec_group="2">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="E" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:specificity hidden="1" site="D" position="Anywhere" classification="Cross-link"
+                           spec_group="1">
+            <umod:NeutralLoss mono_mass="0" avge_mass="0" flag="false" composition="0"
+                              description="Intact cross-link"
+                              code="I"/>
+         </umod:specificity>
+         <umod:delta mono_mass="-18.010565" avge_mass="-18.0153" composition="H(-2) O(-1)">
+            <umod:element symbol="H" number="-2"/>
+            <umod:element symbol="O" number="-1"/>
+         </umod:delta>
+         <umod:alt_name>1-ethyl-3-(3-dimethylaminopropyl)carbodiimide hydrochloride</umod:alt_name>
+         <umod:xref>
+            <umod:text>Thermo data sheet</umod:text>
+            <umod:source>Misc. URL</umod:source>
+            <umod:url>https://www.thermofisher.com/order/catalog/product/22980</umod:url>
+         </umod:xref>
+      </umod:mod>
+      <umod:mod title="Xlink:KQisopeptide"
+                full_name="Isopeptide bond formation with loss of ammonia"
+                username_of_poster="unimod"
+                group_of_poster=""
+                date_time_posted="2020-05-19 16:29:45"
+                date_time_modified="2020-07-16 16:21:36"
+                approved="0"
+                record_id="2026">
+         <umod:specificity hidden="1" site="K" position="Anywhere" classification="Cross-link"
+                           spec_group="2"/>
+         <umod:specificity hidden="1" site="Q" position="Anywhere" classification="Cross-link"
+                           spec_group="1"/>
+         <umod:delta mono_mass="-17.026549" avge_mass="-17.0305" composition="H(-3) N(-1)">
+            <umod:element symbol="H" number="-3"/>
+            <umod:element symbol="N" number="-1"/>
+         </umod:delta>
+         <umod:alt_name>transglutamination</umod:alt_name>
+         <umod:xref>
+            <umod:text>Nutrients 2019, 11(10), 2263</umod:text>
+            <umod:source>Journal</umod:source>
+            <umod:url>http://dx.doi.org/10.3390/nu11102263</umod:url>
+         </umod:xref>
+      </umod:mod>
+   </umod:modifications>
+   <umod:amino_acids>
+      <umod:aa title="-" three_letter="" full_name="" mono_mass="0.0" avge_mass="0.0"/>
+      <umod:aa title="A" three_letter="Ala" full_name="Alanine" mono_mass="71.037114"
+               avge_mass="71.0779">
+         <umod:element symbol="H" number="5"/>
+         <umod:element symbol="C" number="3"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="R" three_letter="Arg" full_name="Arginine" mono_mass="156.101111"
+               avge_mass="156.1857">
+         <umod:element symbol="H" number="12"/>
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="N" number="4"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="N" three_letter="Asn" full_name="Asparagine" mono_mass="114.042927"
+               avge_mass="114.1026">
+         <umod:element symbol="H" number="6"/>
+         <umod:element symbol="C" number="4"/>
+         <umod:element symbol="N" number="2"/>
+         <umod:element symbol="O" number="2"/>
+      </umod:aa>
+      <umod:aa title="D" three_letter="Asp" full_name="Aspartic acid" mono_mass="115.026943"
+               avge_mass="115.0874">
+         <umod:element symbol="H" number="5"/>
+         <umod:element symbol="C" number="4"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="3"/>
+      </umod:aa>
+      <umod:aa title="C" three_letter="Cys" full_name="Cysteine" mono_mass="103.009185"
+               avge_mass="103.1429">
+         <umod:element symbol="H" number="5"/>
+         <umod:element symbol="C" number="3"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+         <umod:element symbol="S" number="1"/>
+      </umod:aa>
+      <umod:aa title="E" three_letter="Glu" full_name="Glutamic acid" mono_mass="129.042593"
+               avge_mass="129.114">
+         <umod:element symbol="H" number="7"/>
+         <umod:element symbol="C" number="5"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="3"/>
+      </umod:aa>
+      <umod:aa title="Q" three_letter="Gln" full_name="Glutamine" mono_mass="128.058578"
+               avge_mass="128.1292">
+         <umod:element symbol="H" number="8"/>
+         <umod:element symbol="C" number="5"/>
+         <umod:element symbol="N" number="2"/>
+         <umod:element symbol="O" number="2"/>
+      </umod:aa>
+      <umod:aa title="G" three_letter="Gly" full_name="Glycine" mono_mass="57.021464"
+               avge_mass="57.0513">
+         <umod:element symbol="H" number="3"/>
+         <umod:element symbol="C" number="2"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="H" three_letter="His" full_name="Histidine" mono_mass="137.058912"
+               avge_mass="137.1393">
+         <umod:element symbol="H" number="7"/>
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="N" number="3"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="I" three_letter="Ile" full_name="Isoleucine" mono_mass="113.084064"
+               avge_mass="113.1576">
+         <umod:element symbol="H" number="11"/>
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="L" three_letter="Leu" full_name="Leucine" mono_mass="113.084064"
+               avge_mass="113.1576">
+         <umod:element symbol="H" number="11"/>
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="K" three_letter="Lys" full_name="Lysine" mono_mass="128.094963"
+               avge_mass="128.1723">
+         <umod:element symbol="H" number="12"/>
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="N" number="2"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="M" three_letter="Met" full_name="Methionine" mono_mass="131.040485"
+               avge_mass="131.1961">
+         <umod:element symbol="H" number="9"/>
+         <umod:element symbol="C" number="5"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+         <umod:element symbol="S" number="1"/>
+      </umod:aa>
+      <umod:aa title="F" three_letter="Phe" full_name="Phenylalanine" mono_mass="147.068414"
+               avge_mass="147.1739">
+         <umod:element symbol="H" number="9"/>
+         <umod:element symbol="C" number="9"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="P" three_letter="Pro" full_name="Proline" mono_mass="97.052764"
+               avge_mass="97.1152">
+         <umod:element symbol="H" number="7"/>
+         <umod:element symbol="C" number="5"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="S" three_letter="Ser" full_name="Serine" mono_mass="87.032028"
+               avge_mass="87.0773">
+         <umod:element symbol="H" number="5"/>
+         <umod:element symbol="C" number="3"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="2"/>
+      </umod:aa>
+      <umod:aa title="T" three_letter="Thr" full_name="Threonine" mono_mass="101.047679"
+               avge_mass="101.1039">
+         <umod:element symbol="H" number="7"/>
+         <umod:element symbol="C" number="4"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="2"/>
+      </umod:aa>
+      <umod:aa title="W" three_letter="Trp" full_name="Tryptophan" mono_mass="186.079313"
+               avge_mass="186.2099">
+         <umod:element symbol="H" number="10"/>
+         <umod:element symbol="C" number="11"/>
+         <umod:element symbol="N" number="2"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="Y" three_letter="Tyr" full_name="Tyrosine" mono_mass="163.063329"
+               avge_mass="163.1733">
+         <umod:element symbol="H" number="9"/>
+         <umod:element symbol="C" number="9"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="2"/>
+      </umod:aa>
+      <umod:aa title="V" three_letter="Val" full_name="Valine" mono_mass="99.068414"
+               avge_mass="99.1311">
+         <umod:element symbol="H" number="9"/>
+         <umod:element symbol="C" number="5"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="N-term" three_letter="N-term" full_name="N-term" mono_mass="1.007825"
+               avge_mass="1.0079">
+         <umod:element symbol="H" number="1"/>
+      </umod:aa>
+      <umod:aa title="C-term" three_letter="C-term" full_name="C-term" mono_mass="17.00274"
+               avge_mass="17.0073">
+         <umod:element symbol="H" number="1"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:aa>
+      <umod:aa title="U" three_letter="Sec" full_name="Selenocysteine" mono_mass="150.953633"
+               avge_mass="150.0379">
+         <umod:element symbol="H" number="5"/>
+         <umod:element symbol="C" number="3"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="1"/>
+         <umod:element symbol="Se" number="1"/>
+      </umod:aa>
+   </umod:amino_acids>
+   <umod:mod_bricks>
+      <umod:brick title="-" full_name="" mono_mass="0" avge_mass="0"/>
+      <umod:brick title="H" full_name="Hydrogen" mono_mass="1.007825035" avge_mass="1.00794">
+         <umod:element symbol="H" number="1"/>
+      </umod:brick>
+      <umod:brick title="C" full_name="Carbon" mono_mass="12" avge_mass="12.0107">
+         <umod:element symbol="C" number="1"/>
+      </umod:brick>
+      <umod:brick title="N" full_name="Nitrogen" mono_mass="14.003074" avge_mass="14.0067">
+         <umod:element symbol="N" number="1"/>
+      </umod:brick>
+      <umod:brick title="O" full_name="Oxygen" mono_mass="15.99491463" avge_mass="15.9994">
+         <umod:element symbol="O" number="1"/>
+      </umod:brick>
+      <umod:brick title="P" full_name="Phosphorous" mono_mass="30.973762" avge_mass="30.973761">
+         <umod:element symbol="P" number="1"/>
+      </umod:brick>
+      <umod:brick title="S" full_name="Sulphur" mono_mass="31.9720707" avge_mass="32.065">
+         <umod:element symbol="S" number="1"/>
+      </umod:brick>
+      <umod:brick title="2H" full_name="Deuterium" mono_mass="2.014101779"
+                  avge_mass="2.014101779">
+         <umod:element symbol="2H" number="1"/>
+      </umod:brick>
+      <umod:brick title="18O" full_name="Oxygen 18" mono_mass="17.9991603" avge_mass="17.9991603">
+         <umod:element symbol="18O" number="1"/>
+      </umod:brick>
+      <umod:brick title="F" full_name="Fluorine" mono_mass="18.99840322" avge_mass="18.9984032">
+         <umod:element symbol="F" number="1"/>
+      </umod:brick>
+      <umod:brick title="Na" full_name="Sodium" mono_mass="22.9897677" avge_mass="22.98977">
+         <umod:element symbol="Na" number="1"/>
+      </umod:brick>
+      <umod:brick title="Se" full_name="Selenium" mono_mass="79.9165196" avge_mass="78.96">
+         <umod:element symbol="Se" number="1"/>
+      </umod:brick>
+      <umod:brick title="Hex" full_name="Hexose" mono_mass="162.0528235" avge_mass="162.1406">
+         <umod:element symbol="H" number="10"/>
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="O" number="5"/>
+      </umod:brick>
+      <umod:brick title="HexNAc" full_name="N-Acetyl Hexosamine" mono_mass="203.079372605"
+                  avge_mass="203.19252">
+         <umod:element symbol="C" number="8"/>
+         <umod:element symbol="H" number="13"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="5"/>
+      </umod:brick>
+      <umod:brick title="Ac" full_name="Acetate" mono_mass="42.0105647" avge_mass="42.03668">
+         <umod:element symbol="C" number="2"/>
+         <umod:element symbol="H" number="2"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:brick>
+      <umod:brick title="dHex" full_name="Deoxy-hexose" mono_mass="146.05790887"
+                  avge_mass="146.1412">
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="H" number="10"/>
+         <umod:element symbol="O" number="4"/>
+      </umod:brick>
+      <umod:brick title="HexA" full_name="Hexuronic acid" mono_mass="176.03208806"
+                  avge_mass="176.12412">
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="H" number="8"/>
+         <umod:element symbol="O" number="6"/>
+      </umod:brick>
+      <umod:brick title="Kdn" full_name="3-deoxy-d-glycero-D-galacto-nonulosonic acid"
+                  mono_mass="250.06886753"
+                  avge_mass="250.20265999999998">
+         <umod:element symbol="C" number="9"/>
+         <umod:element symbol="H" number="14"/>
+         <umod:element symbol="O" number="8"/>
+      </umod:brick>
+      <umod:brick title="Kdo" full_name="2-keto-3-deoxyoctulosonic acid" mono_mass="220.05830283"
+                  avge_mass="220.17668">
+         <umod:element symbol="C" number="8"/>
+         <umod:element symbol="H" number="12"/>
+         <umod:element symbol="O" number="7"/>
+      </umod:brick>
+      <umod:brick title="Me" full_name="Methyl" mono_mass="14.01565007" avge_mass="14.02658">
+         <umod:element symbol="C" number="1"/>
+         <umod:element symbol="H" number="2"/>
+      </umod:brick>
+      <umod:brick title="NeuAc" full_name="N-acetyl neuraminic acid" mono_mass="291.095416635"
+                  avge_mass="291.25458000000003">
+         <umod:element symbol="C" number="11"/>
+         <umod:element symbol="H" number="17"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="8"/>
+      </umod:brick>
+      <umod:brick title="NeuGc" full_name="N-glycoyl neuraminic acid"
+                  mono_mass="307.09033126500003"
+                  avge_mass="307.25398">
+         <umod:element symbol="C" number="11"/>
+         <umod:element symbol="H" number="17"/>
+         <umod:element symbol="N" number="1"/>
+         <umod:element symbol="O" number="9"/>
+      </umod:brick>
+      <umod:brick title="Water" full_name="Water" mono_mass="18.0105647" avge_mass="18.01528">
+         <umod:element symbol="H" number="2"/>
+         <umod:element symbol="O" number="1"/>
+      </umod:brick>
+      <umod:brick title="Phos" full_name="Phosphate" mono_mass="79.96633092500001"
+                  avge_mass="79.979901">
+         <umod:element symbol="H" number="1"/>
+         <umod:element symbol="P" number="1"/>
+         <umod:element symbol="O" number="3"/>
+      </umod:brick>
+      <umod:brick title="Sulf" full_name="Sulfate" mono_mass="79.95681459000001"
+                  avge_mass="80.0632">
+         <umod:element symbol="S" number="1"/>
+         <umod:element symbol="O" number="3"/>
+      </umod:brick>
+      <umod:brick title="Pent" full_name="Pentose" mono_mass="132.0422588" avge_mass="132.11462">
+         <umod:element symbol="C" number="5"/>
+         <umod:element symbol="H" number="8"/>
+         <umod:element symbol="O" number="4"/>
+      </umod:brick>
+      <umod:brick title="Li" full_name="Lithium" mono_mass="7.016003" avge_mass="6.941">
+         <umod:element symbol="Li" number="1"/>
+      </umod:brick>
+      <umod:brick title="13C" full_name="Carbon 13" mono_mass="13.00335483"
+                  avge_mass="13.00335483">
+         <umod:element symbol="13C" number="1"/>
+      </umod:brick>
+      <umod:brick title="15N" full_name="Nitrogen 15" mono_mass="15.00010897"
+                  avge_mass="15.00010897">
+         <umod:element symbol="15N" number="1"/>
+      </umod:brick>
+      <umod:brick title="Cl" full_name="Chlorine" mono_mass="34.96885272" avge_mass="35.453">
+         <umod:element symbol="Cl" number="1"/>
+      </umod:brick>
+      <umod:brick title="K" full_name="Potassium" mono_mass="38.9637074" avge_mass="39.0983">
+         <umod:element symbol="K" number="1"/>
+      </umod:brick>
+      <umod:brick title="Ca" full_name="Calcium" mono_mass="39.9625906" avge_mass="40.078">
+         <umod:element symbol="Ca" number="1"/>
+      </umod:brick>
+      <umod:brick title="Fe" full_name="Iron" mono_mass="55.9349393" avge_mass="55.845">
+         <umod:element symbol="Fe" number="1"/>
+      </umod:brick>
+      <umod:brick title="Ni" full_name="Nickel" mono_mass="57.9353462" avge_mass="58.6934">
+         <umod:element symbol="Ni" number="1"/>
+      </umod:brick>
+      <umod:brick title="Zn" full_name="Zinc" mono_mass="63.9291448" avge_mass="65.409">
+         <umod:element symbol="Zn" number="1"/>
+      </umod:brick>
+      <umod:brick title="Br" full_name="Bromine" mono_mass="78.9183361" avge_mass="79.904">
+         <umod:element symbol="Br" number="1"/>
+      </umod:brick>
+      <umod:brick title="Ag" full_name="Silver" mono_mass="106.905092" avge_mass="107.8682">
+         <umod:element symbol="Ag" number="1"/>
+      </umod:brick>
+      <umod:brick title="Hg" full_name="Mercury" mono_mass="201.970617" avge_mass="200.59">
+         <umod:element symbol="Hg" number="1"/>
+      </umod:brick>
+      <umod:brick title="Au" full_name="Gold" mono_mass="196.966543" avge_mass="196.96655">
+         <umod:element symbol="Au" number="1"/>
+      </umod:brick>
+      <umod:brick title="I" full_name="Iodine" mono_mass="126.904473" avge_mass="126.90447">
+         <umod:element symbol="I" number="1"/>
+      </umod:brick>
+      <umod:brick title="Mo" full_name="Molybdenum" mono_mass="97.9054073" avge_mass="95.94">
+         <umod:element symbol="Mo" number="1"/>
+      </umod:brick>
+      <umod:brick title="Cu" full_name="Copper" mono_mass="62.9295989" avge_mass="63.546">
+         <umod:element symbol="Cu" number="1"/>
+      </umod:brick>
+      <umod:brick title="Hep" full_name="Heptose" mono_mass="192.06338820000002"
+                  avge_mass="192.16658">
+         <umod:element symbol="C" number="7"/>
+         <umod:element symbol="H" number="12"/>
+         <umod:element symbol="O" number="6"/>
+      </umod:brick>
+      <umod:brick title="B" full_name="Boron" mono_mass="11.0093055" avge_mass="10.811">
+         <umod:element symbol="B" number="1"/>
+      </umod:brick>
+      <umod:brick title="As" full_name="Arsenic" mono_mass="74.9215942" avge_mass="74.9215942">
+         <umod:element symbol="As" number="1"/>
+      </umod:brick>
+      <umod:brick title="Cd" full_name="Cadmium" mono_mass="113.903357" avge_mass="112.411">
+         <umod:element symbol="Cd" number="1"/>
+      </umod:brick>
+      <umod:brick title="Cr" full_name="Chromium" mono_mass="51.9405098" avge_mass="51.9961">
+         <umod:element symbol="Cr" number="1"/>
+      </umod:brick>
+      <umod:brick title="Co" full_name="Cobalt" mono_mass="58.9331976" avge_mass="58.933195">
+         <umod:element symbol="Co" number="1"/>
+      </umod:brick>
+      <umod:brick title="Mn" full_name="Manganese" mono_mass="54.9380471" avge_mass="54.938045">
+         <umod:element symbol="Mn" number="1"/>
+      </umod:brick>
+      <umod:brick title="Mg" full_name="Magnesium" mono_mass="23.9850423" avge_mass="24.305">
+         <umod:element symbol="Mg" number="1"/>
+      </umod:brick>
+      <umod:brick title="Pd" full_name="Palladium" mono_mass="105.903478" avge_mass="106.42">
+         <umod:element symbol="Pd" number="1"/>
+      </umod:brick>
+      <umod:brick title="HexN" full_name="Hexosamine" mono_mass="161.068807905"
+                  avge_mass="161.15583999999998">
+         <umod:element symbol="H" number="11"/>
+         <umod:element symbol="C" number="6"/>
+         <umod:element symbol="O" number="4"/>
+         <umod:element symbol="N" number="1"/>
+      </umod:brick>
+      <umod:brick title="Al" full_name="Aluminium" mono_mass="26.9815386" avge_mass="26.9815386">
+         <umod:element symbol="Al" number="1"/>
+      </umod:brick>
+      <umod:brick title="Pt" full_name="Platinum" mono_mass="194.964766" avge_mass="195.084">
+         <umod:element symbol="Pt" number="1"/>
+      </umod:brick>
+      <umod:brick title="Ru" full_name="Ruthenium" mono_mass="101.9043485" avge_mass="101.07">
+         <umod:element symbol="Ru" number="1"/>
+      </umod:brick>
+      <umod:brick title="Si" full_name="Silicon" mono_mass="27.9769271" avge_mass="28.085">
+         <umod:element symbol="Si" number="1"/>
+      </umod:brick>
+   </umod:mod_bricks>
+</umod:unimod>


### PR DESCRIPTION
#### Rationale
unimod_xl.xml  contains master crosslink entries in Unimod. These entries are not included in the unimod.xml file. We want them to be available to Panorama Public submitters when try to assign Unimod Ids to their Skyline modifications.
unimod_xl.xml can be downloaded from https://www.unimod.org/xlink.html


