### PR TITLE
PanoramaPublic bug fixes

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -6894,6 +6894,11 @@ public class PanoramaPublicController extends SpringActionController
                         errors.reject(ERROR_MSG, String.format("Cannot find a copy of experiment Id %d on '%s'", expAnnot.getId(), _journal.getName()));
                         return null;
                     }
+                    if (submission.isPending())
+                    {
+                        errors.reject(ERROR_MSG, String.format("There is a pending re-submit request for experiment Id %d on '%s'", expAnnot.getId(), _journal.getName()));
+                        return null;
+                    }
                     return copiedExperiment;
                 }
             }
@@ -7007,12 +7012,10 @@ public class PanoramaPublicController extends SpringActionController
                         return;
                     }
                 }
-                if (!form.hasNewPublicationDetails(_copiedExperiment))
-                {
-                    errors.reject(ERROR_MSG, String.format("Publication details are the same as the ones associated with the data on %s at %s",
-                            _journal.getName(), _copiedExperiment.getShortUrl().renderShortURL()));
-                    return;
-                }
+                // Validation removed: no need to ensure that publication details entered in the form differ from the
+                // publication details already associated with the experiment. The user may have entered the
+                // correct PubMedID etc. when submitting but forgot to make the data public.
+                // (See commit history for the original logic.)
             }
             else if (_copiedExperiment.isPublic())
             {
@@ -7355,13 +7358,6 @@ public class PanoramaPublicController extends SpringActionController
         public boolean hasLinkAndCitation()
         {
             return !(StringUtils.isBlank(_link) || StringUtils.isBlank(_citation));
-        }
-
-        public boolean hasNewPublicationDetails(ExperimentAnnotations copiedExperiment)
-        {
-            return !(Objects.equals(_pubmedId, copiedExperiment.getPubmedId())
-                    && Objects.equals(_link, copiedExperiment.getPublicationLink())
-                    && Objects.equals(_citation, copiedExperiment.getCitation()));
         }
     }
 
@@ -9849,7 +9845,7 @@ public class PanoramaPublicController extends SpringActionController
                 {
                     continue;
                 }
-                Announcement announcement = announcementSvc.getAnnouncement(announcementsContainer, getUser(), submission.getAnnouncementId());
+                Announcement announcement = submission.getAnnouncement(announcementSvc, announcementsContainer, getUser());
                 if (announcement == null)
                 {
                     continue; // old data before we started posting submission requests to a message board

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -6876,6 +6876,11 @@ public class PanoramaPublicController extends SpringActionController
                     return null;
                 }
 
+                if (_journalSubmission.hasPendingSubmission())
+                {
+                    errors.reject(ERROR_MSG, String.format("There is a pending re-submit request for this experiment on '%s'", _journal.getName()));
+                    return null;
+                }
                 if (expAnnot.isJournalCopy())
                 {
                     if (!_journalSubmission.isLatestExperimentCopy(_expAnnot.getId()))
@@ -6892,11 +6897,6 @@ public class PanoramaPublicController extends SpringActionController
                     if (copiedExperiment == null)
                     {
                         errors.reject(ERROR_MSG, String.format("Cannot find a copy of experiment Id %d on '%s'", expAnnot.getId(), _journal.getName()));
-                        return null;
-                    }
-                    if (submission.isPending())
-                    {
-                        errors.reject(ERROR_MSG, String.format("There is a pending re-submit request for experiment Id %d on '%s'", expAnnot.getId(), _journal.getName()));
                         return null;
                     }
                     return copiedExperiment;

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicNotification.java
@@ -396,14 +396,15 @@ public class PanoramaPublicNotification
         message.append("Dear ").append(getUserName(submitter)).append(",").append(NL2)
                 .append("We are reaching out regarding your data on Panorama Public (").append(shortUrl).append("), which has been private since ")
                 .append(dateString).append(".")
-                .append("\n\n**Is the paper associated with this work already published?**")
-                .append("\n- If yes: Please make your data public by clicking the \"Make Public\" button in your folder or by clicking this link: ")
+                .append(NL2).append(bold("Title:")).append(" ").append(escape(exptAnnotations.getTitle()))
+                .append(NL2).append(bold("Is the paper associated with this work already published?"))
+                .append(NL).append("- If yes: Please make your data public by clicking the \"Make Public\" button in your folder or by clicking this link: ")
                 .append(bold(link("Make Data Public", makePublicLink)))
                 .append(". This helps ensure that your valuable research is easily accessible to the community.")
-                .append("\n- If not: You have a couple of options:")
-                .append("\n  - **Request an Extension** - If your paper is still under review, or you need additional time, please let us know by clicking ")
+                .append(NL).append("- If not: You have a couple of options:")
+                .append(NL).append("  - ").append(bold("Request an Extension")).append(" - If your paper is still under review, or you need additional time, please let us know by clicking ")
                 .append(bold(link("Request Extension", requestExtensionUrl.getURIString()))).append(".")
-                .append("\n  - **Delete from Panorama Public** - If you no longer wish to host your data on Panorama Public, please click ")
+                .append(NL).append("  - ").append(bold("Delete from Panorama Public")).append(" - If you no longer wish to host your data on Panorama Public, please click ")
                 .append(bold(link("Request Deletion", requesDeletionUrl.getURIString()))).append(". ")
                 .append("We will remove your data from Panorama Public.");
         if (sourceExperiment != null)
@@ -413,9 +414,9 @@ public class PanoramaPublicNotification
                     .append(") will remain intact, allowing you to resubmit your data in the future if you wish.");
         }
 
