### PR TITLE
Don't bother importing the XAR - we just care about Skyline docs

### DIFF
--- a/nextflow/webapp/WEB-INF/nextflow/nextflowContext.xml
+++ b/nextflow/webapp/WEB-INF/nextflow/nextflowContext.xml
@@ -19,23 +19,10 @@
                             <bean id="nextFlowPipelineTask" class="org.labkey.api.pipeline.TaskId">
                                 <constructor-arg><value type="java.lang.Class">org.labkey.nextflow.pipeline.NextFlowRunTask</value></constructor-arg>
                             </bean>
-                            <ref bean="xarGeneratorNextFlow"/>
                         </list>
                     </property>
                 </bean>
             </list>
         </property>
-    </bean>
-
-    <!-- Experiment derived tasks -->
-    <bean id="xarGeneratorNextFlow" class="org.labkey.api.exp.pipeline.XarGeneratorFactorySettings">
-        <constructor-arg value="xarGeneratorNextFlow"/>
-        <!-- Import in the same thread pool as other Skyline doc imports -->
-        <property name="location" value="webserver-high-priority" />
-    </bean>
-
-    <!-- Tasks registered in experiment module -->
-    <bean id="xarGeneratorId" class="org.labkey.api.pipeline.TaskId">
-        <constructor-arg><value type="java.lang.Class">org.labkey.api.exp.pipeline.XarGeneratorId</value></constructor-arg>
     </bean>
 </beans>


### PR DESCRIPTION
#### Rationale
Now that we're importing the Skyline files, we can get away without importing a XAR file for the whole run. This bypasses a potential multi-threading issue.

#### Changes
* Skip the XAR import