### PR TITLE
Don't interfere with failure screenshots with @After

### DIFF
--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -14,6 +14,7 @@ import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.components.SubfoldersWebPart;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentInsertPage;
@@ -113,10 +114,6 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
     @After
     public void afterTest() throws IOException, CommandException
     {
-        if (isImpersonating())
-        {
-            stopImpersonating();
-        }
         verifySymlinks();
     }
 
@@ -149,7 +146,7 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
 
     boolean verifySymlinks() throws IOException, CommandException
     {
-        Connection connection = createDefaultConnection();
+        Connection connection = WebTestHelper.getRemoteApiConnection(false);
         SimpleGetCommand command = new SimpleGetCommand("PanoramaPublic", "verifySymlinks");
         CommandResponse verifyResponse = command.execute(connection, "/");
 

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -191,7 +191,7 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     @NotNull
     private DataRegionTable myDataView()
     {
-        var table = new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();
+        var table = new DataRegionTable("Targeted MS Experiment List", getDriver());
         assertTrue(table.hasHeaderMenu("My Data"));
         table.clickHeaderButtonAndWait("My Data");
         return new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();


### PR DESCRIPTION
#### Rationale
`PanoramaPublicMyDataViewTest` has been failing intermittently but we can't investigate the failure because `PanoramaPublicBaseTest.afterTest` navigates away before we can take failure screenshots.
```
org.openqa.selenium.StaleElementReferenceException: The element with the reference 4b968cbd-bcdb-48a2-80f4-82f579b56e2f is stale; either its node document is not the active document, or it is no longer connected to the DOM
[...]
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.myDataView(PanoramaPublicMyDataViewTest.java:195)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.verifyColumnValues(PanoramaPublicMyDataViewTest.java:156)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.viewSubmitterData(PanoramaPublicMyDataViewTest.java:127)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.testMyDataView(PanoramaPublicMyDataViewTest.java:81)
```
We can avoid this navigation by making `verifySymlinks` not care whether the test is currently impersonating.

#### Related Pull Requests
* N/A

#### Changes
* Don't interfere with failure screenshots with @After
