### PR TITLE
Redirect to ActionURL instead of a String URL

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -594,7 +594,7 @@ public class SkylineToolsStoreController extends SpringActionController
                         tool.setLatest(true);
                         SkylineToolsStoreManager.get().insertTool(c, getUser(), tool);
 
-                        return HttpView.redirect(SkylineToolStoreUrls.getToolDetailsUrl(tool).getLocalURIString());
+                        return HttpView.redirect(SkylineToolStoreUrls.getToolDetailsUrl(tool));
                     }
                 }
                 else
@@ -868,7 +868,6 @@ public class SkylineToolsStoreController extends SpringActionController
         @Override
         public ModelAndView handleRequestInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws Exception
         {
-            final String sender = httpServletRequest.getParameter("sender");
             final int suppTarget = Integer.parseInt(httpServletRequest.getParameter("supptarget"));
 
             final String suppFile = httpServletRequest.getParameter("suppFile");
@@ -890,8 +889,7 @@ public class SkylineToolsStoreController extends SpringActionController
             else
                 throw new Exception();
 
-            return HttpView.redirect((sender != null) ? sender :
-                    SkylineToolStoreUrls.getToolDetailsUrl(tool).getLocalURIString());
+            return HttpView.redirect(SkylineToolStoreUrls.getToolDetailsUrl(tool));
         }
 
         @Override
@@ -1049,8 +1047,8 @@ public class SkylineToolsStoreController extends SpringActionController
                 }
             }
 
-            return HttpView.redirect((senderUrl != null) ? senderUrl.getLocalURIString() :
-                SkylineToolStoreUrls.getToolStoreHomeUrl(toolStoreContainer, getUser()).getLocalURIString());
+            return HttpView.redirect((senderUrl != null) ? senderUrl :
+                SkylineToolStoreUrls.getToolStoreHomeUrl(toolStoreContainer, getUser()));
         }
 
         @Override
@@ -1383,8 +1381,9 @@ public class SkylineToolsStoreController extends SpringActionController
 
                 Container toolStoreContainer = tool != null ? tool.getContainerParent() : getContainer();
 
-                return HttpView.redirect((sender != null) ? sender :
-                        SkylineToolStoreUrls.getToolStoreHomeUrl(toolStoreContainer, getUser()).getLocalURIString());
+
+                return HttpView.redirect((sender != null) ? new ActionURL(sender) :
+                        SkylineToolStoreUrls.getToolStoreHomeUrl(toolStoreContainer, getUser()));
             }
             else
             {
@@ -1505,8 +1504,7 @@ public class SkylineToolsStoreController extends SpringActionController
             else
                 tool.writeIconToFile(makeFile(tool.lookupContainer(), "icon.png"), "png");
 
-            String sender = httpServletRequest.getParameter("sender");
-            return HttpView.redirect((sender != null) ? sender : new ActionURL(BeginAction.class, getContainer()).getLocalURIString());
+            return HttpView.redirect(SkylineToolStoreUrls.getToolDetailsUrl(tool));
         }
 
         @Override

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
@@ -740,7 +740,7 @@ a { text-decoration: none; }
         buttons: {
             Ok: function() {
                 setButtonsEnabled(false);
-                window.location = "<%=h(urlFor(SkylineToolsStoreController.DeleteLatestAction.class).addParameter("id", tool.getRowId()).addParameter("sender", toolDetailsLatestUrl.getLocalURIString()))%>"
+                window.location = <%=q(urlFor(SkylineToolsStoreController.DeleteLatestAction.class).addParameter("id", tool.getRowId()).addParameter("sender", toolDetailsLatestUrl.getLocalURIString()))%>
             },
             Cancel: function() {$(this).dialog("close");}
         }

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
@@ -187,7 +187,7 @@
         <p>
             <label for="toolOwnersManage">Tool owners </label><br />
             <input type="text" id="toolOwnersManage" class="toolOwners" name="toolOwners" /><br /><br />
-            <input type="hidden" name="sender" value="<%= h(request.getRequestURL()) %>" />
+            <input type="hidden" name="sender" value="<%= h(getActionURL()) %>" />
             <input type="hidden" id="updatetargetOwners" name="updatetarget" value="" />
             <input type="submit" value="Update Tool Owners" />
         </p>
@@ -203,7 +203,7 @@
                 <label for="toolOwnersNew">Tool owners </label><br />
                 <input type="text" id="toolOwnersNew" class="toolOwners" name="toolOwners" /><br /><br /><br />
             </span>
-            <input type="hidden" name="sender" value="<%= h(request.getRequestURL()) %>" />
+            <input type="hidden" name="sender" value="<%= h(getActionURL()) %>" />
             <input type="hidden" id="updatetarget" name="updatetarget" value="" />
             <input type="submit" value="Upload Tool" />
         </p>


### PR DESCRIPTION
#### Changes
- Redirect to ActionURL instead of a String URL: replace usage of `HttpView.redirect(String)` with `HttpView.redirect(URLHelper)`.
- Remove lookup for "sender" parameter in `DeleteSupplementAction` and `UpdatePropertyAction`, since it is not included in the request.
- Use `getActionURL()` as the value of "sender" parameter instead of `request.getRequestURL()`.
- Avoid HTML-escaping URLs in JavaScript contexts
