### PR TITLE
Annotate `getFromSQL()` override to squelch IntelliJ warning

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
@@ -2,9 +2,11 @@
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
 <%@ page import="org.labkey.api.security.permissions.UpdatePermission" %>
 <%@ page import="org.labkey.api.settings.AppProps" %>
+<%@ page import="org.labkey.api.util.SafeToRender"%>
 <%@ page import="org.labkey.api.view.ActionURL"%>
-<%@ page import="org.labkey.api.view.HttpView"%>
+<%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page import="org.labkey.skylinetoolsstore.RatingManager" %>
 <%@ page import="org.labkey.skylinetoolsstore.SkylineToolsStoreController" %>
 <%@ page import="org.labkey.skylinetoolsstore.SkylineToolsStoreManager" %>
@@ -13,13 +15,11 @@
 <%@ page import="org.labkey.skylinetoolsstore.view.SkylineToolStoreUrls" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.ArrayList" %>
+<%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Iterator" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.labkey.api.util.SafeToRender" %>
-<%@ page import="java.util.Arrays" %>
-<%@ page import="org.labkey.api.view.template.ClientDependencies" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%!

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSchema.java
@@ -332,7 +332,7 @@ public class PanoramaPublicSchema extends UserSchema
             }
 
             @Override
-            public SQLFragment getFromSQL(String alias)
+            public @NotNull SQLFragment getFromSQL(String alias)
             {
                 // This table does not have a Container column so we will join it to the JournalExperiment and ExperimentAnnotations
                 // tables to filter by the Container of the copied experiment.


### PR DESCRIPTION
#### Rationale
Trivial change to eliminate a `TableInfo` warning