### PR TITLE
Issue 52614: AssertionError deleting site group from its details page

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -441,8 +441,7 @@ public class PanoramaPublicController extends SpringActionController
                 Portal.saveParts(container, Portal.DEFAULT_PORTAL_PAGE_ID, newWebParts); // this will remove the TARGETED_MS_SETUP
 
                 // Add the permissions group
-                Group group = SecurityManager.createGroup(container, form.getGroupName());
-                writeToAuditLog(group);
+                Group group = SecurityManager.createGroup(container, form.getGroupName(), getUser());
 
                 // Assign project admin role to the group.
                 MutableSecurityPolicy policy = new MutableSecurityPolicy(SecurityPolicyManager.getPolicy(container));
@@ -460,13 +459,6 @@ public class PanoramaPublicController extends SpringActionController
             }
 
             return true;
-        }
-
-        private void writeToAuditLog(Group newGroup)
-        {
-            GroupAuditProvider.GroupAuditEvent event = new GroupAuditProvider.GroupAuditEvent(getContainer().getId(), "A new security group named " + newGroup.getName() + " was created by the " + PanoramaPublicModule.NAME + " module.");
-            event.setGroup(newGroup.getUserId());
-            AuditLogService.get().addEvent(getUser(), event);
         }
 
         @Override
@@ -564,7 +556,7 @@ public class PanoramaPublicController extends SpringActionController
                 JournalManager.delete(journal, getUser());
 
                 // Delete the permissions group created for this journal.
-                SecurityManager.deleteGroup(SecurityManager.getGroup(journal.getLabkeyGroupId()));
+                SecurityManager.deleteGroup(SecurityManager.getGroup(journal.getLabkeyGroupId()), getUser());
 
                 // Delete the project created for this journal.
                 ContainerManager.delete(journal.getProject(), getUser());

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
@@ -274,7 +274,7 @@ public class PanoramaPublicSymlinkManager
     private void addFileAuditEvent(Path link, Container container, User user, String comment)
     {
         FileSystemAuditProvider.FileSystemAuditEvent event =  new FileSystemAuditProvider.FileSystemAuditEvent(
-                container != null ? container.getId() : null, comment);
+                container != null ? container : null, comment);
         event.setFile(link.getFileName().toString());
         event.setDirectory(link.getParent().toString());
         AuditLogService.get().addEvent(user, event);


### PR DESCRIPTION
#### Rationale
Improve API for audit log events.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6469

#### Changes
* Use Container instead of String in event constructors
* Include User when making changes to groups so changes can be properly logged