### PR TITLE
Fix another stale element exception on panorama dashboard

### DIFF
--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -85,7 +85,7 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
         // Sign out. Guest should not be able to see the "My Data" button
         simpleSignOut();
         goToProjectHome(PANORAMA_PUBLIC);
-        var table = new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();
+        var table = findPanoramaPublicExperimentsDataRegion();
         assertFalse(table.hasHeaderMenu("My Data"));
 
         simpleSignIn();
@@ -192,12 +192,17 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     @NotNull
     private DataRegionTable myDataView()
     {
-        // The "Panorama Public Search" webpart re-renders the "Targeted MS Experiment List" webpart with a different
-        // title which can cause a StaleElementReferenceException. Find the dataregion by the updated webpart title.
-        var table = new DataRegionTable.DataRegionFinder(getDriver())
-            .find(WebPartPanel.WebPart(getDriver()).withTitle("Panorama Public Experiments").waitFor());
+        var table = findPanoramaPublicExperimentsDataRegion();
         assertTrue(table.hasHeaderMenu("My Data"));
         table.clickHeaderButtonAndWait("My Data");
         return new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();
+    }
+
+    // The "Panorama Public Search" webpart re-renders the "Targeted MS Experiment List" webpart with a different
+    // title which can cause a StaleElementReferenceException. Find the dataregion by the updated webpart title.
+    private DataRegionTable findPanoramaPublicExperimentsDataRegion()
+    {
+        return new DataRegionTable.DataRegionFinder(getDriver())
+            .find(WebPartPanel.WebPart(getDriver()).withTitle("Panorama Public Experiments").waitFor());
     }
 }


### PR DESCRIPTION
#### Rationale
The "Panorama Public Search" webpart re-renders the "Targeted MS Experiment List" webpart with a different title which can cause a StaleElementReferenceException. The [previous fix](https://github.com/LabKey/MacCossLabModules/pull/581) missed a reference to the same data region.
```
org.openqa.selenium.StaleElementReferenceException: The element with the reference 197461b8-3cf4-47e3-a6ff-ffc4911e5fd4 is stale; either its node document is not the active document, or it is no longer connected to the DOM
[...]
  at app//org.labkey.test.util.DataRegion.hasHeaderMenu(DataRegion.java:270)
  at app//org.labkey.test.tests.panoramapublic.PanoramaPublicMyDataViewTest.testMyDataView(PanoramaPublicMyDataViewTest.java:89)
```

#### Related Pull Requests
* #581 

#### Changes
* Fix another stale element exception on panorama dashboard