### PR TITLE
Constants for many commonly used role names in tests

### DIFF
--- a/SkylineToolsStore/test_disabled/src/org.labkey.test.tests/ToolStoreRatingsTest.java
+++ b/SkylineToolsStore/test_disabled/src/org.labkey.test.tests/ToolStoreRatingsTest.java
@@ -49,9 +49,9 @@ public class ToolStoreRatingsTest  extends ToolStoreTestPart
         uncheckCheckbox(Locator.name("sendEmail"));
         clickButton("Update Group Membership");
         enterPermissionsUI();
-        setUserPermissions("SkylineToolStoreGroup", "Editor");
-        _securityHelper.setSiteGroupPermissions("All Site Users", "Reader");
-        _securityHelper.setSiteGroupPermissions("Guests", "Reader");
+        setUserPermissions("SkylineToolStoreGroup", EDITOR_ROLE);
+        _securityHelper.setSiteGroupPermissions("All Site Users", READER_ROLE);
+        _securityHelper.setSiteGroupPermissions("Guests", READER_ROLE);
         int fileNumber = 0;
         while(fileNumber < filesToUpload.length)
         {
@@ -59,8 +59,8 @@ public class ToolStoreRatingsTest  extends ToolStoreTestPart
             fileNumber++;
         }
         //toolName is the directory name in LabKey
-        setupUserPermissions(users[0], "_tool_Population Variation Updated_1.2.16269", "Editor", "panoramaPermissions");
-        setupUserPermissions(users[1], "_tool_MSstats_1.0", "Editor", "panoramaPermissions");
+        setupUserPermissions(users[0], "_tool_Population Variation Updated_1.2.16269", EDITOR_ROLE, "panoramaPermissions");
+        setupUserPermissions(users[1], "_tool_MSstats_1.0", EDITOR_ROLE, "panoramaPermissions");
         testAsGuest();
         testAsUser1();
         testAsUser2();

--- a/SkylineToolsStore/test_disabled/src/org.labkey.test.tests/ToolStoreTest.java
+++ b/SkylineToolsStore/test_disabled/src/org.labkey.test.tests/ToolStoreTest.java
@@ -49,9 +49,9 @@ public class ToolStoreTest  extends ToolStoreTestPart
         uncheckCheckbox(Locator.name("sendEmail"));
         clickButton("Update Group Membership");
         enterPermissionsUI();
-        setUserPermissions("SkylineToolStoreGroup", "Editor");
-        _securityHelper.setSiteGroupPermissions("All Site Users", "Reader");
-        _securityHelper.setSiteGroupPermissions("Guests", "Reader");
+        setUserPermissions("SkylineToolStoreGroup", EDITOR_ROLE);
+        _securityHelper.setSiteGroupPermissions("All Site Users", READER_ROLE);
+        _securityHelper.setSiteGroupPermissions("Guests", READER_ROLE);
         int fileNumber = 0;
         while(fileNumber < filesToUpload.length)
         {
@@ -59,8 +59,8 @@ public class ToolStoreTest  extends ToolStoreTestPart
             fileNumber++;
         }
         //toolName is the directory name in LabKey
-        setupUserPermissions(users[0], "_tool_Population Variation Updated_1.2.16269", "Editor", "panoramaPermissions");
-        setupUserPermissions(users[1], "_tool_MSstats_1.0", "Editor", "panoramaPermissions");
+        setupUserPermissions(users[0], "_tool_Population Variation Updated_1.2.16269", EDITOR_ROLE, "panoramaPermissions");
+        setupUserPermissions(users[1], "_tool_MSstats_1.0", EDITOR_ROLE, "panoramaPermissions");
         testAsSuperAdmin();
         testAsGuest();
         testAsUser1(0);

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -44,6 +44,7 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
 
 public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOnlyTest
 {
@@ -211,7 +212,7 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
         _userHelper.ensureUsersExist(List.of(adminUsers));
         for(String user: adminUsers)
         {
-            permissionsHelper.addMemberToRole(user, "Folder Administrator", PermissionsHelper.MemberType.user, projectName + "/" + folderName);
+            permissionsHelper.addMemberToRole(user, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user, projectName + "/" + folderName);
         }
     }
 
