### PR TITLE
Avoid NPE sending email on dev machines

### DIFF
--- a/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
+++ b/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
@@ -2,6 +2,7 @@ package org.labkey.testresults;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.TableSelector;
@@ -14,6 +15,7 @@ import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.view.ActionURL;
 import org.labkey.testresults.model.BackgroundColor;
 import org.labkey.testresults.model.RunDetail;
@@ -335,15 +337,19 @@ public class SendTestResultsEmail implements org.quartz.Job
     @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException
     {
-        ValidEmail admin = null;
+        ValidEmail admin;
         try
         {
             admin = new ValidEmail(DEFAULT_EMAIL.ADMIN_EMAIL);
+            org.labkey.api.security.@Nullable User adminUser = UserManager.getUser(admin);
+            if (adminUser != null)
+            {
+                execute(MORNING_EMAIL, adminUser, DEFAULT_EMAIL.RECIPIENT);
+            }
         }
         catch (ValidEmail.InvalidEmailException e)
         {
-            e.printStackTrace();
+            throw UnexpectedException.wrap(e);
         }
-        execute(MORNING_EMAIL, UserManager.getUser(admin), DEFAULT_EMAIL.RECIPIENT);
     }
 }


### PR DESCRIPTION
#### Rationale
Every morning I find a message like this in my dev server's logs:

```
ERROR ErrorLogger              2024-08-23T08:04:55,932 uartzScheduler_Worker-10 : Job (TestResultsGroup.TestResultsEmailTrigger threw an exception.
org.quartz.SchedulerException: Job threw an unhandled exception.
	at org.quartz.core.JobRunShell.run(JobRunShell.java:213) [quartz-2.3.2.jar:?]
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) [quartz-2.3.2.jar:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.labkey.api.security.User.getEmail()" because "from" is null
	at org.labkey.testresults.SendTestResultsEmail.execute(SendTestResultsEmail.java:330) ~[testresults-24.9-SNAPSHOT.jar:?]
	at org.labkey.testresults.SendTestResultsEmail.execute(SendTestResultsEmail.java:347) ~[testresults-24.9-SNAPSHOT.jar:?]
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202) ~[quartz-2.3.2.jar:?]
	... 1 more
```

It's because I don't have a user account that the code assumes will be available.

#### Changes
* Simple null check to ensure the user exists before attempting to send email