### PR TITLE
Use the same thread pool as other Skyline doc imports

### DIFF
--- a/nextflow/webapp/WEB-INF/nextflow/nextflowContext.xml
+++ b/nextflow/webapp/WEB-INF/nextflow/nextflowContext.xml
@@ -30,6 +30,8 @@
     <!-- Experiment derived tasks -->
     <bean id="xarGeneratorNextFlow" class="org.labkey.api.exp.pipeline.XarGeneratorFactorySettings">
         <constructor-arg value="xarGeneratorNextFlow"/>
+        <!-- Import in the same thread pool as other Skyline doc imports -->
+        <property name="location" value="webserver-high-priority" />
     </bean>
 
     <!-- Tasks registered in experiment module -->


### PR DESCRIPTION
#### Rationale
Regular Skyline imports use the `webserver-high-priority` thread pool. We should do the same for importing the experiment record for the job, which will spend all of its time importing Skyline docs.

#### Changes
* Use the same pipeline location