### PR TITLE
Update expected form field name casing

### DIFF
--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentInsertPage.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentInsertPage.java
@@ -84,10 +84,10 @@ public class TargetedMsExperimentInsertPage extends InsertPage
 
     private class Elements extends InsertPage.Elements
     {
-        public Locator.XPathLocator expTitle = body.append(Locator.tagWithName("textarea", "title"));
-        public Locator.XPathLocator expAbstract = body.append(Locator.tagWithName("textarea", "abstract"));
-        public Locator.XPathLocator keywords = body.append(Locator.tagWithName("textarea","keywords"));
-        public Locator.XPathLocator submitterAffiliation = body.append(Locator.input("submitterAffiliation"));
+        public Locator.XPathLocator expTitle = body.append(Locator.tagWithName("textarea", "Title"));
+        public Locator.XPathLocator expAbstract = body.append(Locator.tagWithName("textarea", "Abstract"));
+        public Locator.XPathLocator keywords = body.append(Locator.tagWithName("textarea","Keywords"));
+        public Locator.XPathLocator submitterAffiliation = body.append(Locator.input("SubmitterAffiliation"));
         public Locator.XPathLocator organismInputDiv = body.append(Locator.id("input-picker-div-organism")
                 .descendant(Locator.tagWithClass("span", "twitter-typeahead"))
                 .child(Locator.tagWithClass("input", "tt-input")));


### PR DESCRIPTION
#### Rationale
The fix for issue 53306 changed the casing for form field names to use the casing of the column itself instead of a lowercased version of the name.

#### Changes
* Update to match `<input name="x">` values