### PR TITLE
Complete migration from srcURL and returnURL to returnUrl

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -2210,7 +2210,7 @@ public class PanoramaPublicController extends SpringActionController
         {
             ActionURL includeSubfoldersUrl = new ActionURL(IncludeSubFoldersInExperimentAction.class, _experimentAnnotations.getContainer())
                     .addParameter("id", expAnnotations.getId())
-                    .addReturnURL(skipSubfolderCheckUrl);
+                    .addReturnUrl(skipSubfolderCheckUrl);
             HtmlView confirmView = new HtmlView(DIV("Would you like to include data from the following subfolders in the experiment?",
                     getSubfolderListHtml(expAnnotations.getContainer(), allSubfolders),
                     new Button.ButtonBuilder("Include Subfolders and Continue").href(includeSubfoldersUrl).usePost().build(),
@@ -5381,7 +5381,7 @@ public class PanoramaPublicController extends SpringActionController
                 return getViewExperimentDetailsURL(_expAnnot.getId(), getContainer());
             }
             else
-                return form.getReturnURLHelper();
+                return form.getReturnUrlHelper();
         }
 
         @Override
@@ -5600,7 +5600,7 @@ public class PanoramaPublicController extends SpringActionController
                 vBox.addView(submissionList);
 
                 ActionURL url = PanoramaPublicController.getDataValidationCheckUrl(exptAnnotations.getId(), exptAnnotations.getContainer(), true);
-                url.addReturnURL(getViewExperimentDetailsURL(exptAnnotations.getId(), exptAnnotations.getContainer()));
+                url.addReturnUrl(getViewExperimentDetailsURL(exptAnnotations.getId(), exptAnnotations.getContainer()));
                 vBox.addView(new HtmlView(DIV(new Link.LinkBuilder("Validate for ProteomeXchange").href(url).build())));
 
                 result.addView(vBox);
@@ -7926,7 +7926,7 @@ public class PanoramaPublicController extends SpringActionController
                     .addParameter("modificationId", form.getModificationId());
             if (form.getReturnActionURL() != null)
             {
-                findMatchUrl.addReturnURL(form.getReturnActionURL());
+                findMatchUrl.addReturnUrl(form.getReturnActionURL());
             }
             if (form.getCancelActionURL() != null)
             {
@@ -7938,7 +7938,7 @@ public class PanoramaPublicController extends SpringActionController
                     .addParameter("modificationId", form.getModificationId());
             if (form.getReturnActionURL() != null)
             {
-                comboModUrl.addReturnURL(form.getReturnActionURL());
+                comboModUrl.addReturnUrl(form.getReturnActionURL());
             }
             if (form.getCancelActionURL() != null)
             {
@@ -9498,45 +9498,45 @@ public class PanoramaPublicController extends SpringActionController
         }
     }
 
-    public static ActionURL getEditExperimentDetailsURL(Container c, int experimentAnnotationsId, URLHelper returnURL)
+    public static ActionURL getEditExperimentDetailsURL(Container c, int experimentAnnotationsId, URLHelper returnUrl)
     {
         ActionURL url = new ActionURL(ShowUpdateExperimentAnnotationsAction.class, c);
         url.addParameter("id", experimentAnnotationsId);  // The name of the parameter is important. This is used to populate the TableViewForm (refreshFromDb())
-        if(returnURL != null)
+        if(returnUrl != null)
         {
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
         }
         return url;
     }
 
-    public static ActionURL getDeleteExperimentURL(Container c, int experimentAnnotationsId, URLHelper returnURL)
+    public static ActionURL getDeleteExperimentURL(Container c, int experimentAnnotationsId, URLHelper returnUrl)
     {
         ActionURL url = new ActionURL(DeleteExperimentAnnotationsAction.class, c);
         url.addParameter("id", experimentAnnotationsId);
-        if(returnURL != null)
+        if(returnUrl != null)
         {
-            url.addReturnURL(returnURL);
+            url.addReturnUrl(returnUrl);
         }
         return url;
     }
 
-    public static ActionURL getIncludeSubfoldersInExperimentURL(int experimentAnnotationsId, Container container, URLHelper returnURL)
+    public static ActionURL getIncludeSubfoldersInExperimentURL(int experimentAnnotationsId, Container container, URLHelper returnUrl)
     {
         ActionURL result = new ActionURL(IncludeSubFoldersInExperimentAction.class, container);
-        if (returnURL != null)
+        if (returnUrl != null)
         {
-            result.addReturnURL(returnURL);
+            result.addReturnUrl(returnUrl);
         }
         result.addParameter("id", experimentAnnotationsId);
         return result;
     }
 
-    public static ActionURL getExcludeSubfoldersInExperimentURL(int experimentAnnotationsId, Container container, URLHelper returnURL)
+    public static ActionURL getExcludeSubfoldersInExperimentURL(int experimentAnnotationsId, Container container, URLHelper returnUrl)
     {
         ActionURL result = new ActionURL(ExcludeSubFoldersInExperimentAction.class, container);
-        if (returnURL != null)
+        if (returnUrl != null)
         {
-            result.addReturnURL(returnURL);
+            result.addReturnUrl(returnUrl);
         }
         result.addParameter("id", experimentAnnotationsId);
         return result;

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -330,7 +330,7 @@ public class PanoramaPublicNotification
                     .addParameter("rowId", announcement.getRowId());
             ActionURL respondToMessageUrl = new ActionURL("announcements", "respond", announcementContainer)
                     .addParameter("parentId", announcement.getEntityId())
-                    .addReturnURL(viewMessageUrl);
+                    .addReturnUrl(viewMessageUrl);
             toReturn = toReturn.replaceAll(PLACEHOLDER_RESPOND_TO_MESSAGE_URL, respondToMessageUrl.getURIString());
         }
         if (toReturn.contains(PLACEHOLDER_MAKE_DATA_PUBLIC_URL))

--- a/panoramapublic/src/org/labkey/panoramapublic/query/CatalogEntryTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/CatalogEntryTableInfo.java
@@ -68,7 +68,7 @@ public class CatalogEntryTableInfo extends PanoramaPublicTable
                 Object viewCatalogEntryUrl = getValue(ctx);
                 if (viewCatalogEntryUrl instanceof ActionURL url)
                 {
-                    url.addReturnURL(ctx.getViewContext().getActionURL());
+                    url.addReturnUrl(ctx.getViewContext().getActionURL());
                     var viewButton = new Button.ButtonBuilder("View").href(url).build();
                     viewButton.appendTo(out);
                     return;

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -822,8 +822,8 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
                                                     : AppProps.getInstance().getContextPath() + "/PanoramaPublic/images/slideshow-icon.png";
                     String imageTitle = entry != null ? "View catalog entry" : "Add catalog entry";
                     ActionURL returnUrl = ctx.getViewContext().getActionURL().clone();
-                    ActionURL catalogEntryLink = entry != null ? PanoramaPublicController.getViewCatalogEntryUrl(expAnnot, entry).addReturnURL(returnUrl)
-                                                               : PanoramaPublicController.getAddCatalogEntryUrl(expAnnot).addReturnURL(returnUrl);
+                    ActionURL catalogEntryLink = entry != null ? PanoramaPublicController.getViewCatalogEntryUrl(expAnnot, entry).addReturnUrl(returnUrl)
+                                                               : PanoramaPublicController.getAddCatalogEntryUrl(expAnnot).addReturnUrl(returnUrl);
                     DOM.A(at(href, catalogEntryLink.getLocalURIString(), title, PageFlowUtil.filter(imageTitle)),
                             DOM.IMG(at(src, imageUrl, height, 22, width, 22)))
                             .appendTo(out);

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibInfoDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibInfoDisplayColumnFactory.java
@@ -51,18 +51,18 @@ public class EditLibInfoDisplayColumnFactory implements DisplayColumnFactory
                         }
                         if (experimentAnnotationsId != null)
                         {
-                            URLHelper returnUrl = ctx.getViewContext().getActionURL().getReturnURL();
+                            URLHelper returnUrl = ctx.getViewContext().getActionURL().getReturnUrl();
                             if (returnUrl == null)
                             {
                                 returnUrl = ctx.getViewContext().getActionURL();
                             }
                             ActionURL editUrl = PanoramaPublicController.getEditSpecLibInfoURL(experimentAnnotationsId, specLibId, specLibInfoId, ctx.getContainer());
-                            editUrl.addReturnURL(returnUrl);
+                            editUrl.addReturnUrl(returnUrl);
                             out.write(PageFlowUtil.link(specLibInfoId != null ? "Edit" : "Add").href(editUrl).toString());
                             if (specLibInfoId != null)
                             {
                                 ActionURL deleteUrl = PanoramaPublicController.getDeleteSpecLibInfoURL(experimentAnnotationsId, specLibInfoId, ctx.getContainer());
-                                deleteUrl.addReturnURL(returnUrl);
+                                deleteUrl.addReturnUrl(returnUrl);
                                 out.write(PageFlowUtil.link("Delete").href(deleteUrl).usePost("Are you sure you want to delete the spectral library information?").toString());
                             }
                             return;

--- a/panoramapublic/src/org/labkey/panoramapublic/view/PanoramaPublicRunListView.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/PanoramaPublicRunListView.java
@@ -51,8 +51,8 @@ public class PanoramaPublicRunListView extends ExperimentRunListView
         {
             String buttonText = _expAnnotations.isIncludeSubfolders() ? "Exclude Subfolders" : "Include Subfolders";
             ActionURL url = _expAnnotations.isIncludeSubfolders() ?
-                    PanoramaPublicController.getExcludeSubfoldersInExperimentURL(_expAnnotations.getId(), getViewContext().getContainer(), getReturnURL()) :
-                    PanoramaPublicController.getIncludeSubfoldersInExperimentURL(_expAnnotations.getId(), getViewContext().getContainer(), getReturnURL());
+                    PanoramaPublicController.getExcludeSubfoldersInExperimentURL(_expAnnotations.getId(), getViewContext().getContainer(), getReturnUrl()) :
+                    PanoramaPublicController.getIncludeSubfoldersInExperimentURL(_expAnnotations.getId(), getViewContext().getContainer(), getReturnUrl());
 
             ActionButton includeSubfoldersBtn = new ActionButton(buttonText, url);
             includeSubfoldersBtn.setDisplayPermission(InsertPermission.class);

--- a/panoramapublic/src/org/labkey/panoramapublic/view/combinationModInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/combinationModInfo.jsp
@@ -24,7 +24,7 @@
     var modification = bean.getModification();
     var modFormula = bean.getModFormula();
     var unimodMods = bean.getUnimodModificationList();
-    var returnUrl = form.getReturnURLHelper();
+    var returnUrl = form.getReturnUrlHelper();
     var cancelUrl = form.getCancelActionURL(PanoramaPublicController.getViewExperimentModificationsURL(form.getId(), getContainer()));
 %>
 <labkey:errors/>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/editSpecLibInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/editSpecLibInfo.jsp
@@ -20,7 +20,7 @@
     var bean = view.getModelBean();
     var form = bean.getForm();
     var library = bean.getLibrary();
-    var returnUrl = form.getReturnURLHelper(getContainer().getStartURL(getUser()));
+    var returnUrl = form.getReturnUrlHelper(getContainer().getStartURL(getUser()));
 %>
 
 <div style="margin-bottom:10px;">

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/CatalogEntryWebPart.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/CatalogEntryWebPart.java
@@ -55,7 +55,7 @@ public class CatalogEntryWebPart extends VBox
                             "Click the button below to add an entry.",
                     BR(),
                     new Button.ButtonBuilder("Add Catalog Entry").href(PanoramaPublicController.getAddCatalogEntryUrl(expAnnotations)
-                            .addReturnURL(getViewContext().getActionURL()))
+                            .addReturnUrl(getViewContext().getActionURL()))
             )));
         }
         else
