### PR TITLE
Import results directory too

### DIFF
--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
@@ -70,8 +70,11 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
 
         String webdavUrl = FileContentService.get().getWebDavUrl(parentDir, container, FileContentService.PathType.full);
         webdavUrl = StringUtils.stripEnd(webdavUrl, "/");
-
         String substitutedContent = template.replace("${quant_spectra_dir}", "quant_spectra_dir = '" + webdavUrl + "'");
+
+        String uploadUrl = FileContentService.get().getWebDavUrl(jobDir, container, FileContentService.PathType.full);
+        uploadUrl = StringUtils.stripEnd(uploadUrl, "/");
+        substitutedContent = substitutedContent.replace("${panorama.upload_url}", "panorama.upload_url = '" + uploadUrl + "'");
 
         Path substitutedFile = jobDir.resolve(configTemplate.getFileName());
         try (BufferedWriter writer = Files.newBufferedWriter(substitutedFile))
@@ -116,5 +119,4 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     {
         return null;
     }
-
 }

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
@@ -16,7 +16,7 @@ import java.util.Map;
 public class NextFlowProtocol extends AbstractFileAnalysisProtocol<NextFlowPipelineJob>
 {
     public static final List<FileType> INPUT_TYPES = List.of(
-            new FileType(".RAW"),
+            new FileType(".raw"),
             new FileType(".mzML"));
 
     public NextFlowProtocol()

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
@@ -80,6 +80,7 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
                 action.addInput(inputFile.toFile(), SPECTRA_INPUT_ROLE);
             }
             addOutputs(action, getJob().getLogFilePath().getParent().resolve("reports"));
+            addOutputs(action, getJob().getLogFilePath().getParent().resolve("results"));
             return new RecordedActionSet(action);
         }
         catch (IOException e)


### PR DESCRIPTION
#### Rationale
We get output files in both `results` and `reports`

#### Changes
* Pull more output files into the run
* Match normal RAW file extension casing
* Handle another substitution for an optional, separate upload URL for results