### PR TITLE
Use PageFlowUtil.jsString to escape container path

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -162,7 +162,10 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
                                             .at(src, PageFlowUtil.staticResourceUrl("_images/plus.gif"))),
                                     HtmlString.NBSP)
                                     .appendTo(out);
-                            pageConfig.addHandler(spanId, "click", "viewExperimentDetails(this,'" + container.getPath() + "', '" + id + "','" + detailsPage + "')");
+                            pageConfig.addHandler(spanId, "click", "viewExperimentDetails(this,"
+                                    + PageFlowUtil.jsString(container.getPath())
+                                    + ", '" + id + "', "
+                                    + PageFlowUtil.jsString(detailsPage) + ")");
                         }
                         super.renderGridCellContents(ctx, out);
                     }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -164,7 +164,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
                                     .appendTo(out);
                             pageConfig.addHandler(spanId, "click", "viewExperimentDetails(this,"
                                     + PageFlowUtil.jsString(container.getPath())
-                                    + ", '" + id + "', "
+                                    + ", " + id + ", "
                                     + PageFlowUtil.jsString(detailsPage) + ")");
                         }
                         super.renderGridCellContents(ctx, out);

--- a/panoramapublic/webapp/PanoramaPublic/js/dropDownUtil.js
+++ b/panoramapublic/webapp/PanoramaPublic/js/dropDownUtil.js
@@ -69,7 +69,7 @@ viewExperimentDetails = function (obj, experimentContainer, id, detailsPageURL)
             let description = object.rows[rowNum][type];
             if(description.length > 500)
             {
-                results =  LABKEY.Utils.encodeHtml(description.substring(0,500)) +"<a href='"+ LABKEY.Utils.encodeHtml(detailsPageURL) +"'>...more.</a>";
+                results =  LABKEY.Utils.encodeHtml(description.substring(0,500)) +"<a href=\""+ LABKEY.Utils.encodeHtml(detailsPageURL) +"\">...more.</a>";
             }
             else {
                 results =  LABKEY.Utils.encodeHtml(description);

--- a/panoramapublic/webapp/PanoramaPublic/js/dropDownUtil.js
+++ b/panoramapublic/webapp/PanoramaPublic/js/dropDownUtil.js
@@ -66,12 +66,13 @@ viewExperimentDetails = function (obj, experimentContainer, id, detailsPageURL)
         var results;
         if(object.rows[rowNum][type] != null)
         {
-            if(object.rows[rowNum][type].length > 500)
+            let description = object.rows[rowNum][type];
+            if(description.length > 500)
             {
-                results = object.rows[rowNum][type].substring(0,500)+"<a href='"+detailsPageURL+"'>...more.</a>";
+                results =  LABKEY.Utils.encodeHtml(description.substring(0,500)) +"<a href='"+ LABKEY.Utils.encodeHtml(detailsPageURL) +"'>...more.</a>";
             }
             else {
-                results =object.rows[rowNum][type];
+                results =  LABKEY.Utils.encodeHtml(description);
             }
         }
         else {results = null;}


### PR DESCRIPTION
#### Rationale
Properly escape folder names passed as parameter to JS function, otherwise names containing single quotes cause JavaScript error. 
