### PR TITLE
Fix "compare" function in "RunDownBean.getTopLeaks".

### DIFF
--- a/testresults/src/org/labkey/testresults/view/RunDownBean.java
+++ b/testresults/src/org/labkey/testresults/view/RunDownBean.java
@@ -91,10 +91,10 @@ public class RunDownBean extends TestsDataBean
             }
 
             double mem1 = getLeakMemoryAverage(l1);
-            double mem2 = getLeakHandleAverage(l2);
-            if (Double.compare(mem1, mem2) != 0)
+            double mem2 = getLeakMemoryAverage(l2);
+            if (Double.compare(mem2, mem1) != 0)
             {
-                return Double.compare(mem1, mem2);
+                return Double.compare(mem2, mem1);
             }
 
             double handle1 = getLeakHandleAverage(l1);

--- a/testresults/src/org/labkey/testresults/view/RunDownBean.java
+++ b/testresults/src/org/labkey/testresults/view/RunDownBean.java
@@ -92,14 +92,14 @@ public class RunDownBean extends TestsDataBean
 
             double mem1 = getLeakMemoryAverage(l1);
             double mem2 = getLeakHandleAverage(l2);
-            if (mem1 != mem2)
+            if (Double.compare(mem1, mem2) != 0)
             {
-                return (int)(mem2 - mem1);
+                return Double.compare(mem1, mem2);
             }
 
             double handle1 = getLeakHandleAverage(l1);
             double handle2 = getLeakHandleAverage(l2);
-            return (int)(handle2 - handle1);
+            return Double.compare(handle2, handle1);
         });
         Map<String, List<TestLeakDetail>> newMap = new LinkedHashMap<>();
         if (n == 0)


### PR DESCRIPTION
#### Rationale
The Skyline Nightly Test Results page displays an error if there are a lot of leaks reported because the "Compare" method implementation in "getTopLeaks" does not exhibit the "transitive" property. It returns "0" when two doubles differ by less than 1, which means there are cases where A == B, B==C, but A < C.