### PR TITLE
Continue adopting FileLike instead of File or Path

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -1180,7 +1180,7 @@ public class SkylineToolsStoreController extends SpringActionController
                 }
                 else
                 {
-                    PageFlowUtil.streamFile(getViewContext().getResponse(), downloadFile, true);
+                    PageFlowUtil.streamFile(getViewContext().getResponse(), downloadFile.toPath(), true);
                     return null;
                 }
             }

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -87,6 +87,7 @@ import org.labkey.lincs.psp.LincsPspPipelineJob;
 import org.labkey.lincs.psp.LincsPspUtil;
 import org.labkey.lincs.psp.PspEndpoint;
 import org.labkey.lincs.view.GctUtils;
+import org.labkey.vfs.FileLike;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -144,35 +145,32 @@ public class LincsController extends SpringActionController
         }
     }
 
-    private void copyFiles(Path gctDir, String outputFileBaseName, Path gct, File reportDir) throws IOException
+    private void copyFiles(Path gctDir, String outputFileBaseName, Path gct, FileLike reportDir) throws IOException
     {
         // reportDir is a local directory under tomcat's temp directory
-        File[] reportDirFiles = reportDir.listFiles(new FilenameFilter()
+        List<FileLike> reportDirFiles = reportDir.getChildren((f) ->
         {
-            @Override
-            public boolean accept(File dir, String name)
-            {
-                return name.toLowerCase().endsWith(".txt")
+            String name = f.getName();
+            return name.toLowerCase().endsWith(".txt")
                         || name.toLowerCase().endsWith(".gct")
                         || name.equals("script.Rout");
-            }
         });
 
         // The report should create two files: lincs.gct and lincs.processed.gct
         // Copy both to the GCT folder
-        for(File file: reportDirFiles)
+        for(FileLike file: reportDirFiles)
         {
             if(file.getName().equalsIgnoreCase("lincs.gct"))
             {
-                Files.copy(file.toPath(), gct, StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(file.toNioPathForRead(), gct, StandardCopyOption.REPLACE_EXISTING);
             }
             else if(file.getName().equalsIgnoreCase("console.txt"))
             {
-                Files.copy(file.toPath(), gctDir.resolve(outputFileBaseName + ".console.txt" ), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(file.toNioPathForRead(), gctDir.resolve(outputFileBaseName + ".console.txt" ), StandardCopyOption.REPLACE_EXISTING);
             }
             else if(file.getName().equals("script.Rout"))
             {
-                Files.copy(file.toPath(), gctDir.resolve(outputFileBaseName + ".script.Rout" ), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(file.toNioPathForRead(), gctDir.resolve(outputFileBaseName + ".script.Rout" ), StandardCopyOption.REPLACE_EXISTING);
             }
         }
     }
@@ -306,11 +304,11 @@ public class LincsController extends SpringActionController
             }
             catch(Exception e)
             {
-                copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDir(getContainer().getId()));
+                copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDirFileLike(getContainer().getId()));
                 throw new ApiUsageException("There was an error running the GCT R script.", e);
             }
 
-            copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDir(getContainer().getId()));
+            copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDirFileLike(getContainer().getId()));
 
             if(!Files.exists(downloadFile))
             {

--- a/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
@@ -43,7 +43,7 @@ public class LincsPspPipelineJob extends PipelineJob implements LincsPspJobSuppo
         String baseLogFileName = FileUtil.makeFileNameWithTimestamp("LincsPSP_" + (_oldPspJob != null ? "rerun_" : "") + run.getBaseName().replace(" ", "_"));
 
         LocalDirectory localDirectory = LocalDirectory.create(root, baseLogFileName,
-                !root.isCloudRoot() ? root.getRootPath().getAbsolutePath() : FileUtil.getTempDirectory().getPath());
+                !root.isCloudRoot() ? root.getRootFileLike() : FileUtil.getTempDirectoryFileLike());
         setLocalDirectory(localDirectory);
         setLogFile(localDirectory.determineLogFile());
 

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
@@ -25,7 +25,6 @@ import org.labkey.nextflow.NextFlowManager;
 import org.labkey.vfs.FileLike;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -117,7 +116,7 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     @Override
     public String getDescription()
     {
-        return "NextFlow analysis of " + StringUtilsLabKey.pluralize(getInputFilePaths().size(), "file") + " using config: " + config.getName();
+        return "NextFlow analysis of " + StringUtilsLabKey.pluralize(getInputFiles().size(), "file") + " using config: " + config.getName();
     }
 
     @Override
@@ -139,13 +138,13 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     }
 
     @Override
-    public File findInputFile(String name)
+    public FileLike findInputFile(String name)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public File findOutputFile(String name)
+    public FileLike findOutputFile(String name)
     {
         return null;
     }

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
@@ -19,7 +19,6 @@ import org.labkey.nextflow.NextFlowManager;
 import org.labkey.vfs.FileLike;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -76,7 +75,7 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
             // Need to pass to the main process directly in the future to allow concurrent execution for different users
             ProcessBuilder secretsPB = new ProcessBuilder("nextflow", "secrets", "set", "PANORAMA_API_KEY", apiKey);
             log.info("Setting secrets");
