### PR TITLE
Write valid ProteomeXchange XML for datasets that do not have any Unimod modifications

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
@@ -391,7 +391,7 @@ public class PxXmlWriter extends PxWriter
          */
         Element mod_list = new Element("ModificationList");
         var mods = validationStatus.getModifications();
-        if(mods.size() == 0)
+        if(mods.size() == 0 || mods.stream().noneMatch(Modification::isValid))
         {
             mod_list.addChild(new CvParamElement("MS", "MS:1002864", "No PTMs are included in the dataset"));
         }


### PR DESCRIPTION
#### Rationale
`<ModificationList>` element in the XML submitted to ProteomeXchange requires at least one cvParam subelement. https://proteomecentral.proteomexchange.org/schemas/proteomeXchange-1.4.0.html#ModificationList.  We can add cvParam subelements only for modifications that have a Unimod Id.  XML generated for datasets that do not have any modifications with Unimod Ids fail validation on the ProteomeXchange server.


#### Changes
- If there are no modifications with Unimod Ids, write the following subelement.
`<cvParam cvRef="MS" accession="MS:1002864" name="No PTMs are included in the dataset"/>`