@@ -523,7 +524,7 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
     {
         _userHelper.ensureUsersExist(Collections.singletonList(user));
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.addMemberToRole(user, "Folder Administrator", PermissionsHelper.MemberType.user, projectName + "/" + folderName);
+        permissionsHelper.addMemberToRole(user, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user, projectName + "/" + folderName);
     }
 
     protected void makeDataPublic(boolean unpublishedData)

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -116,7 +117,7 @@ public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
         impersonate(SUBMITTER);
         verifyCatalogEntryWebpart(projectName ,folderName, true);
         stopImpersonating();
-        impersonateRole("Reader");
+        impersonateRole(READER_ROLE);
         verifyCatalogEntryWebpart(projectName ,folderName, false);
         stopImpersonating();
     }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
@@ -42,7 +43,7 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     {
         goToProjectHome(PANORAMA_PUBLIC);
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.setSiteGroupPermissions("Guests", "Reader");
+        permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
         portalHelper.removeAllWebParts();
         portalHelper.addBodyWebPart("Panorama Public Search");
         portalHelper.addBodyWebPart("Targeted MS Experiment List");

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicTest.java
@@ -25,6 +25,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
@@ -262,8 +264,8 @@ public class PanoramaPublicTest extends PanoramaPublicBaseTest
         // in all subfolders are required for submitting an experiment.
         goToProjectFolder(projectName, sourceFolder + "/" + subfolder_mam);
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.removeUserRoleAssignment(SUBMITTER_2, "Folder Administrator", projectName + "/" + sourceFolder + "/" + subfolder_mam);
-        permissionsHelper.assertNoPermission(SUBMITTER_2, "Reader");
+        permissionsHelper.removeUserRoleAssignment(SUBMITTER_2, FOLDER_ADMIN_ROLE, projectName + "/" + sourceFolder + "/" + subfolder_mam);
+        permissionsHelper.assertNoPermission(SUBMITTER_2, READER_ROLE);
 
         goToProjectFolder(projectName, sourceFolder);
         impersonate(SUBMITTER_2);
@@ -296,7 +298,7 @@ public class PanoramaPublicTest extends PanoramaPublicBaseTest
         {
             _userHelper.deleteUser(user);
             _userHelper.createUser(user);
-            permissionsHelper.addMemberToRole(user, "Folder Administrator", PermissionsHelper.MemberType.user, projectName + "/" + folderName);
+            permissionsHelper.addMemberToRole(user, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user, projectName + "/" + folderName);
         }
     }
 

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaWebPublicSearchTest.java
@@ -19,6 +19,8 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import java.util.Arrays;
 import java.util.Set;
 
+import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
+
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
@@ -69,7 +71,7 @@ public class PanoramaWebPublicSearchTest extends PanoramaPublicBaseTest
         createExperimentCompleteMetadata("Experiment for small molecule search");
 
         _userHelper.createUser(SUBMITTER);
-        permissionsHelper.addMemberToRole(SUBMITTER, "Folder Administrator", PermissionsHelper.MemberType.user, getProjectName() + "/" + SUBFOLDER_2);
+        permissionsHelper.addMemberToRole(SUBMITTER, FOLDER_ADMIN_ROLE, PermissionsHelper.MemberType.user, getProjectName() + "/" + SUBFOLDER_2);
         impersonate(SUBMITTER);
         updateSubmitterAccountInfo(AUTHOR_FIRST_NAME, AUTHOR_LAST_NAME, SUBFOLDER_2);
         createExperimentCompleteMetadata("Submitter Experiment");

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PrivateDataReminderTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PrivateDataReminderTest.java
@@ -14,6 +14,7 @@ import org.labkey.test.util.DataRegionTable;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 7)
@@ -40,7 +41,7 @@ public class PrivateDataReminderTest extends PanoramaPublicBaseTest
         String panoramaPublicProject = PANORAMA_PUBLIC;
         goToProjectHome(panoramaPublicProject);
         ApiPermissionsHelper permissionsHelper = new ApiPermissionsHelper(this);
-        permissionsHelper.setSiteGroupPermissions("Guests", "Reader");
+        permissionsHelper.setSiteGroupPermissions("Guests", READER_ROLE);
 
 
         String testProject = getProjectName();


### PR DESCRIPTION
#### Rationale
There's an exciting new computer science concept - using constants instead of many copies of hard-code values. Let's give it a try with our most commonly used role names in automated tests.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2703

#### Changes
- Common role names available in PermissionsHelper
- Update tests to use them