### PR TITLE
Avoid leaking static ModuleProperties from LincsModule

### DIFF
--- a/lincs/src/org/labkey/lincs/LincsModule.java
+++ b/lincs/src/org/labkey/lincs/LincsModule.java
@@ -45,9 +45,9 @@ import java.util.Set;
 public class LincsModule extends SpringModule
 {
     public static final String NAME = "LINCS";
+    public static final String PSP_JOB_NAME_SUFFIX = "PSP job name suffix";
     public final ModuleProperty PSP_JOB_NAME_SUFFIX_PROPERTY;
     public final ModuleProperty LINCS_ASSAY_TYPE_PROPERTY;
-    public static String PSP_JOB_NAME_SUFFIX = "PSP job name suffix";
 
     private static final String NO_SUFFIX = "";
 

--- a/lincs/src/org/labkey/lincs/LincsModule.java
+++ b/lincs/src/org/labkey/lincs/LincsModule.java
@@ -45,11 +45,11 @@ import java.util.Set;
 public class LincsModule extends SpringModule
 {
     public static final String NAME = "LINCS";
-    public static ModuleProperty PSP_JOB_NAME_SUFFIX_PROPERTY;
-    public static ModuleProperty LINCS_ASSAY_TYPE_PROPERTY;
+    public final ModuleProperty PSP_JOB_NAME_SUFFIX_PROPERTY;
+    public final ModuleProperty LINCS_ASSAY_TYPE_PROPERTY;
     public static String PSP_JOB_NAME_SUFFIX = "PSP job name suffix";
 
-    private static String NO_SUFFIX = "";
+    private static final String NO_SUFFIX = "";
 
     public LincsModule()
     {

--- a/lincs/src/org/labkey/lincs/psp/LincsPspTask.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspTask.java
@@ -3,6 +3,7 @@ package org.labkey.lincs.psp;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.AbstractTaskFactory;
 import org.labkey.api.pipeline.AbstractTaskFactorySettings;
 import org.labkey.api.pipeline.PipelineJob;
@@ -84,7 +85,8 @@ public class LincsPspTask extends PipelineJob.Task<LincsPspTask.Factory>
                 pspJob.setPipelineJobId(pipelineJobId);
             }
 
-            String suffix = LincsModule.PSP_JOB_NAME_SUFFIX_PROPERTY.getEffectiveValue(container);
+            String suffix = ModuleLoader.getInstance().getModule(LincsModule.class).PSP_JOB_NAME_SUFFIX_PROPERTY
+                    .getEffectiveValue(container);
 
             pspJob.setPspJobName(LincsPspUtil.getJobName(run, endpoint, suffix, log));
             log.info("PSP job name: " + pspJob.getPspJobName());


### PR DESCRIPTION
#### Rationale
`static` members of main Module classes can be caught by our leak checker if the module is excluded for some reason (such as via startup properties or due to database incompatibility).

#### Related Pull Requests
* N/A

#### Changes
* Avoid leaking static ModuleProperties from LincsModule
