### PR TITLE
Fix NPE when attempting to enable NextFlow in the root container

### DIFF
--- a/nextflow/src/org/labkey/nextflow/NextFlowController.java
+++ b/nextflow/src/org/labkey/nextflow/NextFlowController.java
@@ -198,7 +198,6 @@ public class NextFlowController extends SpringActionController
             if (getUser().hasSiteAdminPermission())
             {
                 Boolean status = NextFlowManager.get().getEnabledState(getContainer());
-                boolean inheritedStatus = NextFlowManager.get().isEnabled(getContainer().getParent());
 
                 return new HtmlView("Enable or Disable NextFlow",
                         FORM(at(method, "POST"),
@@ -209,7 +208,7 @@ public class NextFlowController extends SpringActionController
                                 DIV(INPUT(at(type, "radio", name, "enabled", value, "", (status == null ? checked : null), null)),
                                         getContainer().isRoot() ?
                                                 "Unset" :
-                                                "Inherited from " + getContainer().getParent().getPath() + " (currently " + (inheritedStatus ? "enabled" : "disabled") + ")"),
+                                                "Inherited from " + getContainer().getParent().getPath() + " (currently " + (NextFlowManager.get().isEnabled(getContainer().getParent()) ? "enabled" : "disabled") + ")"),
                                 new Button.ButtonBuilder("Save").submit(true).build(), " ",
                                 new Button.ButtonBuilder("Cancel").href(getContainer().getStartURL(getUser())).build()));
             }


### PR DESCRIPTION
#### Rationale
```
java.lang.NullPointerException: Cannot invoke "org.labkey.api.data.Container.getId()" because "c" is null
org.labkey.api.data.PropertyCache.getCacheKey(PropertyCache.java:59)
org.labkey.api.data.PropertyCache.getProperties(PropertyCache.java:37)
org.labkey.api.data.AbstractPropertyStore.getProperties(AbstractPropertyStore.java:58)
org.labkey.api.data.AbstractPropertyStore.getProperties(AbstractPropertyStore.java:73)
org.labkey.api.data.PropertyManager.getProperties(PropertyManager.java:96)
org.labkey.nextflow.NextFlowManager.isEnabled(NextFlowManager.java:104)
org.labkey.nextflow.NextFlowController$BeginAction.getView(NextFlowController.java:201)
org.labkey.nextflow.NextFlowController$BeginAction.getView(NextFlowController.java:186)
org.labkey.api.action.FormViewAction.handleRequest(FormViewAction.java:110)
```

#### Changes
* Don't try to get the inherited value when invoked at the root