### PR TITLE
Issue 51100: SignUp link from admin console shows up to the troubleshooter but throws 403 while accessing it

### DIFF
--- a/signup/src/org/labkey/signup/SignUpModule.java
+++ b/signup/src/org/labkey/signup/SignUpModule.java
@@ -23,7 +23,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.security.UserManager;
-import org.labkey.api.security.permissions.ApplicationAdminPermission;
+import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.JspView;
@@ -98,7 +98,7 @@ public class SignUpModule extends DefaultModule
         UserManager.addUserListener(new SignUpListener());
 
         // Add a link in the admin console
-        AdminConsole.addLink(AdminConsole.SettingsLinkType.Configuration, "SignUp", SignUpController.getShowSignUpAdminUrl(), ApplicationAdminPermission.class);
+        AdminConsole.addLink(AdminConsole.SettingsLinkType.Configuration, "SignUp", SignUpController.getShowSignUpAdminUrl(), SiteAdminPermission.class);
     }
 
     @Override

--- a/signup/src/org/labkey/signup/SignUpModule.java
+++ b/signup/src/org/labkey/signup/SignUpModule.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.security.permissions.ApplicationAdminPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.JspView;
@@ -97,7 +98,7 @@ public class SignUpModule extends DefaultModule
         UserManager.addUserListener(new SignUpListener());
 
         // Add a link in the admin console
-        AdminConsole.addLink(AdminConsole.SettingsLinkType.Configuration, "SignUp", SignUpController.getShowSignUpAdminUrl());
+        AdminConsole.addLink(AdminConsole.SettingsLinkType.Configuration, "SignUp", SignUpController.getShowSignUpAdminUrl(), ApplicationAdminPermission.class);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51100
Only site admins should be able to see the "SignUp" link in the admin console

