### PR TITLE
Remove unnecessary QueryWebPart renders

### DIFF
--- a/panoramapublic/resources/views/peptideSearchResults.html
+++ b/panoramapublic/resources/views/peptideSearchResults.html
@@ -17,5 +17,4 @@
             parameters: {peptideSequence : peptideSequence, exactMatch: exactMatch},
             containerFilter: LABKEY.Query.containerFilter.currentAndSubfolders
         });
-        wp.render();
 </script>

--- a/panoramapublic/resources/views/proteinSearchResults.html
+++ b/panoramapublic/resources/views/proteinSearchResults.html
@@ -17,5 +17,4 @@
             parameters: {proteinLabel : label, exactMatch: exactMatch},
             containerFilter: LABKEY.Query.containerFilter.currentAndSubfolders
         });
-        wp.render();
 </script>

--- a/panoramapublic/resources/views/smallMoleculeSearchResults.html
+++ b/panoramapublic/resources/views/smallMoleculeSearchResults.html
@@ -17,5 +17,4 @@
             parameters: {smallMolecule : smallMolecule, exactMatch: exactMatch},
             containerFilter: LABKEY.Query.containerFilter.currentAndSubfolders
         });
-        wp.render();
 </script>


### PR DESCRIPTION
#### Rationale
If `renderTo` is defined in a QueryWebPart config, it is automatically rendered. Calling `render()` explicitly will request the data again and re-render the grid. This is inefficient at best but I suspect this re-render is behind some intermittent failures we've been seeing on TeamCity.
I'm cleaning up all that I could find.

#### Related Pull Requests
* N/A

#### Changes
* Remove unnecessary QueryWebPart renders