### PR TITLE
Remove public account details from the "Download Data" webpart

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
@@ -28,12 +28,13 @@
     client such as <span class="nobr"><%=simpleLink("CyberDuck", "https://cyberduck.io")%></span>
     or <span class="nobr"><%=simpleLink("WinSCP", "https://winscp.net/eng/docs/introduction")%></span>.
     For details look at <%=simpleLink("Download data from Panorama Public", downloadDataDocHref)%>.
-    Use the following URL, login email and password to connect to this folder:
+    Use the following URL to connect to this folder:
     <br/>
     <br/>
     URL: <b class="bold"><span class="nobr" id="webdav_url_link"><%=h(webdavUrl)%></span></b>
     <br/>
-    Login email: <b class="bold"><%=h(publicDataUser.getEmail())%></b>
     <br/>
-    Password: <b class="bold"><%=h(publicDataUser.getPassword())%></b>
+    <b class="bold">Note: </b> If you plan to download large volumes of data or datasets from multiple projects,
+    please contact the PanoramaWeb team in advance so that we can coordinate the download to minimize load on the server
+    and ensure reliable access.
 </p>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
@@ -34,7 +34,7 @@
     URL: <b class="bold"><span class="nobr" id="webdav_url_link"><%=h(webdavUrl)%></span></b>
     <br/>
     <br/>
-    <b class="bold">Note: </b> If you plan to download large volumes of data or datasets from multiple projects,
+    <b class="bold">Note: </b> If you plan to download large volumes of data or datasets from multiple projects via WebDAV,
     please contact the PanoramaWeb team in advance so that we can coordinate the download to minimize load on the server
     and ensure reliable access.
 </p>

--- a/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/publish/dataDownloadInfo.jsp
@@ -23,13 +23,15 @@
 %>
 <p>
     Select one or more files or folders in the browser above and click the download icon ( <span class="fa fa-download"></span> ).
+    <br/>
+    <br/>
     Data can also be downloaded by mapping this folder as a network drive in Windows Explorer, or by using a
     <%=simpleLink("WebDAV", "https://en.wikipedia.org/wiki/WebDAV")%>
     client such as <span class="nobr"><%=simpleLink("CyberDuck", "https://cyberduck.io")%></span>
     or <span class="nobr"><%=simpleLink("WinSCP", "https://winscp.net/eng/docs/introduction")%></span>.
-    For details look at <%=simpleLink("Download data from Panorama Public", downloadDataDocHref)%>.
-    Use the following URL to connect to this folder:
-    <br/>
+    WebDAV downloads require an account on the PanoramaWeb server. Information on obtaining an account and other download options
+    is available on the <%=simpleLink("Download data from Panorama Public", downloadDataDocHref)%> help page.
+    Use the following URL to connect to this folder for WebDAV downloads:
     <br/>
     URL: <b class="bold"><span class="nobr" id="webdav_url_link"><%=h(webdavUrl)%></span></b>
     <br/>


### PR DESCRIPTION
#### Changes
- Removed public account details from the "Download Data" webpart
- Added a note about contacting the PanoramaWeb team before initiating very large downloads via WebDAV
