### PR TITLE
Issue 50179: Exceptions logged by Radeox are difficult to track back

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -9270,7 +9270,7 @@ public class PanoramaPublicController extends SpringActionController
             {
                 List<String> validationErrors = new ArrayList<>();
 
-                HtmlString formattedMessage = WikiRenderingService.get().getFormattedHtml(WikiRendererType.MARKDOWN, form.getMessage());
+                HtmlString formattedMessage = WikiRenderingService.get().getFormattedHtml(WikiRendererType.MARKDOWN, form.getMessage(), null);
                 PageFlowUtil.validateHtml(formattedMessage.renderToString(), validationErrors, false);
                 if (!validationErrors.isEmpty())
                 {
@@ -9336,7 +9336,7 @@ public class PanoramaPublicController extends SpringActionController
                 example.setExperimentAnnotations(expAnnotations);
                 example.setTitle(title);
                 example.setMessage(messageBody.toString());
-                example.setMarkdownMessage(WikiRenderingService.get().getFormattedHtml(WikiRendererType.MARKDOWN, messageBody.toString()));
+                example.setMarkdownMessage(WikiRenderingService.get().getFormattedHtml(WikiRendererType.MARKDOWN, messageBody.toString(), "Panorama experiment " + experimentId));
                 return example;
             }
             return null;


### PR DESCRIPTION
#### Rationale
Radeox can spam our log files when it encounters non-fatal issues rendering wikis. In general, we want to capture a pointer back to the original source so that we can determine if there's a real problem. And in most cases, we want to relax the logging and simply render the original text even if Radeox can't interpret it.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5802

#### Changes
- Pass a `sourceDescription` through to Radeox so we can point to the wiki, announcement, etc where the source came from
- Update to a new Radeox version that quiets a little logging and adds the `sourceDescription` via the `RenderContext` in error messages to the offending wiki