-            File dir = getJob().getLogFile().getParentFile();
+            FileLike dir = getJob().getLogFileLike().getParent();
             getJob().runSubProcess(secretsPB, dir);
 
             ProcessBuilder executionPB = new ProcessBuilder(getArgs());
@@ -85,9 +84,9 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
             NextFlowPipelineJob.LOG.info("Finished executing NextFlow: {}", getJob().getJsonJobInfo(true));
 
             RecordedAction action = new RecordedAction(ACTION_NAME);
-            for (Path inputFile : getJob().getInputFilePaths())
+            for (FileLike inputFile : getJob().getInputFiles())
             {
-                action.addInput(inputFile.toFile(), SPECTRA_INPUT_ROLE);
+                action.addInput(inputFile, SPECTRA_INPUT_ROLE);
             }
             addOutputs(action, getJob().getLogFilePath().getParent().resolve("reports"), log);
             addOutputs(action, getJob().getLogFilePath().getParent().resolve("results"), log);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -4723,7 +4723,7 @@ public class PanoramaPublicController extends SpringActionController
             }
             else
             {
-                return FileSystemLike.wrapFile(fileRoot.resolve(fileName));
+                return FileSystemLike.wrapFile(fileRoot).resolveChild(fileName);
             }
         }
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -139,6 +139,7 @@ import org.labkey.api.view.*;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiRenderingService;
+import org.labkey.api.writer.PrintWriters;
 import org.labkey.panoramapublic.bluesky.BlueskyApiClient;
 import org.labkey.panoramapublic.bluesky.BlueskyException;
 import org.labkey.panoramapublic.bluesky.BlueskySettingsManager;
@@ -4617,11 +4618,11 @@ public class PanoramaPublicController extends SpringActionController
             }
         }
 
