### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/RatingManager.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/RatingManager.java
@@ -87,7 +87,7 @@ public class RatingManager
             for (SkylineTool tool : tools)
                 ratings.addAll(Arrays.asList(getRatingsByToolId(tool.getRowId())));
         }
-        return ratings.toArray(new Rating[ratings.size()]);
+        return ratings.toArray(new Rating[0]);
     }
 
     public boolean userLeftRating(String toolLsid, User user)

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -129,7 +129,7 @@ public class SkylineToolsStoreController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -460,7 +460,7 @@ public class SkylineToolsStoreController extends SpringActionController
                 ArrayList<User> toolOwnersUsers = parsedOwners.first;
                 ArrayList<String> toolOwnersInvalid = parsedOwners.second;
 
-                if (toolOwnersInvalid.size() > 0)
+                if (!toolOwnersInvalid.isEmpty())
                 {
                     getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "form",
                         UNKNOWN_USERS + StringUtils.join(toolOwnersInvalid, ", "));
@@ -607,7 +607,7 @@ public class SkylineToolsStoreController extends SpringActionController
             getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "sender", sender);
             getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "updatetarget", updateTargetString);
             getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "toolowners", toolOwners);
-            return new JspView("/org/labkey/skylinetoolsstore/view/SkylineToolsStoreUpload.jsp", null);
+            return new JspView<>("/org/labkey/skylinetoolsstore/view/SkylineToolsStoreUpload.jsp", null);
         }
 
         @Override
@@ -667,9 +667,9 @@ public class SkylineToolsStoreController extends SpringActionController
             final String ratingIdString = httpServletRequest.getParameter("ratingId");
             int ratingId;
             try {
-                ratingId = (ratingIdString != null && !ratingIdString.isEmpty()) ? Integer.parseInt(ratingIdString) : -1;;
+                ratingId = (ratingIdString != null && !ratingIdString.isEmpty()) ? Integer.parseInt(ratingIdString) : -1;
             } catch(Exception e) {
-                return new JspView("/org/labkey/skylinetoolsstore/view/SkylineRating.jsp", null);
+                return new JspView<>("/org/labkey/skylinetoolsstore/view/SkylineRating.jsp", null);
             }
             Rating rating = (ratingId < 0) ? null : RatingManager.get().getRatingById(ratingId);
             final SkylineTool tool = SkylineToolsStoreManager.get().getTool((toolId >= 0) ? toolId : rating.getToolId());
@@ -679,7 +679,7 @@ public class SkylineToolsStoreController extends SpringActionController
             try {
                 ratingValue = Integer.parseInt(ratingValueString);
             } catch(Exception e) {
-                return new JspView("/org/labkey/skylinetoolsstore/view/SkylineRating.jsp", null);
+                return new JspView<>("/org/labkey/skylinetoolsstore/view/SkylineRating.jsp", null);
             }
             final String ratingTitle = httpServletRequest.getParameter("title");
             final String review = httpServletRequest.getParameter("review");
@@ -701,7 +701,7 @@ public class SkylineToolsStoreController extends SpringActionController
                 getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "form",
                     NO_RATING);
             }
-            else if (review == null || review.length() == 0)
+            else if (review == null || review.isEmpty())
             {
                 getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "form",
                     NO_REVIEW);
@@ -748,7 +748,7 @@ public class SkylineToolsStoreController extends SpringActionController
             if (review != null)
                 getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "formReview", review);
 
-            return new JspView("/org/labkey/skylinetoolsstore/view/SkylineRating.jsp", null);
+            return new JspView<>("/org/labkey/skylinetoolsstore/view/SkylineRating.jsp", null);
         }
 
         @Override
@@ -813,7 +813,7 @@ public class SkylineToolsStoreController extends SpringActionController
             {
                 httpServletRequest.setAttribute(BindingResult.MODEL_KEY_PREFIX + "form", INVALID_TOOL_ID + " " + suppTargetString);
                 httpServletRequest.setAttribute(BindingResult.MODEL_KEY_PREFIX + "supptarget", suppTargetString);
-                return new JspView("/org/labkey/skylinetoolsstore/view/SkylineToolSupplementUpload.jsp", null);
+                return new JspView<>("/org/labkey/skylinetoolsstore/view/SkylineToolSupplementUpload.jsp", null);
             }
 
             SkylineTool tool = SkylineToolsStoreManager.get().getTool(suppTarget);
@@ -846,7 +846,7 @@ public class SkylineToolsStoreController extends SpringActionController
             }
 
             getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "supptarget", suppTargetString);
-            return new JspView("/org/labkey/skylinetoolsstore/view/SkylineToolSupplementUpload.jsp", null);
+            return new JspView<>("/org/labkey/skylinetoolsstore/view/SkylineToolSupplementUpload.jsp", null);
         }
 
         @Override
@@ -902,7 +902,7 @@ public class SkylineToolsStoreController extends SpringActionController
     }
 
     @RequiresLogin
-    public class DeleteAction extends FormHandlerAction<IdForm>
+    public static class DeleteAction extends FormHandlerAction<IdForm>
     {
         @Override
         public URLHelper getSuccessURL(IdForm idForm)
@@ -1002,7 +1002,7 @@ public class SkylineToolsStoreController extends SpringActionController
         @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
-            Integer id;
+            int id;
             try {
                 id = Integer.parseInt(httpServletRequest.getParameter("id"));
             }
@@ -1156,7 +1156,7 @@ public class SkylineToolsStoreController extends SpringActionController
 
     @RequiresNoPermission
     @ActionNames("downloadFile")
-    public class DownloadToolFileAction extends SimpleViewAction<DownloadFileForm> implements PermissionCheckable
+    public static class DownloadToolFileAction extends SimpleViewAction<DownloadFileForm> implements PermissionCheckable
     {
         @Override
         public ModelAndView getView(DownloadFileForm form, BindException errors) throws Exception
@@ -1243,8 +1243,7 @@ public class SkylineToolsStoreController extends SpringActionController
                 _tool = SkylineToolsStoreManager.get().getTool(toolId);
                 if (_tool == null)
                 {
-                    StringBuilder msg = new StringBuilder("Could not find tool ").append(" by Id ").append(toolId);
-                    errors.reject(SpringActionController.ERROR_MSG,  msg.toString());
+                    errors.reject(SpringActionController.ERROR_MSG, "Could not find tool " + " by Id " + toolId);
                     return new SimpleErrorView(errors);
                 }
             }
@@ -1396,7 +1395,7 @@ public class SkylineToolsStoreController extends SpringActionController
             getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "toolowners", toolOwners);
             getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "sender", sender);
             getViewContext().getRequest().setAttribute(BindingResult.MODEL_KEY_PREFIX + "updatetarget", updateTargetString);
-            return new JspView("/org/labkey/skylinetoolsstore/view/SkylineToolManageOwners.jsp", null);
+            return new JspView<>("/org/labkey/skylinetoolsstore/view/SkylineToolManageOwners.jsp", null);
         }
 
         @Override
@@ -1414,7 +1413,7 @@ public class SkylineToolsStoreController extends SpringActionController
         @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
-            final Integer id = Integer.parseInt(httpServletRequest.getParameter("id"));
+            final int id = Integer.parseInt(httpServletRequest.getParameter("id"));
 
             final SkylineTool tool = SkylineToolsStoreManager.get().getTool(id);
             if(tool == null)

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreModule.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreModule.java
@@ -32,7 +32,6 @@ import org.labkey.api.view.WebPartView;
 import org.labkey.skylinetoolsstore.model.SkylineTool;
 import org.labkey.skylinetoolsstore.view.SkylineToolsStoreWebPart;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -66,19 +65,21 @@ public class SkylineToolsStoreModule extends DefaultModule
     @NotNull
     protected Collection<WebPartFactory> createWebPartFactories()
     {
-        return new ArrayList<WebPartFactory>(
-            Arrays.asList(
-                    new BaseWebPartFactory("Skyline Tool Store") {
+        return new ArrayList<>(
+                Arrays.asList(
+                        new BaseWebPartFactory("Skyline Tool Store")
                         {
-                            addLegacyNames("Skyline Tools Store");
+                            {
+                                addLegacyNames("Skyline Tools Store");
+                            }
+
+                            @Override
+                            public WebPartView getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart) throws WebPartConfigurationException
+                            {
+                                return new SkylineToolsStoreWebPart();
+                            }
                         }
-                        @Override
-                        public WebPartView getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart) throws WebPartConfigurationException
-                        {
-                            return new SkylineToolsStoreWebPart();
-                        }
-                    }
-            ));
+                ));
     }
 
     @Override

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreSchema.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreSchema.java
@@ -20,8 +20,6 @@ import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.data.TableInfo;
 
