### PR TITLE
Fix failure in PanoramaWebPublicSearchTest due to invalid URL parameters

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -499,7 +499,6 @@
                                ];
                             }
 
-                            debugger;
                             let wp = new LABKEY.QueryWebPart({
                                 renderTo: 'webpart_'+ expWebpart[0].webPartId,
                                 title: 'Panorama Public Experiments',

--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -361,21 +361,26 @@
                 let instrument = document.getElementById(instrumentItemId).value;
 
                 let expSearchParams = "";
+                let separator = "";
                 if (author) {
                     expAnnotationFilters.push(createFilter(authorsItemId, author));
-                    expSearchParams += "Targeted MS Experiment List." + "authors~containsoneof" + "=" + encodeURIComponent(author) + "&";
+                    expSearchParams += separator + "Targeted MS Experiment List." + "authors~containsoneof=" + encodeURIComponent(author);
+                    separator = "&";
                 }
                 if (title) {
                     expAnnotationFilters.push(createFilter(titleItemId, title));
-                    expSearchParams += "Targeted MS Experiment List." + "title~containsoneof" + "=" + encodeURIComponent(title) + "&";
+                    expSearchParams += separator + "Targeted MS Experiment List." + "title~containsoneof=" + encodeURIComponent(title);
+                    separator = "&";
                 }
                 if (organism) {
                     expAnnotationFilters.push(createFilter(organismItemId, organism));
-                    expSearchParams += "Targeted MS Experiment List." + "organism~containsoneof" + "=" + encodeURIComponent(organism.replaceAll(",", ";")) + "&";
+                    expSearchParams += separator + "Targeted MS Experiment List." + "organism~containsoneof=" + encodeURIComponent(organism.replaceAll(",", ";"));
+                    separator = "&";
                 }
                 if (instrument) {
                     expAnnotationFilters.push(createFilter(instrumentItemId, instrument));
-                    expSearchParams += "Targeted MS Experiment List." + "instrument~containsoneof" + "=" + encodeURIComponent(instrument.replaceAll(",", ";"));
+                    expSearchParams += separator + "Targeted MS Experiment List." + "instrument~containsoneof" + "=" + encodeURIComponent(instrument.replaceAll(",", ";"));
+                    separator = "&";
                 }
                 if (expSearchParams !== "") {
                     location.replace(window.location.href + "?" + expSearchParams);
@@ -494,6 +499,7 @@
                                ];
                             }
 
+                            debugger;
                             let wp = new LABKEY.QueryWebPart({
                                 renderTo: 'webpart_'+ expWebpart[0].webPartId,
                                 title: 'Panorama Public Experiments',


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/bt310/3814947?buildTab=tests&status=failed&suite=org.labkey.test.Runner%3A+&package=org.labkey.test.tests.panoramapublic&class=PanoramaWebPublicSearchTest

We're generating invalid URLs with empty GET parameters. Example snippet:

`&Targeted%20MS%20Experiment%20List.authors~containsoneof=Doe&=&dataRegionName=Targeted%20MS%20Experiment%20List`

Tomcat 11 has gotten stricter about validating the URL structure.

#### Changes
* Don't blindly append `&` when we may not need the separator