-        message.append("\n\nIf you have any questions or need further assistance, please do not hesitate to respond to this message by ")
+        message.append(NL2).append("If you have any questions or need further assistance, please do not hesitate to respond to this message by ")
         .append(bold(link("clicking here", respondToMessageUrl.getURIString()))).append(".")
-        .append("\n\nThank you for sharing your research on Panorama Public. We appreciate your commitment to open science and your contributions to the research community.")
+        .append(NL2).append("Thank you for sharing your research on Panorama Public. We appreciate your commitment to open science and your contributions to the research community.")
         .append(NL2).append("Best regards,")
         .append(NL).append(getUserName(journalAdmin));
         return message.toString();

--- a/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/ExperimentAnnotations.java
@@ -224,6 +224,11 @@ public class ExperimentAnnotations extends DbEntity
         return instruments;
     }
 
+    public String getInstrumentsCommaSeparated()
+    {
+        return StringUtils.join(getInstruments(), ", ");
+    }
+
     public void setInstrument(String instrument)
     {
         _instrument = instrument;
@@ -504,12 +509,12 @@ public class ExperimentAnnotations extends DbEntity
 
     /**
      * Returns true if the experiment is in an 'Experimental Data' folder that is public and the experiment is
-     * associated with a published paper.
+     * associated with a peer-reviewed paper (excludes biorxiv and medrxiv preprint servers).
      */
     public boolean isFinal()
     {
         TargetedMSService.FolderType folderType = TargetedMSService.get().getFolderType(getContainer());
-        return Experiment.equals(folderType) && isPublic() && isPublished();
+        return Experiment.equals(folderType) && isPublic() && isPeerReviewed();
     }
 
     public boolean hasCompletePublicationInfo()

--- a/panoramapublic/src/org/labkey/panoramapublic/model/JournalSubmission.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/model/JournalSubmission.java
@@ -2,6 +2,10 @@ package org.labkey.panoramapublic.model;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.announcements.api.Announcement;
+import org.labkey.api.announcements.api.AnnouncementService;
+import org.labkey.api.data.Container;
+import org.labkey.api.security.User;
 import org.labkey.api.view.ShortURLRecord;
 import org.labkey.panoramapublic.query.SubmissionManager;
 
@@ -69,9 +73,18 @@ public class JournalSubmission
         return _journalExperiment.getModifiedBy();
     }
 
-    public Integer getAnnouncementId()
+    public @Nullable Integer getAnnouncementId()
     {
         return _journalExperiment.getAnnouncementId();
+    }
+
+    public @Nullable Announcement getAnnouncement(@NotNull AnnouncementService announcementSvc,
+                                                                @NotNull Container announcementsContainer,
+                                                                @NotNull User user)
+    {
+        return (getAnnouncementId() != null)
+                ? announcementSvc.getAnnouncement(announcementsContainer, user, getAnnouncementId())
+                : null; // old data before we started posting submission requests to a message board
     }
 
     public Integer getReviewerId()

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/PostPanoramaPublicMessageJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/PostPanoramaPublicMessageJob.java
@@ -103,7 +103,8 @@ public class PostPanoramaPublicMessageJob extends PipelineJob
                     continue;
                 }
 
