### PR TITLE
Fix stale element exception on panorama dashboard

### DIFF
--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -193,7 +193,7 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     private DataRegionTable myDataView()
     {
         // The "Panorama Public Search" webpart re-renders the "Targeted MS Experiment List" webpart with a different
-        // name which can cause a StaleElementReferenceException. Find the dataregion by the updated webpart title.
+        // title which can cause a StaleElementReferenceException. Find the dataregion by the updated webpart title.
         var table = new DataRegionTable.DataRegionFinder(getDriver())
             .find(WebPartPanel.WebPart(getDriver()).withTitle("Panorama Public Experiments").waitFor());
         assertTrue(table.hasHeaderMenu("My Data"));

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -192,8 +192,8 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     @NotNull
     private DataRegionTable myDataView()
     {
-        // The "Panorama Public Search" re-renders the "Targeted MS Experiment List" webpart with a different name which
-        // can cause a StaleElementReferenceException. Find the dataregion by the updated webpart title.
+        // The "Panorama Public Search" webpart re-renders the "Targeted MS Experiment List" webpart with a different
+        // name which can cause a StaleElementReferenceException. Find the dataregion by the updated webpart title.
         var table = new DataRegionTable.DataRegionFinder(getDriver())
             .find(WebPartPanel.WebPart(getDriver()).withTitle("Panorama Public Experiments").waitFor());
         assertTrue(table.hasHeaderMenu("My Data"));

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -192,8 +192,8 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     @NotNull
     private DataRegionTable myDataView()
     {
-        // "Panorama Public Search" re-renders webpart with a different name which can cause a
-        // StaleElementReferenceException. Find the dataregion by the updated webpart title.
+        // The "Panorama Public Search" re-renders the "Targeted MS Experiment List" webpart with a different name which
+        // can cause a StaleElementReferenceException. Find the dataregion by the updated webpart title.
         var table = new DataRegionTable.DataRegionFinder(getDriver())
             .find(WebPartPanel.WebPart(getDriver()).withTitle("Panorama Public Experiments").waitFor());
         assertTrue(table.hasHeaderMenu("My Data"));

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -7,6 +7,7 @@ import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.categories.External;
 import org.labkey.test.categories.MacCossLabModules;
+import org.labkey.test.components.WebPartPanel;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.DataRegionTable;
 import org.openqa.selenium.By;
@@ -191,7 +192,10 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     @NotNull
     private DataRegionTable myDataView()
     {
-        var table = new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();
+        // "Panorama Public Search" re-renders webpart with a different name which can cause a
+        // StaleElementReferenceException. Find the dataregion by the updated webpart title.
+        var table = new DataRegionTable.DataRegionFinder(getDriver())
+            .find(WebPartPanel.WebPart(getDriver()).withTitle("Panorama Public Experiments").waitFor());
         assertTrue(table.hasHeaderMenu("My Data"));
         table.clickHeaderButtonAndWait("My Data");
         return new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();


### PR DESCRIPTION
#### Rationale
The "Panorama Public Search" webpart re-renders the "Targeted MS Experiment List" webpart with a different title which can cause a StaleElementReferenceException. Finding the dataregion by the updated webpart title should avoid this.

```
org.openqa.selenium.StaleElementReferenceException: The element with the reference d929f1f2-8349-4e30-8ab1-8b42f437c3e4 is stale; either its node document is not the active document, or it is no longer connected to the DOM
[...]
  at app//org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:79)
  at app//org.labkey.test.selenium.WebElementWrapper.isEnabled(WebElementWrapper.java:79)
  at app//org.labkey.test.util.DataRegion.elementCache(DataRegion.java:98)
  at app//org.labkey.test.util.DataRegionTable.elementCache(DataRegionTable.java:107)
  at app//org.labkey.test.util.DataRegionTable.elementCache(DataRegionTable.java:1)
  at app//org.labkey.test.util.DataRegion.hasHeaderMenu(DataRegion.java:270)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.myDataView(PanoramaPublicMyDataViewTest.java:195)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.verifyColumnValues(PanoramaPublicMyDataViewTest.java:156)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.viewSubmitterData(PanoramaPublicMyDataViewTest.java:127)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.testMyDataView(PanoramaPublicMyDataViewTest.java:81)
```

#### Related Pull Requests
* N/A

#### Changes
* Fix stale element exception with panorama dashboard