### PR TITLE
Make the "Public" column on the ExperimentAnnotations tableinfo an ExprColumn

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -387,6 +387,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
 
     private ExprColumn getIsPublicCol()
     {
+        // Panorama Public dataset folders do not inherit permissions from the parent folder, so we don't need to worry about that case.
         SQLFragment isPublicColSql = new SQLFragment(" (SELECT CASE WHEN EXISTS (SELECT 1 FROM ")
                 .append(CoreSchema.getInstance().getTableInfoRoleAssignments())
                 .append(" WHERE userId = ? AND role = ? AND resourceId = ").append(ExprColumn.STR_TABLE_ALIAS + ".Container").append(")")


### PR DESCRIPTION
#### Rationale
The "Public" column on the ExperimentAnnotations table tells us if a Panorama Public dataset is public or not.  We have been using the hasPermissions() method on the Container for this purpose. Make the column an ExprColumn so that it is filterable. 

