### PR TITLE
Issue 51100: SignUp link from admin console shows up to the troubleshooter but throws 403 while accessing it

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -38,6 +38,7 @@ import org.labkey.api.action.SimpleErrorView;
 import org.labkey.api.action.SimpleStreamAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.admin.AdminUrls;
 import org.labkey.api.announcements.api.Announcement;
 import org.labkey.api.announcements.api.AnnouncementService;
 import org.labkey.api.attachments.Attachment;
@@ -344,7 +345,7 @@ public class PanoramaPublicController extends SpringActionController
         @Override
         public void addNavTrail(NavTree root)
         {
-            root.addChild("Panorama Public Admin Console");
+            PageFlowUtil.urlProvider(AdminUrls.class).addAdminNavTrail(root, "Panorama Public Admin Console", getClass(), getContainer());
         }
     }
 

--- a/signup/src/org/labkey/signup/SignUpModule.java
+++ b/signup/src/org/labkey/signup/SignUpModule.java
@@ -23,6 +23,7 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.module.DefaultModule;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.api.security.UserManager;
+import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.view.BaseWebPartFactory;
 import org.labkey.api.view.JspView;
@@ -97,7 +98,7 @@ public class SignUpModule extends DefaultModule
         UserManager.addUserListener(new SignUpListener());
 
         // Add a link in the admin console
-        AdminConsole.addLink(AdminConsole.SettingsLinkType.Configuration, "SignUp", SignUpController.getShowSignUpAdminUrl());
+        AdminConsole.addLink(AdminConsole.SettingsLinkType.Configuration, "SignUp", SignUpController.getShowSignUpAdminUrl(), SiteAdminPermission.class);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale

- Only site admins should be able to see the "SignUp" link in the admin console (https://www.labkey.org/home/Developer/issues/issues-details.view?issueId=51100)
- Fix failure in AdminConsoleNavigationTest due to missing Admin Console navtrails in PanoramaPublicAdminViewAction
