### PR TITLE
Return Set<Class<?>> from Module "get test" methods

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreModule.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreModule.java
@@ -74,7 +74,7 @@ public class SkylineToolsStoreModule extends DefaultModule
                             }
 
                             @Override
-                            public WebPartView getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart) throws WebPartConfigurationException
+                            public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart) throws WebPartConfigurationException
                             {
                                 return new SkylineToolsStoreWebPart();
                             }

--- a/lincs/src/org/labkey/lincs/LincsModule.java
+++ b/lincs/src/org/labkey/lincs/LincsModule.java
@@ -85,7 +85,7 @@ public class LincsModule extends SpringModule
         BaseWebPartFactory runsList = new BaseWebPartFactory(LincsDataView.WEB_PART_NAME)
         {
             @Override
-            public WebPartView getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
+            public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, @NotNull Portal.WebPart webPart)
             {
                 return new LincsDataView(portalCtx);
             }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -357,9 +357,8 @@ public class PanoramaPublicModule extends SpringModule
         return Collections.singleton(PanoramaPublicSchema.SCHEMA_NAME);
     }
 
-    @NotNull
     @Override
-    public Set<Class> getIntegrationTests()
+    public @NotNull Set<Class<?>> getIntegrationTests()
     {
         return Set.of(
                 PanoramaPublicController.TestCase.class,
@@ -368,11 +367,10 @@ public class PanoramaPublicModule extends SpringModule
         );
     }
 
-    @NotNull
     @Override
-    public Set<Class> getUnitTests()
+    public @NotNull Set<Class<?>> getUnitTests()
     {
-        Set<Class> set = new HashSet<>();
+        Set<Class<?>> set = new HashSet<>();
         set.add(PanoramaPublicController.TestCase.class);
         set.add(PanoramaPublicNotification.TestCase.class);
         set.add(SkylineVersion.TestCase.class);
@@ -384,7 +382,7 @@ public class PanoramaPublicModule extends SpringModule
         set.add(CatalogEntryManager.TestCase.class);
         set.add(BlueskyApiClient.TestCase.class);
         set.add(PrivateDataReminderSettings.TestCase.class);
-        return set;
 
+        return set;
     }
 }

--- a/signup/src/org/labkey/signup/SignUpModule.java
+++ b/signup/src/org/labkey/signup/SignUpModule.java
@@ -31,6 +31,7 @@ import org.labkey.api.view.Portal;
 import org.labkey.api.view.ViewContext;
 import org.labkey.api.view.WebPartFactory;
 import org.labkey.api.view.WebPartView;
+import org.labkey.signup.SignUpController.SignupForm;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -69,9 +70,9 @@ public class SignUpModule extends DefaultModule
         BaseWebPartFactory signupWebpart = new BaseWebPartFactory("Sign Up")
         {
             @Override
-            public WebPartView getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart)
+            public JspView<SignupForm> getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart)
             {
-                JspView<SignUpController.SignupForm> view = new JspView<>("/org/labkey/signup/signupPage.jsp", new SignUpController.SignupForm());
+                JspView<SignupForm> view = new JspView<>("/org/labkey/signup/signupPage.jsp", new SignupForm());
                 view.setTitle("Sign Up");
 
                 return view;

--- a/testresults/src/org/labkey/testresults/TestResultsWebPart.java
+++ b/testresults/src/org/labkey/testresults/TestResultsWebPart.java
@@ -22,7 +22,7 @@ public class TestResultsWebPart extends BaseWebPartFactory
     }
 
     @Override
-    public WebPartView getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart) throws WebPartConfigurationException
+    public WebPartView<?> getWebPartView(@NotNull ViewContext portalCtx, Portal.@NotNull WebPart webPart) throws WebPartConfigurationException
     {
         Container c =portalCtx.getContainer();
         TestsDataBean bean = null;


### PR DESCRIPTION
#### Rationale
Eliminate IntelliJ warnings caused by `Module` methods `getUnitTests()` and `getIntegrationTests()` returning raw `Set<Class>`; they now return `Set<Class<?>>`.