### PR TITLE
Return null to signal no support for listFilesQuery()

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileListener.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicFileListener.java
@@ -60,6 +60,6 @@ public class PanoramaPublicFileListener implements FileListener
     @Override
     public SQLFragment listFilesQuery()
     {
-        throw new UnsupportedOperationException("Not implemented");
+        return null;
     }
 }


### PR DESCRIPTION
#### Rationale
```
Stack Trace	
java.lang.UnsupportedOperationException: Not implemented
	at org.labkey.panoramapublic.PanoramaPublicFileListener.listFilesQuery(PanoramaPublicFileListener.java:63)
	at org.labkey.filecontent.FileContentServiceImpl.listFilesQuery(FileContentServiceImpl.java:1286)
	at org.labkey.core.query.FileListTableInfo$FileUnionTable.<init>(FileListTableInfo.java:62)
	at org.labkey.core.query.FileListTableInfo.createVirtualTable(FileListTableInfo.java:48)
	at org.labkey.core.query.FileListTableInfo.<init>(FileListTableInfo.java:42)
	at org.labkey.core.query.CoreQuerySchema.getFilesTable(CoreQuerySchema.java:662)
	at org.labkey.core.query.CoreQuerySchema.createTable(CoreQuerySchema.java:170)
	at org.labkey.api.query.UserSchema.createTable(UserSchema.java:333)
	at org.labkey.api.query.UserSchema._getTableOrQuery(UserSchema.java:274)
	at org.labkey.api.query.UserSchema.getTable(UserSchema.java:192)
	at org.labkey.api.query.UserSchema.getTable(UserSchema.java:172)
	at org.labkey.query.TableQueryDefinition.createTable(TableQueryDefinition.java:187)
	at org.labkey.query.QueryDefinitionImpl.getTable(QueryDefinitionImpl.java:565)
	at org.labkey.query.QueryDefinitionImpl.getTable(QueryDefinitionImpl.java:541)
	at org.labkey.api.query.UserSchema.createView(UserSchema.java:450)
	at org.labkey.core.query.CoreQuerySchema.createView(CoreQuerySchema.java:116)
	at org.labkey.core.admin.FileListAction.getView(FileListAction.java:41)
	at org.labkey.api.action.SimpleViewAction.handleRequest(SimpleViewAction.java:75)
```

#### Changes
* Implementations can return `null` to opt out