-        private File writePxXmlFile(String xmlString) throws PxException
+        private FileLike writePxXmlFile(String xmlString) throws PxException
         {
-            File xml = getLocalFile(getContainer(), "px.xml"); // TODO: Add date time stamp
+            FileLike xml = getLocalFile(getContainer(), "px.xml"); // TODO: Add date time stamp
 
-            try (PrintWriter out = new PrintWriter(new FileWriter(xml, StandardCharsets.UTF_8)))
+            try (PrintWriter out = PrintWriters.getPrintWriter(xml.openOutputStream()))
             {
                 out.write(xmlString);
             }
@@ -4656,7 +4657,7 @@ public class PanoramaPublicController extends SpringActionController
 
         private void validatePxXml(boolean useTestDb, String pxChangeLog, String pxUser, String pxPassword, BindException errors) throws PxException, ProteomeXchangeServiceException
         {
-            File xmlFile = writePxXmlFile(createPxXml(_expAnnot, _journalExperiment, _submission, _validationStatus, pxChangeLog, true).getXml());
+            FileLike xmlFile = writePxXmlFile(createPxXml(_expAnnot, _journalExperiment, _submission, _validationStatus, pxChangeLog, true).getXml());
             _pxResponse = ProteomeXchangeService.validatePxXml(xmlFile, useTestDb, pxUser, pxPassword);
             if(ProteomeXchangeService.responseHasErrors(_pxResponse))
             {
@@ -4677,7 +4678,7 @@ public class PanoramaPublicController extends SpringActionController
                 return;
             }
             PxXml pxXml = createPxXml(_expAnnot, _journalExperiment, _submission, _validationStatus, pxChangeLog, true);
-            File xmlFile = writePxXmlFile(pxXml.getXml());
+            FileLike xmlFile = writePxXmlFile(pxXml.getXml());
             _pxResponse = ProteomeXchangeService.submitPxXml(xmlFile, useTestDb, pxUser, pxPassword);
             if(ProteomeXchangeService.responseHasErrors(_pxResponse))
             {
@@ -4699,7 +4700,7 @@ public class PanoramaPublicController extends SpringActionController
             submitPxXml(useTestDb, testMode, pxChangeLog, pxUser, pxPassword, errors);
         }
 
-        private static File getLocalFile(Container container, String fileName) throws PxException
+        private static FileLike getLocalFile(Container container, String fileName) throws PxException
         {
             // File.createTempFile()
             java.nio.file.Path fileRoot = FileContentService.get().getFileRootPath(container, FileContentService.ContentType.files);
@@ -4713,7 +4714,7 @@ public class PanoramaPublicController extends SpringActionController
                 if (root != null)
                 {
                     LocalDirectory localDirectory = LocalDirectory.create(root);
-                    return new File(localDirectory.getLocalDirectoryFile(), fileName);
+                    return localDirectory.getLocalDirectoryFile().resolveChild(fileName);
                 }
                 else
                 {
@@ -4722,7 +4723,7 @@ public class PanoramaPublicController extends SpringActionController
             }
             else
             {
-                return fileRoot.resolve(fileName).toFile();
+                return FileSystemLike.wrapFile(fileRoot.resolve(fileName));
             }
         }
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -34,9 +34,6 @@ import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
 import org.labkey.vfs.FileLike;
 
-import java.io.File;
-import java.io.IOException;
-
 /**
  * User: vsharma
  * Date: 8/21/2014
@@ -118,7 +115,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     }
 
     @Override
-    public TaskPipeline getTaskPipeline()
+    public TaskPipeline<?> getTaskPipeline()
     {
         return PipelineJobService.get().getTaskPipeline(new TaskId(CopyExperimentPipelineJob.class));
     }
@@ -132,19 +129,6 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
            super.finallyCleanUpLocalDirectory();
        }
    }
-
-    public static File getLogFileFor(PipeRoot root, ExperimentAnnotations experimentAnnotations) throws IOException
-    {
-        File rootDir = root.getLogDirectory();
-        if (!rootDir.exists())
-        {
-            throw new IOException("Pipeline root directory " + rootDir.getAbsolutePath() + " does not exist.");
-        }
-
-        String logFileName = "Experiment_" + experimentAnnotations.getExperimentId() + ".log";
-
-        return new File(rootDir, logFileName);
-    }
 
     @Override
     public ExperimentAnnotations getExpAnnotations()

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/PxDataValidationPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/PxDataValidationPipelineJob.java
@@ -14,8 +14,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 
-import java.io.File;
-
 public class PxDataValidationPipelineJob extends PipelineJob implements PxDataValidationJobSupport
 {
     private final ExperimentAnnotations _experimentAnnotations;
@@ -41,7 +39,7 @@ public class PxDataValidationPipelineJob extends PipelineJob implements PxDataVa
         _description = String.format("Validating data for experiment Id: %d, validation Id: %d", experiment.getId(), validationId);
 
         String baseLogFileName = FileUtil.makeFileNameWithTimestamp("Experiment_Validation_" + experiment.getExperimentId(), "log");
-        setLogFile(new File(root.getLogDirectory(), baseLogFileName));
+        setLogFile(root.getLogDirectory(true).resolveChild(baseLogFileName));
 
         header("Validating data for a ProteomeXchange submission.");
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
@@ -17,10 +17,12 @@ package org.labkey.panoramapublic.proteomexchange;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.client5.http.entity.mime.InputStreamBody;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -28,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.logging.LogHelper;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,17 +52,17 @@ public class ProteomeXchangeService
 
     private static final Logger LOG = LogHelper.getLogger(ProteomeXchangeService.class, "Handles requests to the ProteomeXchange server");
 
-    public static String validatePxXml(File pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
+    public static String validatePxXml(FileLike pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
     {
         return postPxXml(pxxmlFile, testDatabase, user, pass, METHOD.validateXML);
     }
 
-    public static String submitPxXml(File pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
+    public static String submitPxXml(FileLike pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
     {
         return postPxXml(pxxmlFile, testDatabase, user, pass, METHOD.submitDataset);
     }
 
-    private static String postPxXml(File pxxmlFile, boolean testDatabase, String user, String pass, METHOD method) throws ProteomeXchangeServiceException
+    private static String postPxXml(FileLike pxxmlFile, boolean testDatabase, String user, String pass, METHOD method) throws ProteomeXchangeServiceException
     {
         String responseMessage;
         try {
@@ -118,12 +121,12 @@ public class ProteomeXchangeService
     }
 
     @NotNull
-    private static MultipartEntityBuilder getMultipartEntityBuilder(File pxxmlFile, boolean testDatabase, METHOD method, String user, String pass)
+    private static MultipartEntityBuilder getMultipartEntityBuilder(FileLike pxxmlFile, boolean testDatabase, METHOD method, String user, String pass) throws IOException
     {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
         if(pxxmlFile != null)
         {
-            builder.addPart("ProteomeXchangeXML", new FileBody(pxxmlFile));
+            builder.addPart("ProteomeXchangeXML", new InputStreamBody(pxxmlFile.openInputStream(), ContentType.TEXT_XML, pxxmlFile.getName()));
         }
         builder.addTextBody("PXPartner", user);
         builder.addTextBody("authentication", pass);
@@ -140,7 +143,7 @@ public class ProteomeXchangeService
         return builder;
     }
 
-    private static MultipartEntityBuilder getMultipartEntityBuilder(boolean testDatabase, METHOD method, String user, String pass)
+    private static MultipartEntityBuilder getMultipartEntityBuilder(boolean testDatabase, METHOD method, String user, String pass) throws IOException
     {
         return getMultipartEntityBuilder(null, testDatabase, method, user, pass);
     }


### PR DESCRIPTION
#### Rationale
We can continue to strengthen our protections against path traversal attacks and start phasing out deprecated and overloaded methods that take or return Files or Paths. 

### Related Pull Requests
- https://github.com/LabKey/platform/pull/7211

#### Changes
- Eliminate some overloaded, deprecated versions of methods taking `File` or `Path`
- Convert `LocalDirectory` and `WorkDirectory` to `FileLike`
- Use `FileLike` more consistently for transform scripts