### PR TITLE
Delete MS2 GWT code. Switch to simple job launcher

### DIFF
--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
@@ -7,8 +7,6 @@ import org.labkey.api.pipeline.file.AbstractFileAnalysisProtocolFactory;
 import org.labkey.api.util.FileType;
 import org.labkey.api.view.ViewBackgroundInfo;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +60,7 @@ public class NextFlowProtocol extends AbstractFileAnalysisProtocol<NextFlowPipel
     }
 
     @Override
-    public NextFlowPipelineJob createPipelineJob(ViewBackgroundInfo info, PipeRoot root, List<File> filesInput, File fileParameters, @Nullable Map<String, String> variableMap) throws IOException
+    public NextFlowPipelineJob createPipelineJob(ViewBackgroundInfo info, PipeRoot root, List<Path> filesInput, Path fileParameters, @Nullable Map<String, String> variableMap)
     {
         throw new UnsupportedOperationException();
     }

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
@@ -1,6 +1,7 @@
 package org.labkey.nextflow.pipeline;
 
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.data.Container;
 import org.labkey.api.pipeline.PipeRoot;
 import org.labkey.api.pipeline.file.AbstractFileAnalysisProtocol;
 import org.labkey.api.pipeline.file.AbstractFileAnalysisProtocolFactory;
@@ -40,7 +41,7 @@ public class NextFlowProtocol extends AbstractFileAnalysisProtocol<NextFlowPipel
         return new AbstractFileAnalysisProtocolFactory<>()
         {
             @Override
-            public NextFlowProtocol createProtocolInstance(String name, String description, String xml)
+            public NextFlowProtocol createProtocolInstance(String name, String description, String xml, Container container)
             {
                 return new NextFlowProtocol();
             }


### PR DESCRIPTION
#### Rationale
We are removing GWT-based code, including the MS2 protocol designer and job launcher. We can use the simpler XML-based implementation from the pipeline module.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6163

#### Changes
* Update to match API improvements