-                Announcement announcement = announcementSvc.getAnnouncement(announcementsContainer, getUser(), submission.getAnnouncementId());
+                Announcement announcement = submission.getAnnouncement(announcementSvc, announcementsContainer, getUser());
+
                 if (announcement == null)
                 {
                     getLogger().error("Could not find the message thread for experiment Id: " + experimentAnnotationsId

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/PrivateDataReminderJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/PrivateDataReminderJob.java
@@ -100,6 +100,13 @@ public class PrivateDataReminderJob extends PipelineJob
             return ReminderDecision.skip("Not the current version of the experiment");
         }
 
+        // Make sure the data does not have a pending re-submission request
+        JournalSubmission journalSubmission = SubmissionManager.getSubmissionForJournalCopy(exptAnnotations);
+        if (journalSubmission != null && journalSubmission.hasPendingSubmission())
+        {
+            return ReminderDecision.skip("Data has a pending re-submission request");
+        }
+
         DatasetStatus datasetStatus = DatasetStatusManager.getForExperiment(exptAnnotations);
         if (datasetStatus != null)
         {
@@ -244,7 +251,7 @@ public class PrivateDataReminderJob extends PipelineJob
         }
 
         Container announcementsFolder = context.getAnnouncementsFolder();
-        Announcement announcement = context.getAnnouncementService().getAnnouncement(announcementsFolder, getUser(), submission.getAnnouncementId());
+        Announcement announcement = submission.getAnnouncement(context.getAnnouncementService(), context.getAnnouncementsFolder(), getUser());
         if (announcement == null)
         {
             processingResults.addAnnouncementNotFound(experimentAnnotationsId, submission, announcementsFolder);

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PxHtmlWriter.java
@@ -300,7 +300,7 @@ public class PxHtmlWriter extends PxWriter
         HtmlList publicationList = new HtmlList();
         if(experimentAnnotations.isPublished())
         {
-            publicationList.addItem("Link: ", experimentAnnotations.getPublicationLink(), false);
+            publicationList.addItem("Link", experimentAnnotations.getPublicationLink(), false);
 
             if(experimentAnnotations.hasPubmedId())
             {

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -337,7 +337,7 @@
  <li><strong>Organism:</strong> <%=h(annot.getOrganismsNoTaxId())%></li>
     <%}%>
     <%if(annot.getInstrument() != null){%>
- <li><strong>Instrument:</strong> <%=h(annot.getInstrument())%></li>
+ <li><strong>Instrument:</strong> <%=h(annot.getInstrumentsCommaSeparated())%></li>
     <%}%>
     <%if(annot.getSpikeIn() != null){%>
  <li><strong>SpikeIn:</strong>

--- a/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
+++ b/panoramapublic/test/src/org/labkey/test/components/panoramapublic/TargetedMsExperimentWebPart.java
@@ -2,9 +2,15 @@ package org.labkey.test.components.panoramapublic;
 
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
+import org.labkey.test.WebTest;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.WebElement;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -81,6 +87,24 @@ public class TargetedMsExperimentWebPart extends BodyWebPart <TargetedMsExperime
     public void clickMakePublic()
     {
         clickLink(elementCache().makePublicButton, "Expected to see a \"Make Public\" button");
+    }
+
+    public Integer getExperimentAnnotationsId()
+    {
+        WebElement moreDetailsLink = elementCache().moreDetailsLink;
+        if (moreDetailsLink != null)
+        {
+            String href = moreDetailsLink.getAttribute("href");
+            try
+            {
+                return Integer.parseInt(WebTestHelper.parseUrlQuery(new URL(href)).get("id"));
+            }
+            catch (MalformedURLException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
     }
 
     public void clickAddPublication()

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
@@ -50,7 +50,7 @@ public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
         // Verify that a folder admin in the source folder, who is not the submitter or lab head will not see the
         // "Make Public" button in the Panorama Public copy.
         verifyMakePublicButtonIsNotVisible(PANORAMA_PUBLIC, targetFolder, ADMIN_2,
-                "Make Public button should not be visible to a non-submitter and non-lab head user in the Panorama Public copy");
+                "Make Public button should not be visible in the Panorama Public copy to a user who is neither submitter nor lab head");
 
         // Verify that the submitter can make the data public
         verifyMakePublic(PANORAMA_PUBLIC, targetFolder, SUBMITTER, true);
@@ -58,11 +58,11 @@ public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
         // Resubmit the folder.  This is still possible since the Panorama Public copy is not yet associated with a publication.
         resubmitFolder(projectName, folderName, SUBMITTER, true);
 
-        // Data copy is pending. Verify that the "Make Public" button in not available in the source folder or the copied folder
+        // Data copy is pending. Verify that the "Make Public" button in not visible in the source folder or the copied folder
         verifyMakePublicButtonIsNotVisible(PANORAMA_PUBLIC, targetFolder, SUBMITTER,
-                "Make Public button should not be visible in the Panorama Public copy for submitter if data copy is pending");
+                "Make Public button should not be visible in the Panorama Public copy if data copy is pending");
         verifyMakePublicButtonIsNotVisible(projectName, folderName, SUBMITTER,
-                "Make Public button should not be visible in the Panorama Public copy for submitter if data copy is pending");
+                "Make Public button should not be visible in the source folder if data copy is pending");
 
         // Verify that the submitter cannot enter the MakePublicAction URL in the browser to make the data public
         verifyCannotMakePublicPendingResubmit(PANORAMA_PUBLIC, targetFolder, SUBMITTER); // In the target folder
@@ -297,7 +297,7 @@ public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
         stopImpersonating();
     }
 
-    private void verifyMakePublicButtonVisible(boolean visible, String projectName, String folderName, String user, String errorMessage)
+    private void verifyMakePublicButtonVisible(boolean expectVisible, String projectName, String folderName, String user, String errorMessage)
     {
         if (isImpersonating())
         {
@@ -308,7 +308,7 @@ public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
         goToDashboard();
         TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
 
-        if (visible)
+        if (expectVisible)
         {
             assertTrue(errorMessage, expWebPart.hasMakePublicButton());
         }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMakePublicTest.java
@@ -18,11 +18,13 @@ import org.labkey.test.util.PermissionsHelper;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @Category({External.class, MacCossLabModules.class})
@@ -45,24 +47,38 @@ public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
         verifyIsPublicColumn(PANORAMA_PUBLIC, experimentTitle, false);
         verifyPermissions(projectName, folderName, PANORAMA_PUBLIC, targetFolder);
 
-        // Verify that the submitter can make the data public
-        verifyMakePublic(PANORAMA_PUBLIC, targetFolder, SUBMITTER, true);
         // Verify that a folder admin in the source folder, who is not the submitter or lab head will not see the
         // "Make Public" button in the Panorama Public copy.
-        verifyMakePublic(PANORAMA_PUBLIC, targetFolder, ADMIN_2, false);
+        verifyMakePublicButtonIsNotVisible(PANORAMA_PUBLIC, targetFolder, ADMIN_2,
+                "Make Public button should not be visible to a non-submitter and non-lab head user in the Panorama Public copy");
+
+        // Verify that the submitter can make the data public
+        verifyMakePublic(PANORAMA_PUBLIC, targetFolder, SUBMITTER, true);
 
         // Resubmit the folder.  This is still possible since the Panorama Public copy is not yet associated with a publication.
         resubmitFolder(projectName, folderName, SUBMITTER, true);
+
+        // Data copy is pending. Verify that the "Make Public" button in not available in the source folder or the copied folder
+        verifyMakePublicButtonIsNotVisible(PANORAMA_PUBLIC, targetFolder, SUBMITTER,
+                "Make Public button should not be visible in the Panorama Public copy for submitter if data copy is pending");
+        verifyMakePublicButtonIsNotVisible(projectName, folderName, SUBMITTER,
+                "Make Public button should not be visible in the Panorama Public copy for submitter if data copy is pending");
+
+        // Verify that the submitter cannot enter the MakePublicAction URL in the browser to make the data public
+        verifyCannotMakePublicPendingResubmit(PANORAMA_PUBLIC, targetFolder, SUBMITTER); // In the target folder
+        verifyCannotMakePublicPendingResubmit(projectName, folderName, SUBMITTER); // In the source folder
 
         // Re-copy the experiment to the Panorama Public project. Do not delete the previous copy
         makeCopy(shortAccessUrl, experimentTitle, targetFolder, true, false);
 
         // Verify that the "Make Public button is not visible in the older copy of the data.
         String v1Folder = targetFolder + " V.1";
-        verifyMakePublic(PANORAMA_PUBLIC, v1Folder, SUBMITTER, true);
-        // Verify that the submitter can make data public, and add publication details
+        verifyMakePublicButtonIsNotVisible(PANORAMA_PUBLIC, v1Folder, SUBMITTER,
+                "Make Public button should not be visible in an older copy of the data");
+        verifyCannotMakePublicOldCopy(PANORAMA_PUBLIC, v1Folder, SUBMITTER);
+
+        // Verify that the submitter can make the latest copy of the data public, and add publication details
         verifyMakePublic(PANORAMA_PUBLIC, targetFolder, SUBMITTER, true, true);
-        verifyMakePublic(PANORAMA_PUBLIC, v1Folder, ADMIN_2, false);
 
         verifyIsPublicColumn(PANORAMA_PUBLIC, experimentTitle, true);
 
@@ -280,6 +296,64 @@ public class PanoramaPublicMakePublicTest extends PanoramaPublicBaseTest
         }
         stopImpersonating();
     }
+
+    private void verifyMakePublicButtonVisible(boolean visible, String projectName, String folderName, String user, String errorMessage)
+    {
+        if (isImpersonating())
+        {
+            stopImpersonating(true);
+        }
+        goToProjectFolder(projectName, folderName);
+        impersonate(user);
+        goToDashboard();
+        TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
+
+        if (visible)
+        {
+            assertTrue(errorMessage, expWebPart.hasMakePublicButton());
+        }
+        else
+        {
+            assertFalse(errorMessage, expWebPart.hasMakePublicButton());
+        }
+    }
+
+    private void verifyMakePublicButtonIsVisible(String projectName, String folderName, String user, String errorMessage)
+    {
+        verifyMakePublicButtonVisible(true, projectName, folderName, user, errorMessage);
+    }
+
+    private void verifyMakePublicButtonIsNotVisible(String projectName, String folderName, String user, String errorMessage)
+    {
+        verifyMakePublicButtonVisible(false, projectName, folderName, user, errorMessage);
+    }
+
+    private void verifyCannotMakePublicOldCopy(String projectName, String folderName, String user)
+    {
+        verifyCannotMakePublic(projectName, folderName, user, "not the most recent copy of the data");
+    }
+
+    private void verifyCannotMakePublicPendingResubmit(String projectName, String folderName, String user)
+    {
+        verifyCannotMakePublic(projectName, folderName, user, "There is a pending re-submit request for this experiment");
+    }
+
+    private void verifyCannotMakePublic(String projectName, String folderName, String user, String expectedMessage)
+    {
+        if (isImpersonating())
+        {
+            stopImpersonating(true);
+        }
+        goToProjectFolder(projectName, folderName);
+        impersonate(user);
+        goToDashboard();
+        TargetedMsExperimentWebPart expWebPart = new TargetedMsExperimentWebPart(this);
+        Integer expAnnotationsId = expWebPart.getExperimentAnnotationsId();
+        assertNotNull(expAnnotationsId);
+        beginAt(WebTestHelper.buildURL("panoramapublic", getCurrentContainerPath(), "makePublic", Map.of("id", expAnnotationsId)));
+        waitForText(expectedMessage);
+    }
+
 
     private void makeDataPublic()
     {


### PR DESCRIPTION
#### Changes
- Do not send private data reminders for datasets that may have been resubmitted and are pending copy.
- Fix NPE in `PrivateDataReminderJob` when a submitted experiment has no associated `announcementId`.
- Allow re-submitting data that is already public but not yet published in a peer-reviewed journal e.g., manuscript is on pre-print servers like bioRxiv or medRxiv.
- Removed logic that prevented making data public when full publication details were entered at submission time but the data was kept private.
- Include experiment title in the private data reminder message
- Updated `PanoramaPublicMakePublicTest` to verify that data pending copy cannot be made public by entering the MakePublicAction URL in the browser