@@ -68,17 +68,17 @@ public class CatalogEntryWebPart extends VBox
                         .build();
             }
 
-            URLHelper ctxReturnUrl = getViewContext().getActionURL().getReturnURL();
+            URLHelper ctxReturnUrl = getViewContext().getActionURL().getReturnUrl();
             ActionURL deleteUrl = new ActionURL(PanoramaPublicController.DeleteCatalogEntryAction.class, container)
                     .addParameter("id", expAnnotations.getId());
             if (ctxReturnUrl != null)
             {
-                deleteUrl.addReturnURL(ctxReturnUrl);
+                deleteUrl.addReturnUrl(ctxReturnUrl);
             }
 
             ActionURL editUrl = new ActionURL(PanoramaPublicController.EditCatalogEntryAction.class, container)
                     .addParameter("id", expAnnotations.getId())
-                    .addReturnURL(ctxReturnUrl != null ? ctxReturnUrl : getContextURLHelper());
+                    .addReturnUrl(ctxReturnUrl != null ? ctxReturnUrl : getContextURLHelper());
 
             CatalogEntrySettings settings = CatalogEntryManager.getCatalogEntrySettings();
             addView(new HtmlView(
@@ -130,7 +130,7 @@ public class CatalogEntryWebPart extends VBox
                                 .addParameter("id", expAnnotationsId)
                                 .addParameter("catalogEntryId", catalogEntryId)
                                 .addParameter("approve", approve)
-                                .addReturnURL(getContextURLHelper()))
+                                .addReturnUrl(getContextURLHelper()))
                 .usePost("Are you sure you want to " + btnTxt.toLowerCase() + " this catalog entry?");
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/pxActions.jsp
@@ -186,7 +186,7 @@
                     fieldLabel: "Update PX ID And Submission Type",
                     autoEl: {tag: 'a',
                         href: <%=q(urlFor(UpdatePxDetailsAction.class).addParameter("id", expAnnot.getId())
-                                 .addReturnURL(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(expAnnot.getContainer())))%>,
+                                 .addReturnUrl(PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(expAnnot.getContainer())))%>,
                         html: 'Update PX ID And Submission Type',
                         style: 'font-weight: bold'}
                 }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/unimodMatchInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/unimodMatchInfo.jsp
@@ -21,12 +21,12 @@
     var form = bean.getForm();
     var modification = bean.getModification();
     var unimodMatches = bean.getUnimodMatches();
-    var returnUrl = form.getReturnURLHelper();
+    var returnUrl = form.getReturnUrlHelper();
 
     var defineCombinationModUrl = new ActionURL(PanoramaPublicController.DefineCombinationModificationAction.class, getContainer())
             .addParameter("id", form.getId())
             .addParameter("modificationId", form.getModificationId())
-            .addReturnURL(form.getReturnActionURL(new ActionURL(PanoramaPublicController.ViewExperimentModifications.class, getContainer()).addParameter("id", form.getId())));
+            .addReturnUrl(form.getReturnActionURL(new ActionURL(PanoramaPublicController.ViewExperimentModifications.class, getContainer()).addParameter("id", form.getId())));
 %>
 <labkey:errors/>
 


### PR DESCRIPTION
#### Rationale
In 2021 we made a major push to use `returnUrl` consistently instead of `srcURL` or `returnURL`. We can finish the job.

Issue 7580: inconsistent use of returnUrl parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6407

#### Changes
- Change everything to `returnUrl` and get rid of code checking for old versions of the parameters