### PR TITLE
Fix "compare" function in "RunDownBean.getTopLeaks". (#411)

### DIFF
--- a/testresults/src/org/labkey/testresults/view/RunDownBean.java
+++ b/testresults/src/org/labkey/testresults/view/RunDownBean.java
@@ -91,15 +91,15 @@ public class RunDownBean extends TestsDataBean
             }
 
             double mem1 = getLeakMemoryAverage(l1);
-            double mem2 = getLeakHandleAverage(l2);
-            if (mem1 != mem2)
+            double mem2 = getLeakMemoryAverage(l2);
+            if (Double.compare(mem2, mem1) != 0)
             {
-                return (int)(mem2 - mem1);
+                return Double.compare(mem2, mem1);
             }
 
             double handle1 = getLeakHandleAverage(l1);
             double handle2 = getLeakHandleAverage(l2);
-            return (int)(handle2 - handle1);
+            return Double.compare(handle2, handle1);
         });
         Map<String, List<TestLeakDetail>> newMap = new LinkedHashMap<>();
         if (n == 0)


### PR DESCRIPTION
Rationale
The Skyline Nightly Test Results page displays an error if there are a lot of leaks reported because the "Compare" method implementation in "getTopLeaks" does not return consistent results. This was because it was mistakenly comparing the wrong set of numbers (comparing number of bytes leaked in one test to handle leaks in the other test) such that Compare(a, b) was not necessarily the opposite of Compare(b, a).

Backport of https://github.com/LabKey/MacCossLabModules/pull/411