### PR TITLE
Fix permission check for launching NextFlow jobs

### DIFF
--- a/nextflow/src/org/labkey/nextflow/NextFlowController.java
+++ b/nextflow/src/org/labkey/nextflow/NextFlowController.java
@@ -20,6 +20,7 @@ import org.labkey.api.pipeline.browse.PipelinePathForm;
 import org.labkey.api.security.AdminConsoleAction;
 import org.labkey.api.security.RequiresPermission;
 import org.labkey.api.security.permissions.AdminOperationsPermission;
+import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.security.permissions.SiteAdminPermission;
 import org.labkey.api.util.Button;
@@ -246,7 +247,7 @@ public class NextFlowController extends SpringActionController
         private String configFile;
     }
 
-    @RequiresPermission(AdminOperationsPermission.class)
+    @RequiresPermission(InsertPermission.class)
     public class NextFlowRunAction extends FormViewAction<AnalyzeForm>
     {
         @Override


### PR DESCRIPTION
#### Rationale
A site admin is responsible for enabling NextFlow in a container, so insert permission is sufficient to launch jobs.

#### Changes
* Switch to `InsertPermission.class`