-import java.lang.String;
-
 public class SkylineToolsStoreSchema
 {
     private static final SkylineToolsStoreSchema _instance = new SkylineToolsStoreSchema();

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/Rating.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/Rating.java
@@ -76,9 +76,8 @@ public class Rating extends Entity
 
     public boolean equals(Object obj)
     {
-        if (!(obj instanceof Rating))
+        if (!(obj instanceof Rating p))
             return false;
-        Rating p = (Rating)obj;
 
         return Objects.equals(_rating, p.getRating()) &&
                Objects.equals(_toolId, p.getToolId()) &&

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/SkylineTool.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/SkylineTool.java
@@ -177,9 +177,8 @@ public class SkylineTool extends Entity
 
     public boolean equals(Object obj)
     {
-        if (!(obj instanceof SkylineTool))
+        if (!(obj instanceof SkylineTool p))
             return false;
-        SkylineTool p = (SkylineTool)obj;
 
         return Objects.equals(_name, p.getName()) &&
                Objects.equals(_authors, p.getAuthors()) &&

--- a/lincs/src/org/labkey/lincs/DocImportListener.java
+++ b/lincs/src/org/labkey/lincs/DocImportListener.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 
 public class DocImportListener implements ExperimentListener, SkylineDocumentImportListener
 {
-    private static Logger _log = LogManager.getLogger(DocImportListener.class);
+    private static final Logger _log = LogManager.getLogger(DocImportListener.class);
 
     @Override
     public void beforeRunDelete(ExpProtocol protocol, ExpRun run, User user)

--- a/lincs/src/org/labkey/lincs/Gct.java
+++ b/lincs/src/org/labkey/lincs/Gct.java
@@ -32,11 +32,11 @@ import java.util.Set;
  */
 public class Gct
 {
-    private List<GctEntity> _probes;
-    private Map<String, Integer> _probeIndexMap;
-    private List<GctEntity> _replicates;
-    private Map<String, Integer> _replicateIndexMap;
-    private GctTable<ProbeReplicate> _areaRatios;
+    private final List<GctEntity> _probes;
+    private final Map<String, Integer> _probeIndexMap;
+    private final List<GctEntity> _replicates;
+    private final Map<String, Integer> _replicateIndexMap;
+    private final GctTable<ProbeReplicate> _areaRatios;
 
     private List<String> _probeAnnotationNames;
     private List<String> _replicateAnnotationNames;
@@ -164,7 +164,7 @@ public class Gct
         // Sort replicates by the value of the det_plate annotation, and then
         // by replicate name. For custom GCT, the replicate name is:
         // <exp_type>_<plate_number>_<original_replicate_name>
-        List<GctEntity> sortedReplicates = new ArrayList<GctEntity>(_replicates.size());
+        List<GctEntity> sortedReplicates = new ArrayList<>(_replicates.size());
         sortedReplicates.addAll(_replicates);
         sortedReplicates.sort((rep1, rep2) ->
         {
@@ -262,7 +262,7 @@ public class Gct
     public static class GctEntity
     {
         private final String _name;
-        private Map<String, String> _annotations;
+        private final Map<String, String> _annotations;
 
         public GctEntity(String name)
         {
@@ -418,7 +418,7 @@ public class Gct
 
     public interface GctKeyBuilder <T extends GctKey>
     {
-        public T build(String key1, String key2);
+        T build(String key1, String key2);
     }
 
     public static class ProbePlateKeyBuilder implements GctKeyBuilder<ProbeExpTypePlate>
@@ -446,7 +446,7 @@ public class Gct
 
     public static class GctTable <T extends GctKey>
     {
-        private Map<T, String> _map;
+        private final Map<T, String> _map;
         private List<String> _sortedKey2;
 
         public GctTable()

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -130,12 +130,12 @@ public class LincsController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/lincs/view/hello.jsp");
+            return new JspView<>("/org/labkey/lincs/view/hello.jsp");
         }
 
         @Override
@@ -216,7 +216,7 @@ public class LincsController extends SpringActionController
                 throw new ApiUsageException("Could not find report with name " + form.getReportName());
             }
 
-            if (!(report instanceof RReport))
+            if (!(report instanceof RReport rreport))
             {
                 throw new ApiUsageException("The specified report is not based upon an R script and therefore cannot be executed.");
             }
@@ -299,7 +299,6 @@ public class LincsController extends SpringActionController
                 propertyValues.addPropertyValue("param.isotope", "medium");
             }
             ctx.setBindPropertyValues(propertyValues);
-            RReport rreport = (RReport)report;
             try
             {
                 // Execute the script
@@ -388,7 +387,7 @@ public class LincsController extends SpringActionController
         {
             if(customGCTForm.getCustomGctBean() != null)
             {
-                JspView view = new JspView("/org/labkey/lincs/view/downloadCustomGCT.jsp", customGCTForm, errors);
+                JspView view = new JspView<>("/org/labkey/lincs/view/downloadCustomGCT.jsp", customGCTForm, errors);
                 view.setFrame(WebPartView.FrameType.PORTAL);
                 view.setTitle("Download Custom GCT");
                 return view;
@@ -405,7 +404,7 @@ public class LincsController extends SpringActionController
                 bean.setAnnotations(getReplicateAnnotationNameValues(getUser(), getContainer()));
 
 
-                JspView view = new JspView("/org/labkey/lincs/view/customGCTForm.jsp", bean, errors);
+                JspView view = new JspView<>("/org/labkey/lincs/view/customGCTForm.jsp", bean, errors);
                 view.setFrame(WebPartView.FrameType.PORTAL);
                 view.setTitle("Create Custom GCT");
                 return view;
@@ -424,7 +423,7 @@ public class LincsController extends SpringActionController
             {
                 return false;
             }
-            if(files.size() == 0)
+            if(files.isEmpty())
             {
                 errors.reject(ERROR_MSG, "No GCT files found in the folder for experiment type " + customGCTForm.getExperimentType());
                 return false;
@@ -712,7 +711,7 @@ public class LincsController extends SpringActionController
         }
     }
     @RequiresPermission(ReadPermission.class)
-    public class DownloadCustomGCTReportAction extends SimpleViewAction<DownloadCustomGCTReportForm>
+    public static class DownloadCustomGCTReportAction extends SimpleViewAction<DownloadCustomGCTReportForm>
     {
         @Override
         public ModelAndView getView(DownloadCustomGCTReportForm form, BindException errors) throws Exception
@@ -762,7 +761,7 @@ public class LincsController extends SpringActionController
             _fileName = fileName;
         }
     }
-    public class CustomGCTBean
+    public static class CustomGCTBean
     {
         private List<SelectedAnnotation> _annotations;
         private CustomGCTForm _form;
@@ -836,8 +835,8 @@ public class LincsController extends SpringActionController
 
     public static class SelectedAnnotation
     {
-        private LincsAnnotation _lincsAnnotation;
-        private Set<String> _values;
+        private final LincsAnnotation _lincsAnnotation;
+        private final Set<String> _values;
 
         private SelectedAnnotation(LincsAnnotation lincsAnnotation)
         {
@@ -891,7 +890,7 @@ public class LincsController extends SpringActionController
     private static final SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss");
 
     @RequiresPermission(ReadPermission.class)
-    public class GetLincsStatusAction extends ReadOnlyApiAction
+    public static class GetLincsStatusAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors)
@@ -1011,7 +1010,7 @@ public class LincsController extends SpringActionController
 
     @RequiresPermission(AdminPermission.class)
     @ActionNames("pspConfig")
-    public class ManageLincsClueCredentials extends FormViewAction<ClueCredentialsForm>
+    public static class ManageLincsClueCredentials extends FormViewAction<ClueCredentialsForm>
     {
         @Override
         public void validateCommand(ClueCredentialsForm target, Errors errors) {}
@@ -1090,7 +1089,7 @@ public class LincsController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class CromwellConfigAction extends FormViewAction<CromwellConfigForm>
+    public static class CromwellConfigAction extends FormViewAction<CromwellConfigForm>
     {
         @Override
         public void validateCommand(CromwellConfigForm target, Errors errors) {}
@@ -1307,7 +1306,7 @@ public class LincsController extends SpringActionController
                 Integer progress = ctx.get(FieldKey.fromParts("Progress"), Integer.class);
                 if(progress != null)
                 {
-                    String str = "";
+                    String str;
                     int i = progress.intValue();
                     str = (i&1) == 1 ? "L2 done " : "";
                     str += (i&2) == 2 ? "L3 done " : "";
@@ -1329,7 +1328,7 @@ public class LincsController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class LincsPspJobStatusAction extends SimpleViewAction<LincsPspJobForm>
+    public static class LincsPspJobStatusAction extends SimpleViewAction<LincsPspJobForm>
     {
         @Override
         public ModelAndView getView(LincsPspJobForm form, BindException errors)
@@ -1491,7 +1490,7 @@ public class LincsController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class SubmitPspJobAction extends FormHandlerAction<LincsPspJobForm>
+    public static class SubmitPspJobAction extends FormHandlerAction<LincsPspJobForm>
     {
         @Override
         public void validateCommand(LincsPspJobForm target, Errors errors)

--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -57,7 +57,7 @@ public class LincsDataTable extends FilteredTable
     public static final String PARENT_QUERY = "TargetedMSRunAndAnnotations";
     public static final String NAME = "LincsDataTable";
     public static final String PLATE_COL = "Plate";
-    private static Pattern plateRegex = Pattern.compile("^LINCS.*_(Plate[a-zA-Z0-9]*)_.*\\.sky\\.zip$");
+    private static final Pattern plateRegex = Pattern.compile("^LINCS.*_(Plate[a-zA-Z0-9]*)_.*\\.sky\\.zip$");
 
     public LincsDataTable(@NotNull TableInfo table, @NotNull UserSchema userSchema)
     {
@@ -122,19 +122,19 @@ public class LincsDataTable extends FilteredTable
 
         var level2Col = wrapColumn("Level 2", getRealTable().getColumn(FieldKey.fromParts("FileName")));
         addColumn(level2Col);
-        level2Col.setDisplayColumnFactory(colInfo -> new LincsDataTable.GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Two, gctDir, davUrl));
+        level2Col.setDisplayColumnFactory(colInfo -> new GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Two, gctDir, davUrl));
 
         var level3Col = wrapColumn("Level 3", getRealTable().getColumn(FieldKey.fromParts("FileName")));
         addColumn(level3Col);
-        level3Col.setDisplayColumnFactory(colInfo -> new LincsDataTable.GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Three, gctDir, davUrl));
+        level3Col.setDisplayColumnFactory(colInfo -> new GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Three, gctDir, davUrl));
 
         var level4Col = wrapColumn("Level 4", getRealTable().getColumn(FieldKey.fromParts("FileName")));
         addColumn(level4Col);
-        level4Col.setDisplayColumnFactory(colInfo -> new LincsDataTable.GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Four, gctDir, davUrl));
+        level4Col.setDisplayColumnFactory(colInfo -> new GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Four, gctDir, davUrl));
 
         var cfgCol = wrapColumn("Config", getRealTable().getColumn(FieldKey.fromParts("FileName")));
         addColumn(cfgCol);
-        cfgCol.setDisplayColumnFactory(colInfo -> new LincsDataTable.GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Config, gctDir, davUrl));
+        cfgCol.setDisplayColumnFactory(colInfo -> new GctColumnPSP(colInfo, assayType, LincsModule.LincsLevel.Config, gctDir, davUrl));
 
         var pspJobCol = wrapColumn("PSP Job Status", getRealTable().getColumn(FieldKey.fromParts("FileName")));
         addColumn(pspJobCol);
@@ -223,12 +223,12 @@ public class LincsDataTable extends FilteredTable
             return FileUtil.getBaseName(fileName, 1);
     }
 
-    public class GctColumnPSP extends DataColumn
+    public static class GctColumnPSP extends DataColumn
     {
-        private LincsModule.LincsAssay assayType;
-        private LincsModule.LincsLevel level;
-        private Path gctDir;
-        private String davUrl;
+        private final LincsModule.LincsAssay assayType;
+        private final LincsModule.LincsLevel level;
+        private final Path gctDir;
+        private final String davUrl;
 
         public GctColumnPSP(ColumnInfo col, LincsModule.LincsAssay assayType, LincsModule.LincsLevel level, Path gctDir, String davUrl)
         {

--- a/lincs/src/org/labkey/lincs/LincsManager.java
+++ b/lincs/src/org/labkey/lincs/LincsManager.java
@@ -49,7 +49,7 @@ public class LincsManager
 {
     private static final LincsManager _instance = new LincsManager();
 
-    private static Logger _log = LogManager.getLogger(LincsManager.class);
+    private static final Logger _log = LogManager.getLogger(LincsManager.class);
 
     private LincsManager()
     {

--- a/lincs/src/org/labkey/lincs/LincsSchema.java
+++ b/lincs/src/org/labkey/lincs/LincsSchema.java
@@ -117,7 +117,7 @@ public class LincsSchema extends UserSchema
         }
         if (getTableNames().contains(name))
         {
-            SimpleUserSchema.SimpleTable<LincsSchema> result = new SimpleUserSchema.SimpleTable<LincsSchema>(this, getSchema().getTable(name), cf)
+            SimpleUserSchema.SimpleTable<LincsSchema> result = new SimpleUserSchema.SimpleTable<>(this, getSchema().getTable(name), cf)
             {
                 @Override
                 public boolean hasPermission(@NotNull UserPrincipal user, @NotNull Class<? extends Permission> perm)

--- a/lincs/src/org/labkey/lincs/cromwell/CromwellGctTask.java
+++ b/lincs/src/org/labkey/lincs/cromwell/CromwellGctTask.java
@@ -19,7 +19,6 @@ import org.labkey.lincs.LincsController;
 import org.labkey.lincs.LincsModule;
 import org.labkey.lincs.psp.LincsPspJobSupport;
 
-import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
@@ -16,10 +16,10 @@ import org.labkey.lincs.LincsModule;
 
 public class LincsPspPipelineJob extends PipelineJob implements LincsPspJobSupport
 {
-    private ITargetedMSRun _run;
-    private String _description;
-    private LincsPspJob _pspJob;
-    private LincsPspJob _oldPspJob;
+    private final ITargetedMSRun _run;
+    private final String _description;
+    private final LincsPspJob _pspJob;
+    private final LincsPspJob _oldPspJob;
 
     @JsonCreator
     protected LincsPspPipelineJob(@JsonProperty("_run") ITargetedMSRun run, @JsonProperty("_pspJob") LincsPspJob pspJob,

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -421,7 +421,7 @@ public class PanoramaPublicController extends SpringActionController
                     errors.addError(new LabKeyError("Project name " + form.getProjectName() + " already exists."));
                 }
             }
-            else if(error.length() > 0)
+            else if(!error.isEmpty())
             {
                 errors.addError(new LabKeyError(error.toString()));
             }
@@ -569,7 +569,7 @@ public class PanoramaPublicController extends SpringActionController
                 return false;
             }
 
-            if(JournalManager.getExperimentsForJournal(journal.getId()).size() > 0)
+            if(!JournalManager.getExperimentsForJournal(journal.getId()).isEmpty())
             {
                 // Do not delete the journal via the Admin console link if it contains any published data.
                 // The journal project can still be deleted from the LabKey UI, however.
@@ -1388,7 +1388,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class DownloadPanoramaLogoForBlueskyAction extends BaseDownloadAction<AttachmentForm>
+    public static class DownloadPanoramaLogoForBlueskyAction extends BaseDownloadAction<AttachmentForm>
     {
         @Nullable
         @Override
@@ -1412,7 +1412,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class DeletePanoramaLogoForBlueskyAction extends FormHandlerAction
+    public static class DeletePanoramaLogoForBlueskyAction extends FormHandlerAction<Object>
     {
         @Override
         public void validateCommand(Object target, Errors errors)
@@ -2213,12 +2213,12 @@ public class PanoramaPublicController extends SpringActionController
             {
                 List<Container> allSubfolders = getAllSubfolders(_experimentAnnotations.getContainer());
                 List<Container> hiddenFolders = getHiddenFolders(allSubfolders, getUser());
-                if(!_experimentAnnotations.isIncludeSubfolders() && allSubfolders.size() > 0)
+                if(!_experimentAnnotations.isIncludeSubfolders() && !allSubfolders.isEmpty())
                 {
                     // Experiment is not configured to include subfolders but there are subfolders.
                     ActionURL skipSubfolderCheckUrl = getViewContext().getActionURL().clone();
                     skipSubfolderCheckUrl.addParameter("doSubfolderCheck", "false");
-                    if(hiddenFolders.size() == 0)
+                    if(hiddenFolders.isEmpty())
                     {
                         // Return a view to make the user confirm their intention to include / exclude subfolders from the experiment.
                         return getConfirmIncludeSubfoldersView(_experimentAnnotations, allSubfolders, skipSubfolderCheckUrl);
@@ -2231,7 +2231,7 @@ public class PanoramaPublicController extends SpringActionController
                         return getNoPermsInSubfoldersView(_experimentAnnotations, hiddenFolders, skipSubfolderCheckUrl);
                     }
                 }
-                else if(_experimentAnnotations.isIncludeSubfolders() && hiddenFolders.size() > 0)
+                else if(_experimentAnnotations.isIncludeSubfolders() && !hiddenFolders.isEmpty())
                 {
                     // Experiment is already configured to include subfolders but there are subfolders where this user does
                     // not have read permissions.
@@ -2261,7 +2261,7 @@ public class PanoramaPublicController extends SpringActionController
             // This may be OK for template documents that do not have any imported chromatograms but they should be rare on Panorama.
             // Most documents should have chromatogram data (.skyd files in the .sky.zip archive)
             List<ITargetedMSRun> notSkyZipRuns = getNotSkyZipRuns(_experimentAnnotations);
-            if (notSkyZipRuns.size() > 0)
+            if (!notSkyZipRuns.isEmpty())
             {
                 return new HtmlView(DIV("The following Skyline documents are incomplete. " +
                                 "Please upload the complete Skyline ZIP archive (.sky.zip file) by using the 'Upload to Panorama' button or menu in Skyline.",
@@ -2536,7 +2536,7 @@ public class PanoramaPublicController extends SpringActionController
 
         @NotNull ModelAndView getMissingMetadataView(MissingMetadataBean missingMetadataBean, String viewTitle, BindException errors)
         {
-            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/missingMetadata.jsp", missingMetadataBean, errors);
+            JspView view = new JspView<>("/org/labkey/panoramapublic/view/publish/missingMetadata.jsp", missingMetadataBean, errors);
             view.setFrame(WebPartView.FrameType.PORTAL);
             view.setTitle(viewTitle);
             return view;
@@ -2565,7 +2565,7 @@ public class PanoramaPublicController extends SpringActionController
             form.setId(exptAnnotations.getId());
             form.setShortAccessUrl(generateRandomUrl(RANDOM_URL_SIZE));
             List<Journal> journals = JournalManager.getJournals();
-            if (journals.size() == 0)
+            if (journals.isEmpty())
             {
                 throw new NotFoundException("Could not find any journals.");
             }
@@ -2606,7 +2606,7 @@ public class PanoramaPublicController extends SpringActionController
             bean.setJournal(_journal);
             bean.setForm(form);
 
-            JspView<PanoramaPublicRequest> confirmView = new JspView<PanoramaPublicRequest>("/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp", bean, errors);
+            JspView<PanoramaPublicRequest> confirmView = new JspView<>("/org/labkey/panoramapublic/view/publish/confirmSubmit.jsp", bean, errors);
             confirmView.setTitle(getConfirmViewTitle());
             return confirmView;
         }
@@ -3007,7 +3007,7 @@ public class PanoramaPublicController extends SpringActionController
             _experimentAnnotations = experimentAnnotations;
             JournalSubmission js = SubmissionManager.getJournalSubmission(experimentAnnotations.getId(), form.getJournalId(), experimentAnnotations.getContainer());
             // "Permanent Link" field in the form should not be editable if one or more copies of this experiment already exist in the journal project
-            _accessUrlEditable = js == null ? true : js.getCopiedSubmissions().size() == 0;
+            _accessUrlEditable = js == null ? true : js.getCopiedSubmissions().isEmpty();
         }
 
         public PublishExperimentForm getForm()
@@ -3188,6 +3188,7 @@ public class PanoramaPublicController extends SpringActionController
             _shortCopyUrl = shortCopyUrl;
         }
 
+        @Override
         public ExperimentAnnotations lookupExperiment()
         {
             return ExperimentAnnotationsManager.get(getId());
@@ -3450,7 +3451,7 @@ public class PanoramaPublicController extends SpringActionController
         public void validateCommand(PxDataValidationForm form, Errors errors)
         {
             var validationJobs = PipelineService.get().getActivePipelineJobs(getUser(), getContainer(), PxValidationPipelineProvider.NAME);
-            if (validationJobs.size() > 0)
+            if (!validationJobs.isEmpty())
             {
                 var job = validationJobs.size() > 1 ? "jobs" : "job";
                 errors.reject(ERROR_MSG, String.format("%d data validation %s %s already running in this folder. Wait for the running %s to finish, or cancel the %s and try again.",
@@ -3822,6 +3823,7 @@ public class PanoramaPublicController extends SpringActionController
             form.setUpdate(true);
         }
 
+        @Override
         String getFormViewTitle(String journalName)
         {
             return "Update Submission Request to " + journalName;
@@ -3889,6 +3891,7 @@ public class PanoramaPublicController extends SpringActionController
 
         abstract Submission getSubmission();
 
+        @Override
         boolean validateGetRequest(PublishExperimentForm form, BindException errors)
         {
             return super.validateGetRequest(form, errors) && foundValidSubmissionRequest(form, errors);
@@ -3912,6 +3915,7 @@ public class PanoramaPublicController extends SpringActionController
             return true;
         }
 
+        @Override
         protected void checkForValidation(ExperimentAnnotations experimentAnnotations, PublishExperimentForm form)
         {
             if (form.getValidationId() == null)
@@ -3989,7 +3993,7 @@ public class PanoramaPublicController extends SpringActionController
         {
             if (foundValidSubmissionRequest(form, errors))
             {
-                super.validateForm(form, errors);;
+                super.validateForm(form, errors);
             }
         }
     }
@@ -4164,12 +4168,14 @@ public class PanoramaPublicController extends SpringActionController
             return true;
         }
 
+        @Override
         void populateForm(PublishExperimentForm form, ExperimentAnnotations exptAnnotations)
         {
             super.populateForm(form, exptAnnotations);
             form.setResubmit(true);
         }
 
+        @Override
         String getFormViewTitle(String journalName)
         {
             return "Resubmit Request to " + journalName;
@@ -4396,7 +4402,7 @@ public class PanoramaPublicController extends SpringActionController
         {
             Set<Container> expContainers = expAnnot.isIncludeSubfolders() ? ContainerManager.getAllChildren(expAnnot.getContainer())
                     : Collections.singleton(expAnnot.getContainer());
-            return expContainers.stream().anyMatch(container -> service.getRuns(container).size() > 0);
+            return expContainers.stream().anyMatch(container -> !service.getRuns(container).isEmpty());
         }
         return false;
     }
@@ -5215,7 +5221,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class AssignDoiAction extends DoiAction
+    public static class AssignDoiAction extends DoiAction
     {
         private Doi _doi;
 
@@ -5462,7 +5468,7 @@ public class PanoramaPublicController extends SpringActionController
     public static class PostToBlueskyOptionsAction extends SimpleViewAction<ExperimentIdForm>
     {
         @Override
-        public ModelAndView getView(ExperimentIdForm form, BindException errors) throws Exception
+        public ModelAndView getView(ExperimentIdForm form, BindException errors)
         {
             return new HtmlView(
                     DIV(
@@ -5709,9 +5715,9 @@ public class PanoramaPublicController extends SpringActionController
             view.setTitle(TargetedMSExperimentWebPart.WEB_PART_NAME);
             view.setInitialValue(SUBMITTER, getUser().getUserId());
             List<PsiInstrumentParser.PsiInstrument> instruments = ExperimentAnnotationsManager.getContainerInstruments(getContainer(), getUser());
-            if (instruments.size() > 0)
+            if (!instruments.isEmpty())
             {
-                view.setInitialValue("instrument", StringUtils.join(instruments.stream().map(i -> i.getName()).collect(Collectors.toList()), ","));
+                view.setInitialValue("instrument", StringUtils.join(instruments.stream().map(PsiInstrumentParser.PsiInstrument::getName).collect(Collectors.toList()), ","));
             }
             return view;
         }
@@ -5739,7 +5745,7 @@ public class PanoramaPublicController extends SpringActionController
             // We are here either because handlePost failed or there were errors in the form (e.g. missing required values)
             ExperimentAnnotations expAnnot = form.getBean();
 
-            if (expAnnot.getTitle() == null || expAnnot.getTitle().trim().length() == 0)
+            if (expAnnot.getTitle() == null || expAnnot.getTitle().trim().isEmpty())
             {
                 errors.reject(ERROR_MSG, "You must specify a title for the experiment");
             }
@@ -5986,7 +5992,7 @@ public class PanoramaPublicController extends SpringActionController
             HtmlView subfoldersView = null;
             if(exptAnnotations.isIncludeSubfolders())
             {
-                if(children.size() == 0)
+                if(children.isEmpty())
                 {
                    subfoldersView = new HtmlView(DIV(cl("labkey-error"),"Experiment is configured to include subfolders but no subfolders were found.",
                            BR(),
@@ -5999,7 +6005,7 @@ public class PanoramaPublicController extends SpringActionController
                             getExcludeSubfoldersButton(exptAnnotations).build()));
                 }
             }
-            else if(children.size() > 0)
+            else if(!children.isEmpty())
             {
                 subfoldersView = new HtmlView(DIV("This folder contains " + children.size() + " subfolders. " +
                                 "Data from the subfolders is not included in this experiment. Click the button below to include subfolders.",
@@ -6020,7 +6026,7 @@ public class PanoramaPublicController extends SpringActionController
             // List of runs in the experiment.
             PanoramaPublicRunListView runListView = PanoramaPublicRunListView.createView(getViewContext(), exptAnnotations);
             TableInfo tinfo = runListView.getTable();
-            if(tinfo instanceof FilteredTable)
+            if(tinfo instanceof FilteredTable<?> filteredTable)
             {
                 SQLFragment sql = new SQLFragment();
 
@@ -6029,19 +6035,19 @@ public class PanoramaPublicController extends SpringActionController
                 sql.append(ExperimentService.get().getTinfoRunList(), "runlist").append(" ");
                 sql.append("WHERE runlist.experimentId = ? AND runlist.experimentRunId = run.rowid) ");
                 sql.add(experiment.getRowId());
-                ((FilteredTable) tinfo).addCondition(sql);
+                filteredTable.addCondition(sql);
             }
             result.addView(runListView);
 
             // Add a table of spectral libraries, if there are any
             List<ITargetedMSRun> runs = ExperimentAnnotationsManager.getTargetedMSRuns(exptAnnotations);
             TargetedMSService tmsSvc = TargetedMSService.get();
-            if (runs.stream().anyMatch(run -> tmsSvc.getLibraries(run).size() > 0))
+            if (runs.stream().anyMatch(run -> !tmsSvc.getLibraries(run).isEmpty()))
             {
                 result.addView(new SpecLibView(getViewContext(), exptAnnotations));
             }
 
-            if (runs.size() > 0)
+            if (!runs.isEmpty())
             {
                 // Structural modifications
                 List<Long> runIds = runs.stream().map(ITargetedMSRun::getId).collect(Collectors.toList());
@@ -6287,16 +6293,15 @@ public class PanoramaPublicController extends SpringActionController
         }
     }
 
-    private @Nullable WebPartView getPublishedVersionsView(int sourceExperimentId)
+    private @Nullable WebPartView<?> getPublishedVersionsView(int sourceExperimentId)
     {
         List<ExperimentAnnotations> publishedVersions = ExperimentAnnotationsManager.getPublishedVersionsOfExperiment(sourceExperimentId);
-        if (publishedVersions.size() > 0)
+        if (!publishedVersions.isEmpty())
         {
             QuerySettings qSettings = new QuerySettings(getViewContext(), "PublishedVersions", "ExperimentAnnotations");
             qSettings.setBaseFilter(new SimpleFilter(new SimpleFilter(FieldKey.fromParts("SourceExperimentId"), sourceExperimentId)));
 
-            List<FieldKey> columns = new ArrayList<>();
-            columns.addAll(List.of(FieldKey.fromParts("Version"), FieldKey.fromParts("Created"), FieldKey.fromParts("Link"), FieldKey.fromParts("Share")));
+            List<FieldKey> columns = new ArrayList<>(List.of(FieldKey.fromParts("Version"), FieldKey.fromParts("Created"), FieldKey.fromParts("Link"), FieldKey.fromParts("Share")));
             if (publishedVersions.stream().anyMatch(ExperimentAnnotations::isPublished))
             {
                 columns.add(FieldKey.fromParts("Citation"));
@@ -6443,7 +6448,7 @@ public class PanoramaPublicController extends SpringActionController
             if (je != null && je.getLatestSubmission().isPxidRequested())
             {
                 List<String> missingFields = DataValidationManager.getMissingExperimentMetadataFields(form.getBean());
-                if(missingFields.size() > 0)
+                if(!missingFields.isEmpty())
                 {
                     missingFields.stream().forEach(err -> errors.reject(ERROR_MSG, err));
                     return false;
@@ -6468,7 +6473,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(DeletePermission.class)
-    public class DeleteSelectedExperimentAnnotationsAction extends ConfirmAction<SelectedIdsForm>
+    public static class DeleteSelectedExperimentAnnotationsAction extends ConfirmAction<SelectedIdsForm>
     {
         @Override
         public ModelAndView getConfirmView(SelectedIdsForm deleteForm, BindException errors)
@@ -6546,9 +6551,9 @@ public class PanoramaPublicController extends SpringActionController
         }
     }
 
-    public static interface SelectedExperimentIds
+    public interface SelectedExperimentIds
     {
-        public int[] getIds();
+        int[] getIds();
     }
 
     public static class DeleteExperimentAnnotationsForm extends ExperimentAnnotationsForm implements SelectedExperimentIds
@@ -6561,7 +6566,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(DeletePermission.class)
-    public class DeleteExperimentAnnotationsAction extends ConfirmAction<DeleteExperimentAnnotationsForm>
+    public static class DeleteExperimentAnnotationsAction extends ConfirmAction<DeleteExperimentAnnotationsForm>
     {
         private ExperimentAnnotations _expAnnotations;
 
@@ -6609,6 +6614,7 @@ public class PanoramaPublicController extends SpringActionController
         private ExperimentAnnotations _expAnnot;
         private ActionURL _returnPublishExptUrl;
 
+        @Override
         public ModelAndView getView(ExperimentForm form, boolean reshow, BindException errors)
         {
             // This action does not support GET requests. We should be here only if there are errors to show
@@ -6658,14 +6664,14 @@ public class PanoramaPublicController extends SpringActionController
             }
 
             List<Container> allSubfolders = getAllSubfolders(_expAnnot.getContainer());
-            if (allSubfolders.size() == 0)
+            if (allSubfolders.isEmpty())
             {
                 errors.reject(ERROR_MSG, "No subfolders were found.");
                 return;
             }
 
             List<Container> hiddenSubfolders = getHiddenFolders(allSubfolders, getUser());
-            if (hiddenSubfolders.size() > 0)
+            if (!hiddenSubfolders.isEmpty())
             {
                 errors.reject(ERROR_MSG, "User needs read permissions in all the subfolders to be able to include them in the experiment.");
                 return;
@@ -6678,7 +6684,9 @@ public class PanoramaPublicController extends SpringActionController
                 if(SpringActionController.getActionName(PublishExperimentAction.class).equals(action) ||
                         SpringActionController.getActionName(ResubmitExperimentAction.class).equals(action) ||
                         SpringActionController.getActionName(UpdateSubmissionAction.class).equals(action))
-                _returnPublishExptUrl = returnUrl;
+                {
+                    _returnPublishExptUrl = returnUrl;
+                }
             }
         }
 
@@ -6924,7 +6932,7 @@ public class PanoramaPublicController extends SpringActionController
         private ModelAndView getPublicationDetailsView(PublicationDetailsForm form, BindException errors)
         {
             PublicationDetailsBean bean = new PublicationDetailsBean(form, _copiedExperiment);
-            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/publicationDetails.jsp", bean, errors);
+            JspView view = new JspView<>("/org/labkey/panoramapublic/view/publish/publicationDetails.jsp", bean, errors);
             view.setTitle("Publication Details");
             return view;
         }
@@ -6933,7 +6941,7 @@ public class PanoramaPublicController extends SpringActionController
         private ModelAndView getConfirmView(PublicationDetailsForm form, BindException errors)
         {
             PublicationDetailsBean bean = new PublicationDetailsBean(form, _copiedExperiment);
-            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/confirmPublish.jsp", bean, errors);
+            JspView view = new JspView<>("/org/labkey/panoramapublic/view/publish/confirmPublish.jsp", bean, errors);
             view.setTitle("Confirm Publication Details");
             return view;
         }
@@ -7092,7 +7100,7 @@ public class PanoramaPublicController extends SpringActionController
         {
             String webpartName = PanoramaPublicModule.DOWNLOAD_DATA_INFO_WP;
             List<Portal.WebPart> parts = Portal.getParts(container, RAW_FILES_TAB);
-            if (parts.size() != 0)
+            if (!parts.isEmpty())
             {
                 if (!parts.stream().anyMatch(p -> webpartName.equals(p.getName())))
                 {
@@ -7139,7 +7147,7 @@ public class PanoramaPublicController extends SpringActionController
         public ModelAndView getSuccessView(PublicationDetailsForm form)
         {
             PublishSuccessViewBean bean = new PublishSuccessViewBean(_expAnnot.getContainer(), _copiedExperiment, _madePublic, _addedPublication, _journal.getName());
-            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/publishSuccessView.jsp", bean);
+            JspView view = new JspView<>("/org/labkey/panoramapublic/view/publish/publishSuccessView.jsp", bean);
             view.setTitle("Data Published");
             view.setFrame(WebPartView.FrameType.PORTAL);
             return view;
@@ -7898,7 +7906,7 @@ public class PanoramaPublicController extends SpringActionController
                         .filter(l -> l != 0 && library.getId() != l)
                         .collect(Collectors.toSet());
                 List<SpectralLibrary> otherLibraries = SpecLibInfoManager.getLibraries(ids, getUser());
-                if (otherLibraries.size() > 0)
+                if (!otherLibraries.isEmpty())
                 {
                     List<DOM.Renderable> otherDocs = new ArrayList<>();
                     for (SpectralLibrary otherLib: otherLibraries)
@@ -7960,7 +7968,7 @@ public class PanoramaPublicController extends SpringActionController
                     try
                     {
                         List<LibSourceFile> libSourceFiles = reader.readLibSourceFiles(run, specLib);
-                        if (libSourceFiles == null || libSourceFiles.size() == 0)
+                        if (libSourceFiles == null || libSourceFiles.isEmpty())
                         {
                             view.addView(new HtmlView(DIV(cl("labkey-error"), "No library source file names were found.")));
                         }
@@ -7999,7 +8007,7 @@ public class PanoramaPublicController extends SpringActionController
 
         private DOM.Renderable createTable(String title, List<String> fileNames)
         {
-            if (fileNames.size() > 0)
+            if (!fileNames.isEmpty())
             {
                 return TABLE(at(border, 1),
                         THEAD(TR(TH(at(style, "padding:5px;"), STRONG(title)))),
@@ -8872,7 +8880,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ViewExperimentModifications extends SimpleViewAction<ExperimentIdForm>
+    public static class ViewExperimentModifications extends SimpleViewAction<ExperimentIdForm>
     {
         @Override
         public ModelAndView getView(final ExperimentIdForm form, BindException errors)
@@ -8895,7 +8903,7 @@ public class PanoramaPublicController extends SpringActionController
             if (hasStructuralMods(svc, runs))
             {
                 result.addView(new HtmlView(H3(at(style, "margin-top:10px;"),"Structural Modifications")));
-                if (ModificationInfoManager.getStructuralModInfosForExperiment(exptAnnotations.getId(), getContainer()).size() > 0)
+                if (!ModificationInfoManager.getStructuralModInfosForExperiment(exptAnnotations.getId(), getContainer()).isEmpty())
                 {
                     result.addView(getAssignedUnimodMatchesMessage());
                 }
@@ -8911,7 +8919,7 @@ public class PanoramaPublicController extends SpringActionController
             if (hasIsotopeMods(svc, runs))
             {
                 result.addView(new HtmlView(H3(at(style, "margin-top:10px;"),"Isotope Modifications")));
-                if (ModificationInfoManager.getIsotopeModInfosForExperiment(exptAnnotations.getId(), getContainer()).size() > 0)
+                if (!ModificationInfoManager.getIsotopeModInfosForExperiment(exptAnnotations.getId(), getContainer()).isEmpty())
                 {
                     result.addView(getAssignedUnimodMatchesMessage());
                 }
@@ -8935,12 +8943,12 @@ public class PanoramaPublicController extends SpringActionController
         }
         private boolean hasStructuralMods(TargetedMSService svc, List<ITargetedMSRun> runs)
         {
-            return runs.stream().anyMatch(run -> svc.getStructuralModificationsUsedInRun(run.getId()).size() > 0);
+            return runs.stream().anyMatch(run -> !svc.getStructuralModificationsUsedInRun(run.getId()).isEmpty());
         }
 
         private boolean hasIsotopeMods(TargetedMSService svc, List<ITargetedMSRun> runs)
         {
-            return runs.stream().anyMatch(run -> svc.getIsotopeModificationsUsedInRun(run.getId()).size() > 0);
+            return runs.stream().anyMatch(run -> !svc.getIsotopeModificationsUsedInRun(run.getId()).isEmpty());
         }
 
         @Override
@@ -9028,7 +9036,7 @@ public class PanoramaPublicController extends SpringActionController
         @Nullable Status getValidationStatus(DataValidation validation, BindException errors)
         {
             Status validationStatus = DataValidationManager.getIncompleteSkyDocsInContainer(validation, getContainer(), getUser());
-            if (validationStatus.getSkylineDocs().size() == 0)
+            if (validationStatus.getSkylineDocs().isEmpty())
             {
                 errors.reject(ERROR_MSG, "Could not find Skyline documents in the folder with missing sample files.");
                 return null;
@@ -9056,7 +9064,7 @@ public class PanoramaPublicController extends SpringActionController
         @Nullable Status getValidationStatus(DataValidation validation, BindException errors)
         {
             Status validationStatus = DataValidationManager.getIncompleteSpecLibs(validation, getUser());
-            if (validationStatus.getSpectralLibraries().size() == 0)
+            if (validationStatus.getSpectralLibraries().isEmpty())
             {
                 errors.reject(ERROR_MSG, "Could not find spectral libraries in the experiment with missing source files.");
                 return null;
@@ -9578,7 +9586,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class CatalogImageDownloadAction extends BaseDownloadAction<AttachmentForm>
+    public static class CatalogImageDownloadAction extends BaseDownloadAction<AttachmentForm>
     {
         @Nullable
         @Override
@@ -9701,7 +9709,7 @@ public class PanoramaPublicController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     @RequiresLogin
-    public class MyDataViewAction extends SimpleViewAction<Object>
+    public static class MyDataViewAction extends SimpleViewAction<Object>
     {
         @Override
         public void addNavTrail(NavTree root)
@@ -9728,7 +9736,7 @@ public class PanoramaPublicController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class CreatePanoramaPublicMessageAction extends SimpleViewAction<PanoramaPublicMessageForm>
+    public static class CreatePanoramaPublicMessageAction extends SimpleViewAction<PanoramaPublicMessageForm>
     {
         @Override
         public ModelAndView getView(PanoramaPublicMessageForm form, BindException errors) throws Exception

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicListener.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicListener.java
@@ -132,7 +132,7 @@ public class PanoramaPublicListener implements ExperimentListener, ContainerMana
 
         // Check if the short URL is associated with a JournalExperiment, either as the shortAccessUrl or the shortCopyUrl.
         List<JournalExperiment> journalExperiments = SubmissionManager.getJournalExperimentsWithShortUrl(shortUrl);
-        if (journalExperiments.size() > 0)
+        if (!journalExperiments.isEmpty())
         {
             String url = shortUrl.getShortURL();
             for (JournalExperiment je: journalExperiments)

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicMetadataImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicMetadataImporter.java
@@ -73,7 +73,7 @@ public class PanoramaPublicMetadataImporter implements FolderImporter
             // Get the experiment that was just created in the target folder as part of folder import.
             User user = job.getUser();
             List<? extends ExpExperiment> experiments = ExperimentService.get().getExperiments(container, user, false, false);
-            if (experiments.size() == 0)
+            if (experiments.isEmpty())
             {
                 throw new PipelineJobException("No experiments found in the folder " + container.getPath());
             }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -177,7 +177,7 @@ public class PanoramaPublicModule extends SpringModule
             @Override
             public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
             {
-                JspView view = new JspView("/org/labkey/panoramapublic/view/search/panoramaPublicProteinSearch.jsp", getDefaultProteinSearchForm());
+                JspView view = new JspView<>("/org/labkey/panoramapublic/view/search/panoramaPublicProteinSearch.jsp", getDefaultProteinSearchForm());
                 view.setTitle("Panorama Public Protein Search");
                 return view;
             }
@@ -193,7 +193,7 @@ public class PanoramaPublicModule extends SpringModule
             @Override
             public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
             {
-                JspView view = new JspView("/org/labkey/panoramapublic/view/search/panoramaPublicPeptideSearch.jsp", getDefaultPeptideSearchForm());
+                JspView view = new JspView<>("/org/labkey/panoramapublic/view/search/panoramaPublicPeptideSearch.jsp", getDefaultPeptideSearchForm());
                 view.setTitle("Panorama Public Peptide Search");
                 return view;
             }
@@ -218,7 +218,7 @@ public class PanoramaPublicModule extends SpringModule
                         JournalManager.PublicDataUser publicDataUser = JournalManager.getPublicDataUser(journal);
                         if (publicDataUser != null)
                         {
-                            JspView view = new JspView("/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp", publicDataUser);
+                            JspView view = new JspView<>("/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp", publicDataUser);
                             view.setTitle(DOWNLOAD_DATA_INFO_WP);
                             return view;
                         }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicSymlinkManager.java
@@ -474,26 +474,25 @@ public class PanoramaPublicSymlinkManager
             }
         }
 
-        if(linkInvalidTarget.size() > 0)
+        if(!linkInvalidTarget.isEmpty())
         {
             String linkInvalidTargets = linkInvalidTarget.entrySet().stream().map(String::valueOf).collect(Collectors.joining("\n"));
             _log.error(linkInvalidTarget.size() + " Symlinks with invalid targets: \n" + linkInvalidTargets);
         }
 
-        if(linkWithSymlinkTarget.size() > 0)
+        if(!linkWithSymlinkTarget.isEmpty())
         {
             String linkWithSymlinkTargets = linkWithSymlinkTarget.entrySet().stream().map(String::valueOf).collect(Collectors.joining("\n"));
             _log.error(linkWithSymlinkTarget.size() + " Symlinks targeting symlinks: \n" + linkWithSymlinkTargets);
         }
 
-        return linkInvalidTarget.size() == 0 && linkWithSymlinkTarget.size() == 0;
+        return linkInvalidTarget.isEmpty() && linkWithSymlinkTarget.isEmpty();
     }
 
     /**
      * Returns a set of containers that can have symlinks that target files in targetContainer. This includes the source container,
      * and containers with previous versions of the experiment. Only the container with the current version of the experiment
      * can have symlink targets.
-     * @param targetContainer
      * @return A set of containers that can have symlinks that target files in targetContainer
      */
     private static Set<Container> getSymlinkContainers(Container targetContainer)

--- a/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/chromlib/ChromLibStateImporter.java
@@ -29,9 +29,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.*;
-import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.getMoleculePrecursors;
-import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.getPeptideGroups;
-import static org.labkey.panoramapublic.chromlib.ChromLibStateManager.getPrecursors;
 
 
 public abstract class ChromLibStateImporter
@@ -172,7 +169,7 @@ public abstract class ChromLibStateImporter
     List<LibPeptideGroup> getPeptideGroupDbMatches(LibPeptideGroup tsvPepGrp, String skyFile, Container container) throws ChromLibStateException
     {
         var dbIds = _pepGrpKeyMap.get(tsvPepGrp.getKey());
-        if (dbIds == null || dbIds.size() == 0)
+        if (dbIds == null || dbIds.isEmpty())
         {
             throw new ChromLibStateException(String.format("Expected a db row for peptide group '%s' in the Skyline document '%s'. Container '%s'.",
                     tsvPepGrp.getLabel(), skyFile, container.getPath()));
@@ -439,7 +436,7 @@ public abstract class ChromLibStateImporter
         {
             var dbPepGrpMatches = _pepGrpPrecursorsList.stream().filter(p -> p.hasPrecursorDbMatch(tsvPrecursor)).collect(Collectors.toList());
 
-            if (dbPepGrpMatches.size() == 0)
+            if (dbPepGrpMatches.isEmpty())
             {
                 throw new IllegalStateException(String.format("Expected a db row for precursor %s in the peptide group '%s'. Skyline document '%s'. Folder '%s'.",
                         tsvPrecursor.getKey(), _pepGrpKey.toString(), skyFile, container.getPath()));

--- a/panoramapublic/src/org/labkey/panoramapublic/model/JournalSubmission.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/JournalSubmission.java
@@ -104,7 +104,7 @@ public class JournalSubmission
      */
     public @Nullable Submission getLatestSubmission()
     {
-        return submissions().size() > 0 ? submissions().get(0) : null;
+        return !submissions().isEmpty() ? submissions().get(0) : null;
     }
 
     /**
@@ -129,7 +129,7 @@ public class JournalSubmission
     public @Nullable Submission getLatestCopiedSubmission()
     {
         List<Submission> copiedSubmissions = getCopiedSubmissions();
-        return copiedSubmissions.size() > 0 ? copiedSubmissions.get(0) : null;
+        return !copiedSubmissions.isEmpty() ? copiedSubmissions.get(0) : null;
     }
 
     /**
@@ -170,7 +170,6 @@ public class JournalSubmission
     }
 
     /**
-     * @param copiedExperimentId
      * @return The lab head name entered in the submission request that was copied with the given copiedExperimentId.
      * Returns null if no lab head information was entered in the submission form.
      */

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/DataValidation.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/DataValidation.java
@@ -57,7 +57,7 @@ public class DataValidation extends DbEntity
 
     public PxStatus getStatusIncludingExptMetadata(ExperimentAnnotations expAnnotations)
     {
-        if (isComplete() && DataValidationManager.getMissingExperimentMetadataFields(expAnnotations).size() > 0)
+        if (isComplete() && !DataValidationManager.getMissingExperimentMetadataFields(expAnnotations).isEmpty())
         {
             return PxStatus.NotValid;
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/Modification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/Modification.java
@@ -224,7 +224,7 @@ public class Modification
         if (_modInfo != null)
         {
             List<ExperimentModInfo.UnimodInfo> unimodIdsAndNames = _modInfo.getUnimodInfos();
-            if (unimodIdsAndNames.size() > 0)
+            if (!unimodIdsAndNames.isEmpty())
             {
                 jsonObject.put("unimodMatches", getUnimodMatchesJSON(unimodIdsAndNames));
                 jsonObject.put("modInfoId", _modInfo.getId());

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDocSampleFile.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SkylineDocSampleFile.java
@@ -48,6 +48,7 @@ public class SkylineDocSampleFile extends DataFile
         _filePathImported = filePathImported;
     }
 
+    @Override
     @NotNull
     public JSONObject toJSON(Container container)
     {

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLib.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLib.java
@@ -102,7 +102,7 @@ public class SpecLib extends SpecLibValidation<SkylineDocSpecLib>
         if (!isValid && getSpecLibInfo() == null)
         {
             List<SkylineDocSpecLib> docLibraries = DataValidationManager.getSkylineDocSpecLibs(this);
-            if (docLibraries.size() > 0)
+            if (!docLibraries.isEmpty())
             {
                 // Add the database Id of a library used with one of the Skyline documents so that we can display a link to
                 // add the "Add Library Information". The same library can be used with multiple documents. A new row is

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLibSourceFile.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLibSourceFile.java
@@ -84,6 +84,7 @@ public class SpecLibSourceFile extends DataFile
         return Objects.hash(getSourceType(), getName());
     }
 
+    @Override
     @NotNull
     public JSONObject toJSON(Container container)
     {

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLibValidation.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/SpecLibValidation.java
@@ -266,7 +266,7 @@ public abstract class SpecLibValidation <D extends SkylineDocSpecLib>
                 String missing = hasSpectrumFiles() ? "" : " spectrum file names";
                 if (isBibliospecLibrary() && !hasIdFiles())
                 {
-                    missing += (missing.length() > 0 ? " and " : "") + " peptide ID file names";
+                    missing += (!missing.isEmpty() ? " and " : "") + " peptide ID file names";
                 }
                 return "Library source files in the external repository cannot be verified since the library is missing " + missing + ".";
             }
@@ -311,7 +311,7 @@ public abstract class SpecLibValidation <D extends SkylineDocSpecLib>
         // For example: Koina-Prosit_2020_intensity_HCD-Prosit_2019_irt where
         // Prosit_2020_intensity_HCD is the intensity model and Prosit_2019_irt is the retention time model. Skyline
         // supports multiple Koina models.
-        if(isBibliospecLibrary() && getSpectrumFiles().size() == 1 && getIdFiles().size() == 0)
+        if(isBibliospecLibrary() && getSpectrumFiles().size() == 1 && getIdFiles().isEmpty())
         {
             String modelName = getSpectrumFiles().get(0).getName();
             return "Prositintensity_prosit_publication_v1".equals(modelName)
@@ -341,7 +341,7 @@ public abstract class SpecLibValidation <D extends SkylineDocSpecLib>
         if (isBibliospecLibrary())
         {
             var spectrumFiles = getSpectrumFiles();
-            return spectrumFiles.size() > 0 && spectrumFiles.stream().anyMatch(f -> f.getName().toLowerCase().endsWith(".csv"));
+            return !spectrumFiles.isEmpty() && spectrumFiles.stream().anyMatch(f -> f.getName().toLowerCase().endsWith(".csv"));
         }
         return false;
     }
@@ -354,12 +354,12 @@ public abstract class SpecLibValidation <D extends SkylineDocSpecLib>
 
     private boolean hasSpectrumFiles()
     {
-        return _spectrumFiles != null && _spectrumFiles.size() > 0;
+        return _spectrumFiles != null && !_spectrumFiles.isEmpty();
     }
 
     private boolean hasIdFiles()
     {
-        return _idFiles != null && _idFiles.size() > 0;
+        return _idFiles != null && !_idFiles.isEmpty();
     }
 
     private boolean foundSpectrumFiles()

--- a/panoramapublic/src/org/labkey/panoramapublic/model/validation/Status.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/validation/Status.java
@@ -185,7 +185,7 @@ public class Status extends GenericValidationStatus <SkylineDoc, SpecLib>
             json.put("Sample file validation completed for " + validatedCount + " / " + StringUtilsLabKey.pluralize(documentCount, "document") + "."
             + (missingFilesFound ? " Found missing sample files." : ""));
         }
-        if (getModifications().size() > 0)
+        if (!getModifications().isEmpty())
         {
             boolean invalidModsFound = getModifications().stream().anyMatch(mod -> !mod.isValid());
             json.put("Modifications validation complete." + (invalidModsFound ? " Found invalid modifications." : ""));

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -793,7 +793,7 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
     private void updateRawDataTab(Container c, FileContentService service, User user)
     {
         List<Portal.WebPart> rawDataTabParts = Portal.getEditableParts(c, TargetedMSService.RAW_FILES_TAB);
-        if(rawDataTabParts.size() == 0)
+        if(rawDataTabParts.isEmpty())
         {
             return; // Nothing to do if there is no "Raw Data" tab.
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -242,6 +242,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
         _deletePreviousCopy = deletePreviousCopy;
     }
 
+    @Override
     public String getPreviousVersionName()
     {
         return _previousVersionName;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyLibraryStateTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyLibraryStateTask.java
@@ -63,7 +63,7 @@ public class CopyLibraryStateTask extends PipelineJob.Task<CopyLibraryStateTask.
         var container = job.getContainer();
         User user = job.getUser();
         List<? extends ExpExperiment> experiments = ExperimentService.get().getExperiments(container, user, false, false);
-        if (experiments.size() == 0)
+        if (experiments.isEmpty())
         {
             throw new PipelineJobException(String.format("No experiments found in the container '%s'.", container.getPath()));
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataImporter.java
@@ -42,7 +42,7 @@ public class FilesMetadataImporter
         if (includeSubfolders)
         {
             List<Container> children = ContainerManager.getChildren(container);
-            if (children.size() > 0)
+            if (!children.isEmpty())
             {
                 var subfolders = vf.getDir("subfolders"); // TODO: Make SubfolderWriter.DIRECTORY_NAME public
                 for (Container child : children)

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataWriter.java
@@ -62,7 +62,7 @@ public class FilesMetadataWriter
         if (includeSubfolders)
         {
             List<Container> children = ContainerManager.getChildren(container, user, FolderExportPermission.class);
-            if (children.size() > 0)
+            if (!children.isEmpty())
             {
                 var subfolders = vf.getDir("subfolders"); // TODO: Make SubfolderWriter.DIRECTORY_NAME public
                 for (Container child : children)

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/PxDataValidationPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/PxDataValidationPipelineJob.java
@@ -13,7 +13,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
-import org.labkey.panoramapublic.model.validation.DataValidation;
 
 import java.io.File;
 

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ValidatorListener.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ValidatorListener.java
@@ -64,7 +64,7 @@ public class ValidatorListener implements DataValidatorListener
     public void modificationsValidated(ValidatorStatus status)
     {
         _log.info("Modifications validation:");
-        if (status.getModifications().size() == 0)
+        if (status.getModifications().isEmpty())
         {
             _log.info("No modifications were found in the submitted Skyline documents.");
         }
@@ -132,7 +132,7 @@ public class ValidatorListener implements DataValidatorListener
     @Override
     public void spectralLibrariesValidated(ValidatorStatus status)
     {
-        if (status.getSpectralLibraries().size() == 0)
+        if (status.getSpectralLibraries().isEmpty())
         {
             _log.info("Skyline documents in the experiment do not contain any spectral libraries.");
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ChemElement.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ChemElement.java
@@ -50,8 +50,8 @@ public enum ChemElement
     private final String _symbol;
     private final double _avgMass;
 
-    private static Map<String, ChemElement> titleMap = new HashMap<>();
-    private static Map<String, ChemElement> symbolMap = new HashMap<>();
+    private static final Map<String, ChemElement> titleMap = new HashMap<>();
+    private static final Map<String, ChemElement> symbolMap = new HashMap<>();
     static
     {
         for (ChemElement el: ChemElement.values())

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
@@ -305,7 +305,7 @@ public class ExperimentModificationGetter
 
         public boolean hasPossibleUnimods()
         {
-            return _unimodModifications.size() > 0;
+            return !_unimodModifications.isEmpty();
         }
 
         public @NotNull List<UnimodModification> getPossibleUnimodMatches()
@@ -703,7 +703,7 @@ public class ExperimentModificationGetter
                 printStructuralMod(mod, pxMod);
 
                 List<UnimodModification> matches = unimodMatches.get(pxMod.getSkylineName());
-                if (matches.size() == 0)
+                if (matches.isEmpty())
                 {
                     assertFalse("Unexpected Unimod match for modification " + pxMod.getSkylineName(), pxMod.hasUnimodId());
                     assertEquals("Unexpected possible mods for modification " + pxMod.getSkylineName(), 0, pxMod.getPossibleUnimodMatches().size());
@@ -902,10 +902,10 @@ public class ExperimentModificationGetter
 
                 List<UnimodModification> expectedMatches = matches.get(pxMod.getSkylineName());
 
-                if (expectedMatches.size() == 0)
+                if (expectedMatches.isEmpty())
                 {
                     assertFalse("Unexpected Unimod match for isotopic modification " + pxMod.getSkylineName(), pxMod.hasUnimodId());
-                    assertTrue("Unexpected possible mods for isotopic modification " + pxMod.getSkylineName(), pxMod.getPossibleUnimodMatches().size() == 0);
+                    assertTrue("Unexpected possible mods for isotopic modification " + pxMod.getSkylineName(), pxMod.getPossibleUnimodMatches().isEmpty());
                 }
                 else if (expectedMatches.size() == 1)
                 {

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/Formula.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/Formula.java
@@ -59,7 +59,7 @@ public class Formula
                 negative.append(formulaPart);
             }
         }
-        String separator = positive.length() > 0 && negative.length() > 0 ? " - " : (negative.length() > 0 ? "-" : "");
+        String separator = !positive.isEmpty() && !negative.isEmpty() ? " - " : (!negative.isEmpty() ? "-" : "");
         return positive + separator + negative;
     }
 
@@ -168,7 +168,7 @@ public class Formula
         // from the total mass.  Only one negative part is allowed. We will parse the positive and negative parts separately.
         input = input.trim();
 
-        while (input.length() > 0)
+        while (!input.isEmpty())
         {
             if (input.startsWith("-"))
             {

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxXmlWriter.java
@@ -391,7 +391,7 @@ public class PxXmlWriter extends PxWriter
          */
         Element mod_list = new Element("ModificationList");
         var mods = validationStatus.getModifications();
-        if(mods.size() == 0 || mods.stream().noneMatch(Modification::isValid))
+        if(mods.isEmpty() || mods.stream().noneMatch(Modification::isValid))
         {
             mod_list.addChild(new CvParamElement("MS", "MS:1002864", "No PTMs are included in the dataset"));
         }
@@ -688,7 +688,7 @@ public class PxXmlWriter extends PxWriter
     {
         writer.writeCharacters("\n");
         writer.writeCharacters(indent);
-        if(StringUtils.isBlank(element.getText()) && element.getChildren().size() == 0)
+        if(StringUtils.isBlank(element.getText()) && element.getChildren().isEmpty())
         {
             writer.writeEmptyElement(element.getName());
         }
@@ -712,9 +712,9 @@ public class PxXmlWriter extends PxWriter
             writeElement(writer, child, indent + INDENT);
         }
 
-        if(!StringUtils.isBlank(element.getText()) || element.getChildren().size() != 0)
+        if(!StringUtils.isBlank(element.getText()) || !element.getChildren().isEmpty())
         {
-            if(element.getChildren().size() != 0)
+            if(!element.getChildren().isEmpty())
             {
                 writer.writeCharacters("\n");
                 writer.writeCharacters(indent);

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodModification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodModification.java
@@ -191,12 +191,12 @@ public class UnimodModification
         {
             return false;
         }
-        if (sites.size() == 0 && terminus == null)
+        if (sites.isEmpty() && terminus == null)
         {
             // Cannot find an exact match based on just the formula
             return false;
         }
-        if (sites.size() > 0)
+        if (!sites.isEmpty())
         {
             for (Specificity site: sites)
             {
@@ -243,7 +243,7 @@ public class UnimodModification
         sb.append("UNIMOD:").append(getId());
         sb.append(", ").append(getName());
         sb.append(", ").append(getNormalizedFormula());
-        if(_modSites.size() > 0)
+        if(!_modSites.isEmpty())
         {
             sb.append(", Sites: ").append(StringUtils.join(_modSites, ":"));
         }
@@ -279,7 +279,7 @@ public class UnimodModification
 
     public String getModSitesWithPosition()
     {
-        if(_modSites.size() > 0)
+        if(!_modSites.isEmpty())
         {
             return StringUtils.join(_modSites.stream().map(Specificity::toString).collect(Collectors.toSet()), ":");
         }
@@ -300,7 +300,7 @@ public class UnimodModification
         }
         if (_cTerm != null)
         {
-            terminus = terminus + (terminus.length() > 0 ? ", " : "") + _cTerm;
+            terminus = terminus + (!terminus.isEmpty() ? ", " : "") + _cTerm;
         }
         return terminus;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodParser.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodParser.java
@@ -215,13 +215,13 @@ public class UnimodParser
                 elements.remove(element);
             }
         }
-        return elements.size() == 0;
+        return elements.isEmpty();
     }
 
     private UnimodModification parseModification(Element modEl) throws PxException
     {
         String title = modEl.getAttribute("title");
-        Integer id = Integer.parseInt(modEl.getAttribute("record_id"));
+        int id = Integer.parseInt(modEl.getAttribute("record_id"));
 
         NodeList deltaEl = modEl.getElementsByTagNameNS(NAMESPACE, "delta");
         UnimodModification uMod = new UnimodModification(id, title, getFormula(deltaEl));
@@ -302,7 +302,7 @@ public class UnimodParser
                 {
                     throw new PxException("Unrecognized element in formula: " + symbol);
                 }
-                Integer number = Integer.parseInt(el.getAttribute("number"));
+                int number = Integer.parseInt(el.getAttribute("number"));
                 formula.addElement(chemElement, number);
             }
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/DataValidator.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/DataValidator.java
@@ -191,7 +191,7 @@ public class DataValidator
     {
         List<Character> sites = ModificationInfoManager.getIsotopeModificationSites(pxMod.getDbModId(), runs, user);
         var uModsList = UnimodUtil.getMatchesIfWildcardSkylineMod(pxMod, sites);
-        if (uModsList.size() > 0)
+        if (!uModsList.isEmpty())
         {
             var modInfo = new ExperimentIsotopeModInfo();
             modInfo.setExperimentAnnotationsId(expAnnotations.getId());
@@ -281,7 +281,7 @@ public class DataValidator
         // name but different paths imported into separate replicates of a document. Skyline allows this but it can get
         // confusing even for the user.
         Set<String> ambiguousFiles = sampleFileNameAndKeys.keySet().stream().filter(k -> sampleFileNameAndKeys.get(k).size() > 1).collect(Collectors.toSet());
-        if (ambiguousFiles.size() > 0)
+        if (!ambiguousFiles.isEmpty())
         {
             for (SkylineDocValidator skyDoc : skylineDocs)
             {

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/ValidatorStatus.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/validator/ValidatorStatus.java
@@ -7,7 +7,6 @@ import org.labkey.panoramapublic.model.validation.Modification;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 
 public class ValidatorStatus extends GenericValidationStatus<SkylineDocValidator, SpecLibValidator>

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ContainerJoin.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ContainerJoin.java
@@ -76,7 +76,7 @@ public class ContainerJoin
     public @NotNull SQLFragment getContainerSql()
     {
         SQLFragment sql = new SQLFragment();
-        if (_joinList.size() > 0)
+        if (!_joinList.isEmpty())
         {
             // We expect the last table in the join sequence to have the container column
             sql.append(getLastJoinTableAlias()).append(".");
@@ -91,7 +91,7 @@ public class ContainerJoin
 
     public @Nullable FieldKey getContainerFieldKey()
     {
-        if (_joinList.size() > 0)
+        if (!_joinList.isEmpty())
         {
             var parts = _joinList.stream().map(InnerJoinClause::getJoinCol).collect(Collectors.toList());
             parts.add(CONTAINER);

--- a/panoramapublic/src/org/labkey/panoramapublic/query/DataValidationManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/DataValidationManager.java
@@ -125,7 +125,7 @@ public class DataValidationManager
             SimpleFilter filter = new SimpleFilter();
             filter.addCondition(FieldKey.fromParts("Created"), validation.getCreated(), CompareType.GT);
             filter.addCondition(FieldKey.fromParts("Container"), container.getId());
-            if (AuditLogService.get().getAuditEvents(container, user, FileSystemAuditProvider.EVENT_TYPE, filter, null).size() > 0)
+            if (!AuditLogService.get().getAuditEvents(container, user, FileSystemAuditProvider.EVENT_TYPE, filter, null).isEmpty())
             {
                 return true;
             }
@@ -417,7 +417,7 @@ public class DataValidationManager
             // Get the libraries associated with the given SpecLibInfo
             List<SpecLib> specLibList = getLibrariesForSpecLibInfo(specLibInfo, validation);
 
-            if (specLibList.size() > 0)
+            if (!specLibList.isEmpty())
             {
                 try (DbScope.Transaction transaction = PanoramaPublicSchema.getSchema().getScope().ensureTransaction())
                 {
@@ -440,7 +440,7 @@ public class DataValidationManager
         if (validation != null)
         {
             // Get the libraries associated with the given SpecLibInfo
-            if (getLibrariesForSpecLibInfo(specLibInfo, validation).size() > 0)
+            if (!getLibrariesForSpecLibInfo(specLibInfo, validation).isEmpty())
             {
                 recalculateStatus(validation, user);
             }
@@ -463,7 +463,7 @@ public class DataValidationManager
             // Get the libraries associated with the given SpecLibInfo
             List<SpecLib> specLibList = getLibrariesMatchingSpecLibInfo(specLibInfo, validation, user);
 
-            if (specLibList.size() > 0)
+            if (!specLibList.isEmpty())
             {
                 try (DbScope.Transaction transaction = PanoramaPublicSchema.getSchema().getScope().ensureTransaction())
                 {
@@ -725,12 +725,11 @@ public class DataValidationManager
                 notFound.add(orgName);
             }
         }
-        if(notFound.size() > 0)
+        if(!notFound.isEmpty())
         {
-            StringBuilder err = new StringBuilder("No taxonomy ID found for organism");
-            err.append(notFound.size() > 1 ? "s: " : ": ");
-            err.append(StringUtils.join(notFound, ','));
-            errors.add(err.toString());
+            String err = "No taxonomy ID found for organism" + (notFound.size() > 1 ? "s: " : ": ") +
+                    StringUtils.join(notFound, ',');
+            errors.add(err);
         }
     }
 
@@ -757,12 +756,11 @@ public class DataValidationManager
                 notFound.add(instrumentName);
             }
         }
-        if(notFound.size() > 0)
+        if(!notFound.isEmpty())
         {
-            StringBuilder err = new StringBuilder("Unrecognized instrument");
-            err.append(notFound.size() > 1 ? "s: " : ": ");
-            err.append(StringUtils.join(notFound, ','));
-            errors.add(err.toString());
+            String err = "Unrecognized instrument" + (notFound.size() > 1 ? "s: " : ": ") +
+                    StringUtils.join(notFound, ',');
+            errors.add(err);
         }
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsManager.java
@@ -360,7 +360,7 @@ public class ExperimentAnnotationsManager
         SimpleFilter filter = container != null ? SimpleFilter.createContainerFilter(container) : null;
         List<ExperimentAnnotations> expAnnotations = new TableSelector(PanoramaPublicManager.getTableInfoExperimentAnnotations(),
                 filter, null).getArrayList(ExperimentAnnotations.class);
-        if(expAnnotations.size() > 0)
+        if(!expAnnotations.isEmpty())
         {
             // 09.04.14
             // Return the first experiment in the container.
@@ -374,7 +374,7 @@ public class ExperimentAnnotationsManager
     public static boolean hasExperimentsInSubfolders(Container container, User user)
     {
         Collection<GUID> containerIds = ContainerFilter.Type.CurrentAndSubfolders.create(container, user).getIds();
-        if(containerIds == null || containerIds.size() == 0)
+        if(containerIds == null || containerIds.isEmpty())
         {
             return false;
         }
@@ -394,7 +394,7 @@ public class ExperimentAnnotationsManager
         List<ExperimentAnnotations> expAnnotations = new TableSelector(PanoramaPublicManager.getTableInfoExperimentAnnotations(),
                 filter, null).getArrayList(ExperimentAnnotations.class);
 
-        return expAnnotations.size() > 0;
+        return !expAnnotations.isEmpty();
     }
 
     public static ExperimentAnnotations getExperimentForShortUrl(ShortURLRecord shortUrl)
@@ -546,7 +546,6 @@ public class ExperimentAnnotationsManager
     }
 
     /**
-     * @param experimentAnnotations
      * @return true if the given experiment is a journal copy, and is the most recent version.
      */
     public static boolean isCurrentVersion(ExperimentAnnotations experimentAnnotations)
@@ -577,8 +576,6 @@ public class ExperimentAnnotationsManager
     }
 
     /**
-     * @param container
-     * @param user
      * @return List of instruments that were used to acquire the data for the Skyline documents in the given container.
      * The list will only include instrument model names that have a match in the PSI-MS controlled vocabulary. We are not able
      * to get specific instrument model names from Bruker, Agilent or Waters raw data. The instrument name for data from these
@@ -596,7 +593,7 @@ public class ExperimentAnnotationsManager
 
     private static List<String> getInstrumentModelNames(List<Long> runIds, User user, Container container)
     {
-        if (runIds.size() > 0)
+        if (!runIds.isEmpty())
         {
             SimpleFilter filter = new SimpleFilter().addInClause(FieldKey.fromParts("runId"), runIds);
             return new TableSelector(TargetedMSService.get().getUserSchema(user, container).getTable("instrument"),

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -491,7 +491,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
 
     public static class ExperimentUserForeignKey extends UserIdQueryForeignKey
     {
-        private FieldKey _fieldKey;
+        private final FieldKey _fieldKey;
 
         static public BaseColumnInfo initColumn(ColumnInfo column)
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
@@ -358,7 +358,7 @@ public class JournalManager
         if(group != null)
         {
             Set<User> grpMembers = SecurityManager.getAllGroupMembers(group, MemberType.ACTIVE_USERS);
-            if(grpMembers.size() != 0)
+            if(!grpMembers.isEmpty())
             {
                 return grpMembers.stream().min(Comparator.comparing(User::getUserId)).orElse(null);
             }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ModificationInfoManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ModificationInfoManager.java
@@ -178,7 +178,7 @@ public class ModificationInfoManager
                         new SimpleFilter(FieldKey.fromParts("experimentAnnotationsId"), expAnnotations.getId()),
                         null
                         ).getArrayList(Integer.class);
-                if (modInfoIds.size() > 0)
+                if (!modInfoIds.isEmpty())
                 {
                     SimpleFilter filter = new SimpleFilter(new SimpleFilter.InClause(FieldKey.fromParts("modInfoId"), modInfoIds));
                     Table.delete(PanoramaPublicManager.getTableInfoIsotopeUnimodInfo(), filter);
@@ -252,7 +252,7 @@ public class ModificationInfoManager
 
     private static boolean runsHaveModifications(List<Long> runIds, TableInfo tableInfo, User user, Container container)
     {
-        if (runIds.size() == 0) return false;
+        if (runIds.isEmpty()) return false;
 
         TargetedMSService svc = TargetedMSService.get();
         SQLFragment sql = new SQLFragment("SELECT mod.Id FROM ")

--- a/panoramapublic/src/org/labkey/panoramapublic/query/PxXmlManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/PxXmlManager.java
@@ -10,7 +10,6 @@ import org.labkey.panoramapublic.PanoramaPublicManager;
 import org.labkey.panoramapublic.model.PxXml;
 
 import java.util.Collections;
-import java.util.List;
 
 public class PxXmlManager
 {

--- a/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
@@ -117,7 +117,7 @@ public class SubmissionManager
             List<Submission> allSubmissions = getSubmissionsNewestFirst(submission.getJournalExperimentId());
             allSubmissions.removeIf(Submission::isObsolete);
 
-            if (allSubmissions.size() == 0)
+            if (allSubmissions.isEmpty())
             {
                 // Delete the JournalExperiment if there are no submissions left after removing any obsolete ones
                 JournalExperiment je = getJournalExperiment(submission.getJournalExperimentId());
@@ -436,7 +436,7 @@ public class SubmissionManager
         JournalSubmission js = getJournalSubmission(expAnnotations.getId(), journal.getId(), expAnnotations.getContainer());
         if (js != null)
         {
-            if (js.getCopiedSubmissions().size() == 0)
+            if (js.getCopiedSubmissions().isEmpty())
             {
                 // Experiment was submitted but not yet copied so we can delete the rows in the Submission and JournalExperiment tables.
                 try (DbScope.Transaction transaction = PanoramaPublicManager.getSchema().getScope().ensureTransaction())

--- a/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionTableInfo.java
@@ -13,7 +13,6 @@ import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.HtmlWriter;
 import org.labkey.panoramapublic.PanoramaPublicController;

--- a/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibInfoDisplayColumnFactory.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/speclib/EditLibInfoDisplayColumnFactory.java
@@ -8,7 +8,6 @@ import org.labkey.api.data.RenderContext;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.util.LinkBuilder;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.writer.HtmlWriter;

--- a/panoramapublic/src/org/labkey/panoramapublic/view/PanoramaPublicRunListView.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/PanoramaPublicRunListView.java
@@ -18,7 +18,7 @@ import org.labkey.panoramapublic.model.ExperimentAnnotations;
 
 public class PanoramaPublicRunListView extends ExperimentRunListView
 {
-    private ExperimentAnnotations _expAnnotations;
+    private final ExperimentAnnotations _expAnnotations;
 
     public PanoramaPublicRunListView(ExperimentAnnotations expAnnotations, UserSchema schema, QuerySettings settings)
     {

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -139,7 +139,7 @@
     String publishButtonText = "Submit";
     if (js != null && !annot.isJournalCopy())
     {
-        journal = JournalManager.getJournal(js.getJournalId());
+        JournalManager.getJournal(js.getJournalId());
         Submission submission = js.getLatestSubmission();
         if (submission != null)
         {

--- a/panoramapublic/src/org/labkey/panoramapublic/view/unimodMatchInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/unimodMatchInfo.jsp
@@ -39,7 +39,7 @@
 
 
 <div id="unimodMatchDiv"></div>
-<%if (bean.getUnimodMatches().size() == 0 && !bean.isIsotopicMod()) { %>
+<%if (bean.getUnimodMatches().isEmpty() && !bean.isIsotopicMod()) { %>
 <div class="alert alert-info" style="width:800px;">
     Define a custom <%=button("Combination Modification").href(defineCombinationModUrl)%> if this modification is a combination of two modifications.
 </div>
@@ -85,7 +85,7 @@
             },
             {
                 xtype: 'component',
-                <% if (unimodMatches.size() == 0) { %>
+                <% if (unimodMatches.isEmpty()) { %>
                 cls: 'alert labkey-error alert-warning',
                 <% } %>
                 html: unimodMatchesHtml()

--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/PanoramaPublicSearchWebPart.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/PanoramaPublicSearchWebPart.java
@@ -15,7 +15,7 @@ import java.time.Duration;
 
 public class PanoramaPublicSearchWebPart extends BodyWebPart<PanoramaPublicSearchWebPart.ElementCache>
 {
-    private static String title = "Panorama Public Search";
+    private static final String title = "Panorama Public Search";
 
     private final WebDriverWait tabWait = new WebDriverWait(getDriver(), Duration.ofSeconds(1));
 
@@ -30,6 +30,7 @@ public class PanoramaPublicSearchWebPart extends BodyWebPart<PanoramaPublicSearc
         return new PanoramaPublicSearchWebPart.ElementCache();
     }
 
+    @Override
     public String getTitle()
     {
         return elementCache().title.get();

--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
@@ -2,7 +2,6 @@ package org.labkey.test.components.panoramapublic;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
-import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebElement;

--- a/panoramapublic/test/src/org/labkey/test/pages/panoramapublic/DataValidationPage.java
+++ b/panoramapublic/test/src/org/labkey/test/pages/panoramapublic/DataValidationPage.java
@@ -106,7 +106,7 @@ public class DataValidationPage extends LabKeyPage<DataValidationPage.ElementCac
         scrollIntoView(panel);
         expandSkyDocRow(panel, skylineDocName);
 
-        verifySkyDocStatus(skylineDocName, missing.size() == 0 ? "COMPLETE" : "INCOMPLETE");
+        verifySkyDocStatus(skylineDocName, missing.isEmpty() ? "COMPLETE" : "INCOMPLETE");
 
         var sampleFilesTable = panel.findElement(getFilesTableLocator(skylineDocName, "pxv-tpl-table"));
         for (var file: missing)
@@ -201,8 +201,8 @@ public class DataValidationPage extends LabKeyPage<DataValidationPage.ElementCac
         scrollIntoView(panel);
         expandLibraryRow(panel, libraryFile, fileSize);
         verifySpecLibStatus(libraryFile, fileSize,
-                (spectrumFiles.size() == 0 || idFiles.size() == 0
-                        || spectrumFilesMissing.size() > 0 || idFilesMissing.size() > 0) ? "INCOMPLETE" : "COMPLETE");
+                (spectrumFiles.isEmpty() || idFiles.isEmpty()
+                        || !spectrumFilesMissing.isEmpty() || !idFilesMissing.isEmpty()) ? "INCOMPLETE" : "COMPLETE");
 
         var panelText = panel.getText();
         List<String> expectedTexts = new ArrayList<>(skylineDocNames);
@@ -279,7 +279,7 @@ public class DataValidationPage extends LabKeyPage<DataValidationPage.ElementCac
         cells.forEach(cell -> cellValues.add(cell.getText()));
         assertTrue(modName + " was not found in modification row " + rowIdx, cells.get(MOD_COL_NAME).getText().contains(modName));
 
-        if (unimodMatches == null || unimodMatches.size() == 0)
+        if (unimodMatches == null || unimodMatches.isEmpty())
         {
             assertTrue(cells.get(MOD_COL_UNIMOD_NAME).getText().startsWith("MISSING"));
         }
@@ -300,7 +300,7 @@ public class DataValidationPage extends LabKeyPage<DataValidationPage.ElementCac
 
     private void verifyLibrarySourceFiles(String libraryName, List<String> files, List<String> filesMissing, WebElement specLibsPanel, String tblCls)
     {
-        if (files.size() > 0 || filesMissing.size() > 0)
+        if (!files.isEmpty() || !filesMissing.isEmpty())
         {
             var filesTable = specLibsPanel.findElement(getFilesTableLocator(libraryName, tblCls));
             for (var file : filesMissing)

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -102,7 +102,7 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
     @BeforeClass
     public static void initProject()
     {
-        PanoramaPublicBaseTest init = (PanoramaPublicBaseTest)getCurrentTest();
+        PanoramaPublicBaseTest init = getCurrentTest();
         init.createPanoramaPublicJournalProject();
 
         // Create the test project

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicModificationsTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicModificationsTest.java
@@ -356,7 +356,7 @@ public class PanoramaPublicModificationsTest extends PanoramaPublicBaseTest
     private int checkModificationRow(DataRegionTable modsTable,  List<Unimod> matches, String modificationName)
     {
         String expectedText = "";
-        if (matches != null && matches.size() > 0)
+        if (matches != null && !matches.isEmpty())
         {
             for (var unimod: matches)
             {

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -34,7 +34,7 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     @BeforeClass
     public static void initialSetUp()
     {
-        PanoramaPublicMyDataViewTest test = (PanoramaPublicMyDataViewTest) getCurrentTest();
+        PanoramaPublicMyDataViewTest test = getCurrentTest();
         test.init();
     }
 

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
@@ -1,10 +1,8 @@
 package org.labkey.test.tests.panoramapublic;
 
-import org.apache.commons.collections4.MultiValuedMap;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.labkey.api.view.Portal;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.TestTimeoutException;
@@ -19,9 +17,7 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -43,7 +39,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
     @BeforeClass
     public static void initialSetUp()
     {
-        PanoramaWebPublicSearchTest init = (PanoramaWebPublicSearchTest) getCurrentTest();
+        PanoramaWebPublicSearchTest init = getCurrentTest();
         init.initialSetupHelper();
     }
 

--- a/pwebdashboard/src/org/labkey/pwebdashboard/ProjectAdminsTable.java
+++ b/pwebdashboard/src/org/labkey/pwebdashboard/ProjectAdminsTable.java
@@ -90,7 +90,7 @@ public class ProjectAdminsTable extends ContainerTable
         addCondition(sql);
     }
 
-    class AdminsColumn extends DataColumn
+    static class AdminsColumn extends DataColumn
     {
         public AdminsColumn(ColumnInfo col)
         {

--- a/signup/src/org/labkey/signup/SignUpAdmin.jsp
+++ b/signup/src/org/labkey/signup/SignUpAdmin.jsp
@@ -140,7 +140,7 @@
         Set<String> keySet = groupToGroup.keySet();
         for(String key: keySet) {
         List<String> rules = Arrays.asList(groupToGroup.get(key).split("\\s*,\\s*"));
-        for(String rule: rules) { if(!rule.equals("")) {%>
+        for(String rule: rules) { if(!rule.isEmpty()) {%>
         <tr>
             <td><%=h(SecurityManager.getGroup(Integer.parseInt(key)))%> (<%=h(key)%>)</td>
             <td><%=h(SecurityManager.getGroup(Integer.parseInt(rule)))%> (<%=h(rule)%>)</td>

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -104,7 +104,7 @@ public class SignUpController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class ShowSignUpAdminAction extends SimpleViewAction
+    public static class ShowSignUpAdminAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -123,7 +123,7 @@ public class SignUpController extends SpringActionController
     }
 
    @RequiresSiteAdmin
-   public class AddPropertyAction extends FormHandlerAction<AddPropertyForm>
+   public static class AddPropertyAction extends FormHandlerAction<AddPropertyForm>
    {
        @Override
        public URLHelper getSuccessURL(AddPropertyForm addPropertyForm)
@@ -160,7 +160,7 @@ public class SignUpController extends SpringActionController
    }
 
     @RequiresSiteAdmin
-    public class RemovePropertyAction extends FormHandlerAction<ContainerIdForm>
+    public static class RemovePropertyAction extends FormHandlerAction<ContainerIdForm>
     {
         @Override
         public URLHelper getSuccessURL(ContainerIdForm containerIdForm)
@@ -192,7 +192,7 @@ public class SignUpController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class AddGroupChangeProperty extends FormHandlerAction<AddGroupChangeForm>
+    public static class AddGroupChangeProperty extends FormHandlerAction<AddGroupChangeForm>
     {
         @Override
         public URLHelper getSuccessURL(AddGroupChangeForm containerIdForm)
@@ -228,7 +228,7 @@ public class SignUpController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class RemoveGroupChangeProperty extends FormHandlerAction<AddGroupChangeForm>
+    public static class RemoveGroupChangeProperty extends FormHandlerAction<AddGroupChangeForm>
     {
         @Override
         public URLHelper getSuccessURL(AddGroupChangeForm containerIdForm)
@@ -251,7 +251,7 @@ public class SignUpController extends SpringActionController
             rules.remove(String.valueOf(newgroup));
             String newProperties = StringUtils.join(rules, ',');
             m.put(String.valueOf(oldgroup), newProperties);
-            if(rules.size() == 0 || (rules.size() == 1 && rules.contains("")))
+            if(rules.isEmpty() || (rules.size() == 1 && rules.contains("")))
                 m.remove(oldgroup);
 
             m.save();
@@ -336,7 +336,7 @@ public class SignUpController extends SpringActionController
     // Class ConfirmAction handles a user trying to confirm an account creation.  If the email and confirmation code match
     // that in our database they will be added to the LabKey user base
     @RequiresNoPermission
-    public class ConfirmAction extends FormViewAction<SignupConfirmForm>
+    public static class ConfirmAction extends FormViewAction<SignupConfirmForm>
     {
         protected URLHelper _successUrl = null;
         private TempUser _tempUser = null;
@@ -722,7 +722,7 @@ public class SignUpController extends SpringActionController
     }
 
     @RequiresLogin
-    public class ChangeGroupsApiAction extends MutatingApiAction<AddGroupChangeForm>
+    public static class ChangeGroupsApiAction extends MutatingApiAction<AddGroupChangeForm>
     {
         @Override
         public ApiResponse execute(AddGroupChangeForm addGroupChangeForm, BindException errors) throws Exception

--- a/signup/src/org/labkey/signup/SignUpModule.java
+++ b/signup/src/org/labkey/signup/SignUpModule.java
@@ -71,7 +71,7 @@ public class SignUpModule extends DefaultModule
             @Override
             public WebPartView getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart)
             {
-                JspView<SignUpController.SignupForm> view = new JspView("/org/labkey/signup/signupPage.jsp", new SignUpController.SignupForm());
+                JspView<SignUpController.SignupForm> view = new JspView<>("/org/labkey/signup/signupPage.jsp", new SignUpController.SignupForm());
                 view.setTitle("Sign Up");
 
                 return view;

--- a/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
+++ b/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
@@ -44,7 +44,7 @@ public class SendTestResultsEmail implements org.quartz.Job
     public static final String TEST_GET_HTML_EMAIL = "gethtml";
     public static final String MORNING_EMAIL = "morningemail";
 
-    private Date _date;
+    private final Date _date;
 
     public interface DEFAULT_EMAIL {
         String RECIPIENT = "skyline-dev@proteinms.net";
@@ -119,7 +119,7 @@ public class SendTestResultsEmail implements org.quartz.Job
             ActionURL containerUrl = PageFlowUtil.urlProvider(ProjectUrls.class).getBeginURL(container).addParameter("end", mdyFormatter.format(end));
             String testResultsUrl = AppProps.getInstance().getBaseServerUrl() + AppProps.getInstance().getContextPath() + containerUrl.getEncodedLocalURIString();
             message.append("<div style='margin:auto; text-align:center;'>")
-                .append("<h1>").append(PageFlowUtil.filter(container.getName())).append("<br><span style='font-size:11px;'>starting: ").append(start.toString()).append("</span></h1>")
+                .append("<h1>").append(PageFlowUtil.filter(container.getName())).append("<br><span style='font-size:11px;'>starting: ").append(start).append("</span></h1>")
                 .append("<h5 style='margin:0; padding:0;'><a href=\"" + testResultsUrl + "\">View Full TestResults</a></h5>")
                 .append("</div>");
 

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -143,13 +143,13 @@ public class TestResultsController extends SpringActionController
      * action to view rundown.jsp and also the landing page for module
      */
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
         {
             RunDownBean bean = getRunDownBean(getUser(), getContainer(), getViewContext());
-            return new JspView("/org/labkey/testresults/view/rundown.jsp", bean);
+            return new JspView<>("/org/labkey/testresults/view/rundown.jsp", bean);
         }
 
         @Override
@@ -163,7 +163,7 @@ public class TestResultsController extends SpringActionController
         String viewType = viewContext.getRequest().getParameter("viewType");
 
         Calendar cal = Calendar.getInstance();
-        cal.setTime(end != null && !end.equals("") ? MDYFormat.parse(end) : new Date());
+        cal.setTime(end != null && !end.isEmpty() ? MDYFormat.parse(end) : new Date());
         setToEightAM(cal);
         Date endDate = cal.getTime();
         cal.add(Calendar.DATE, -1);
@@ -335,7 +335,7 @@ public class TestResultsController extends SpringActionController
      * action to view trainging data for each user
      */
     @RequiresPermission(ReadPermission.class)
-    public class TrainingDataViewAction extends SimpleViewAction
+    public static class TrainingDataViewAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -355,7 +355,7 @@ public class TestResultsController extends SpringActionController
 
             User[] users = getUsers(getContainer(), null);
             TestsDataBean bean = new TestsDataBean(runs, users);
-            return new JspView("/org/labkey/testresults/view/trainingdata.jsp", bean);
+            return new JspView<>("/org/labkey/testresults/view/trainingdata.jsp", bean);
         }
 
         @Override
@@ -450,7 +450,7 @@ public class TestResultsController extends SpringActionController
      * accepts url parameter "start" and "end" which will be the date range of selected runs for that user to display
      */
     @RequiresPermission(ReadPermission.class)
-    public class ShowUserAction extends SimpleViewAction
+    public static class ShowUserAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -480,7 +480,7 @@ public class TestResultsController extends SpringActionController
             ensureRunDataCached(runs, false);
 
             TestsDataBean bean = new TestsDataBean(runs, user == null ? new User[0] : new User[]{user});
-            return new JspView("/org/labkey/testresults/view/user.jsp", bean);
+            return new JspView<>("/org/labkey/testresults/view/user.jsp", bean);
         }
 
         @Override
@@ -494,7 +494,7 @@ public class TestResultsController extends SpringActionController
      * accepts a url parameter "runId" which will be the run that the jsp displays the information of
      */
     @RequiresPermission(ReadPermission.class)
-    public class ShowRunAction extends SimpleViewAction
+    public static class ShowRunAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -504,7 +504,7 @@ public class TestResultsController extends SpringActionController
             {
                 runId = Integer.parseInt(getViewContext().getRequest().getParameter("runId"));
             } catch (Exception e) {
-                return new JspView("/org/labkey/testresults/view/runDetail.jsp", null);
+                return new JspView<>("/org/labkey/testresults/view/runDetail.jsp", null);
             }
             String filterTestPassesBy = getViewContext().getRequest().getParameter("filter");
 
@@ -526,10 +526,10 @@ public class TestResultsController extends SpringActionController
 
             RunDetail[] runs = executeGetRunsSQLFragment(sqlFragment, getContainer(), false, true);
             if (runs.length == 0)
-                return new JspView("/org/labkey/testresults/view/runDetail.jsp", null);
+                return new JspView<>("/org/labkey/testresults/view/runDetail.jsp", null);
             RunDetail run = runs[0];
             if (run == null)
-                return new JspView("/org/labkey/testresults/view/runDetail.jsp", null);
+                return new JspView<>("/org/labkey/testresults/view/runDetail.jsp", null);
             if (filterTestPassesBy != null) {
                 if (filterTestPassesBy.equals("duration")) {
                     List<TestPassDetail> filteredPasses = Arrays.asList(passes);
@@ -554,7 +554,7 @@ public class TestResultsController extends SpringActionController
                 run.setHang(hangs[0]);
             run.setPasses(passes);
             TestsDataBean bean = new TestsDataBean(runs, new User[0]);
-            return new JspView("/org/labkey/testresults/view/runDetail.jsp", bean);
+            return new JspView<>("/org/labkey/testresults/view/runDetail.jsp", bean);
         }
 
         @Override
@@ -568,7 +568,7 @@ public class TestResultsController extends SpringActionController
      * accepts a url parameter "viewType" of either wk(week), mo(month), or yr(year) and defaults to month
      */
     @RequiresPermission(ReadPermission.class)
-    public class LongTermAction extends SimpleViewAction
+    public static class LongTermAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -589,7 +589,7 @@ public class TestResultsController extends SpringActionController
             bean.setNonAssociatedFailures(failures);
 
             ensureRunDataCached(runs, true);
-            return new JspView("/org/labkey/testresults/view/longTerm.jsp", bean);
+            return new JspView<>("/org/labkey/testresults/view/longTerm.jsp", bean);
         }
 
         @Override
@@ -604,7 +604,7 @@ public class TestResultsController extends SpringActionController
      * accepts parameter viewType as 'wk', 'mo', or 'yr'.  defaults to 'day'
      */
     @RequiresPermission(ReadPermission.class)
-    public class ShowFailures extends SimpleViewAction
+    public static class ShowFailures extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -636,11 +636,11 @@ public class TestResultsController extends SpringActionController
                         (run.getLeaks() != null && Arrays.stream(run.getLeaks()).anyMatch(leak -> leak.getTestName().equals(failedTest)))
                 ).toArray(RunDetail[]::new));
 
-                return new JspView("/org/labkey/testresults/view/failureDetail.jsp", bean);
+                return new JspView<>("/org/labkey/testresults/view/failureDetail.jsp", bean);
             }
 
             bean.setRuns(runs);
-            return new JspView("/org/labkey/testresults/view/multiFailureDetail.jsp", bean);
+            return new JspView<>("/org/labkey/testresults/view/multiFailureDetail.jsp", bean);
         }
 
         @Override
@@ -713,7 +713,7 @@ public class TestResultsController extends SpringActionController
      * action to show all flagged runs flagged.jsp
      */
     @RequiresNoPermission
-    public class ShowFlaggedAction extends SimpleViewAction
+    public static class ShowFlaggedAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors) throws Exception
@@ -721,7 +721,7 @@ public class TestResultsController extends SpringActionController
             SimpleFilter filter = new SimpleFilter();
             filter.addCondition(FieldKey.fromParts("flagged"), true);
             RunDetail[] details = new TableSelector(TestResultsSchema.getTableInfoTestRuns(), filter, null).getArray(RunDetail.class);
-            return new JspView("/org/labkey/testresults/view/flagged.jsp", new TestsDataBean(details, new User[0]));
+            return new JspView<>("/org/labkey/testresults/view/flagged.jsp", new TestsDataBean(details, new User[0]));
         }
         @Override
         public void addNavTrail(NavTree root)
@@ -730,7 +730,8 @@ public class TestResultsController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class ChangeBoundaries extends MutatingApiAction {
+    public static class ChangeBoundaries extends MutatingApiAction<Object>
+    {
         @Override
         public Object execute(Object o, BindException errors) throws Exception
         {
@@ -785,7 +786,7 @@ public class TestResultsController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ViewLogAction extends ReadOnlyApiAction
+    public static class ViewLogAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors)
@@ -809,7 +810,7 @@ public class TestResultsController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class ViewXmlAction extends ReadOnlyApiAction
+    public static class ViewXmlAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors)
@@ -833,7 +834,7 @@ public class TestResultsController extends SpringActionController
     }
 
     @RequiresNoPermission
-    public class SendEmailNotificationAction extends ReadOnlyApiAction
+    public static class SendEmailNotificationAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors)
@@ -951,12 +952,12 @@ public class TestResultsController extends SpringActionController
                     else
                         error += "Email 'To' not valid.";
 
-                    if (error.equals("")) {
+                    if (error.isEmpty()) {
                         org.labkey.api.security.User y = UserManager.getUser(from);
                         if (y == null)
                             error += "Sender email not a registered user.";
                     }
-                    if (error.equals("")) {
+                    if (error.isEmpty()) {
                         res.put("Message", "Email sent from " + from.getEmailAddress() + " to " + to.getEmailAddress());
                         res.put("Response", "true");
                         testCustom.execute(SendTestResultsEmail.TEST_CUSTOM, UserManager.getUser(from), to.getEmailAddress());
@@ -999,7 +1000,8 @@ public class TestResultsController extends SpringActionController
     }
 
     @RequiresSiteAdmin
-    public class SetUserActive extends MutatingApiAction {
+    public static class SetUserActive extends MutatingApiAction<Object>
+    {
         @Override
         public Object execute(Object o, BindException errors)
         {
@@ -1038,18 +1040,17 @@ public class TestResultsController extends SpringActionController
      * action for posting test output as an xml file
      */
     @RequiresNoPermission
-    public class PostAction extends MutatingApiAction {
+    public static class PostAction extends MutatingApiAction<Object>
+    {
 
         @Override
         public Object execute(Object o, BindException errors) throws Exception
         {
             // DebugRequest(getViewContext().getRequest());
-            if (!(getViewContext().getRequest() instanceof MultipartRequest))
+            if (!(getViewContext().getRequest() instanceof MultipartRequest request))
             {
-                throw new Exception("Expected a request of type MultipartRequest got " + getViewContext().getRequest().getClass().toString());
+                throw new Exception("Expected a request of type MultipartRequest got " + getViewContext().getRequest().getClass());
             }
-
-            MultipartRequest request = (MultipartRequest) getViewContext().getRequest();
 
             MultipartFile file = request.getFile("xml_file");
             if (file == null)
@@ -1092,7 +1093,7 @@ public class TestResultsController extends SpringActionController
 
         private void DebugRequest(HttpServletRequest hsRequest)
         {
-            _log.info("Request is " + hsRequest.getClass().toString());
+            _log.info("Request is " + hsRequest.getClass());
             _log.info("Content length is : "+ hsRequest.getContentLength());
             _log.info("Content type: " + hsRequest.getContentType());
             Enumeration<String> headerNames = hsRequest.getHeaderNames();
@@ -1102,9 +1103,8 @@ public class TestResultsController extends SpringActionController
                 _log.info("Header " + headerName + ": " + hsRequest.getHeader(headerName));
             }
 
-            if (hsRequest instanceof MultipartRequest)
+            if (hsRequest instanceof MultipartRequest request)
             {
-                MultipartRequest request = (MultipartRequest) hsRequest;
                 _log.info("Multi part content type for xml: " + request.getMultipartContentType("xml"));
                 _log.info("Multi part content type for xml_file: " + request.getMultipartContentType("xml_file"));
             }
@@ -1113,7 +1113,7 @@ public class TestResultsController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class ErrorFilesAction extends SimpleViewAction
+    public static class ErrorFilesAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -1122,7 +1122,7 @@ public class TestResultsController extends SpringActionController
             File[] files = local.listFiles();
             if (files == null)
                 files = new File[0];
-            return new JspView("/org/labkey/testresults/view/errorFiles.jsp", files);
+            return new JspView<>("/org/labkey/testresults/view/errorFiles.jsp", files);
         }
 
         @Override
@@ -1132,7 +1132,7 @@ public class TestResultsController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class PostErrorFilesAction extends MutatingApiAction
+    public static class PostErrorFilesAction extends MutatingApiAction<Object>
     {
         @Override
         public Object execute(Object o, BindException errors)
@@ -1753,7 +1753,7 @@ public class TestResultsController extends SpringActionController
             int runId = run.getId();
             List<TestFailDetail> failList = testFailDetails.get(runId);
             run.setFailures(failList != null
-                    ? failList.toArray(new TestFailDetail[failList.size()])
+                    ? failList.toArray(new TestFailDetail[0])
                     : new TestFailDetail[0]);
         }
     }

--- a/testresults/src/org/labkey/testresults/TestResultsWebPart.java
+++ b/testresults/src/org/labkey/testresults/TestResultsWebPart.java
@@ -30,11 +30,7 @@ public class TestResultsWebPart extends BaseWebPartFactory
         {
             bean = TestResultsController.getRunDownBean(portalCtx.getUser(), c, portalCtx);
         }
-        catch (ParseException e)
-        {
-            e.printStackTrace();
-        }
-        catch (IOException e)
+        catch (ParseException | IOException e)
         {
             e.printStackTrace();
         }

--- a/testresults/src/org/labkey/testresults/model/GlobalSettings.java
+++ b/testresults/src/org/labkey/testresults/model/GlobalSettings.java
@@ -1,9 +1,5 @@
 package org.labkey.testresults.model;
 
-import org.labkey.api.data.Container;
-
-import java.util.Date;
-
 public class GlobalSettings
 {
 

--- a/testresults/src/org/labkey/testresults/model/RunDetail.java
+++ b/testresults/src/org/labkey/testresults/model/RunDetail.java
@@ -288,7 +288,7 @@ public class RunDetail implements Comparable<RunDetail>
         List<Double> values = new ArrayList<>();
         try (
             ByteArrayInputStream bais = new ByteArrayInputStream(pointsummary);
-            DataInputStream in = new DataInputStream(bais);
+            DataInputStream in = new DataInputStream(bais)
         ) {
             StringBuilder str = new StringBuilder();
             while (in.available() > 0)

--- a/testresults/src/org/labkey/testresults/model/TestFailDetail.java
+++ b/testresults/src/org/labkey/testresults/model/TestFailDetail.java
@@ -120,7 +120,7 @@ public class TestFailDetail implements Comparable<TestFailDetail>
     @Override
     public int compareTo(TestFailDetail o)
     {
-        int diff = 0;
+        int diff;
         if(this.timestamp == null) {
             diff = Integer.compare(this.testId, o.testId);
         } else {

--- a/testresults/src/org/labkey/testresults/model/User.java
+++ b/testresults/src/org/labkey/testresults/model/User.java
@@ -108,37 +108,35 @@ public class User implements Comparable<User>
     public static double upperBound(double mean, double stdDev, int stdDevs) { return mean + stdDev * stdDevs; }
 
     public String runBoundHtmlString(int warningBoundary, int errorBoundary) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Good: ");
-        sb.append("> ");
-        sb.append((int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), warningBoundary)) - 1);
-        sb.append("\n");
-        sb.append("Warn: ");
-        sb.append((int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), errorBoundary)));
-        sb.append(" - ");
-        sb.append((int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), warningBoundary)) - 1);
-        sb.append("\n");
-        sb.append("Error: ");
-        sb.append("< ");
-        sb.append((int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), errorBoundary)));
-        return sb.toString();
+        String sb = "Good: " +
+                "> " +
+                ((int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), warningBoundary)) - 1) +
+                "\n" +
+                "Warn: " +
+                (int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), errorBoundary)) +
+                " - " +
+                ((int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), warningBoundary)) - 1) +
+                "\n" +
+                "Error: " +
+                "< " +
+                (int) Math.round(lowerBound(getMeantestsrun(), getStddevtestsrun(), errorBoundary));
+        return sb;
     }
 
     public String memBoundHtmlString(int warningBoundary, int errorBoundary) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Good: ");
-        sb.append("< ");
-        sb.append((int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), warningBoundary)) + 1);
-        sb.append("\n");
-        sb.append("Warn: ");
-        sb.append((int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), warningBoundary)) + 1);
-        sb.append(" - ");
-        sb.append((int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), errorBoundary)));
-        sb.append("\n");
-        sb.append("Error: ");
-        sb.append("> ");
-        sb.append((int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), errorBoundary)));
-        return sb.toString();
+        String sb = "Good: " +
+                "< " +
+                ((int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), warningBoundary)) + 1) +
+                "\n" +
+                "Warn: " +
+                ((int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), warningBoundary)) + 1) +
+                " - " +
+                (int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), errorBoundary)) +
+                "\n" +
+                "Error: " +
+                "> " +
+                (int) Math.round(upperBound(getMeanmemory(), getStddevmemory(), errorBoundary));
+        return sb;
     }
 
     @Override

--- a/testresults/src/org/labkey/testresults/view/RunDownBean.java
+++ b/testresults/src/org/labkey/testresults/view/RunDownBean.java
@@ -228,9 +228,9 @@ public class RunDownBean extends TestsDataBean
 
             MathStat stats = service.getStats(ArrayUtils.toPrimitive(list.toArray(new Double[0])));
             double median = stats.getMedian();
-            int largestkey = averagePassPointMap.keySet().size() == 0 ? 0 : Collections.max(averagePassPointMap.keySet());
+            int largestkey = averagePassPointMap.keySet().isEmpty() ? 0 : Collections.max(averagePassPointMap.keySet());
             int tolerance = 500; // pases must be at least 500 runs away from eachother
-            if (averagePassPointMap.size() == 0 ||
+            if (averagePassPointMap.isEmpty() ||
                 (averagePassPointMap.get(largestkey) != null && median > tolerance + averagePassPointMap.get(largestkey))) {
                 averagePassPointMap.put(largestkey+1, median);
             }

--- a/testresults/src/org/labkey/testresults/view/TestsDataBean.java
+++ b/testresults/src/org/labkey/testresults/view/TestsDataBean.java
@@ -28,7 +28,6 @@ import org.labkey.testresults.model.User;
 import org.labkey.testresults.model.TestFailDetail;
 import org.labkey.testresults.model.TestPassDetail;
 
-import java.lang.String;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;

--- a/testresults/src/org/labkey/testresults/view/multiFailureDetail.jsp
+++ b/testresults/src/org/labkey/testresults/view/multiFailureDetail.jsp
@@ -29,7 +29,7 @@
     Container c = getContainer();
     RunDetail[] runs = data.getStatRuns();
     if(runs.length > 1) {
-        Arrays.sort(runs, new Comparator<RunDetail>()
+        Arrays.sort(runs, new Comparator<>()
         {
             @Override
             public int compare(RunDetail o1, RunDetail o2)
@@ -100,7 +100,7 @@
     </tr>
     <%
     Collections.reverse(Arrays.asList(runs)); // so most recent is on top
-    Map<Date, Integer> dates = new TreeMap<Date, Integer>();  // maps dates to count of failures per run
+    Map<Date, Integer> dates = new TreeMap<>();  // maps dates to count of failures per run
     for(RunDetail run: runs) { %>
         <tr>
             <td>
@@ -141,10 +141,10 @@
                 <%
                     Map<String, Double> lang =languageBreakdown.get("");
                    for(String l: lang.keySet()) {
-                    Double percent = lang.get(l) * 100;
+                    double percent = lang.get(l) * 100;
                 %>
 
-                ['<%=h(l)%>', <%=percent.intValue()%>],
+                ['<%=h(l)%>', <%=(int)percent%>],
                 <%}%>  ],
             type : 'pie'
         },

--- a/testresults/src/org/labkey/testresults/view/rundown.jsp
+++ b/testresults/src/org/labkey/testresults/view/rundown.jsp
@@ -52,7 +52,7 @@
     DateFormat df = new SimpleDateFormat("MM/dd/yyyy");
 
     String viewType = data.getViewType();
-    if (viewType == null || viewType.equals(""))
+    if (viewType == null || viewType.isEmpty())
         viewType = ViewType.MONTH;
     String viewTypeWord = "Month";
     if (viewType.equals(ViewType.WEEK))

--- a/testresults/src/org/labkey/testresults/view/user.jsp
+++ b/testresults/src/org/labkey/testresults/view/user.jsp
@@ -52,7 +52,7 @@
     String startDate = req.getParameter("start");
     String endDate = req.getParameter("end");
     String user = req.getParameter("user");
-    boolean showSingleUser = user != null && !user.equals("");
+    boolean showSingleUser = user != null && !user.isEmpty();
     DateFormat df = new SimpleDateFormat("MM/dd/yyyy");
     Date today = new Date();
     if (startDate == null)


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


