### PR TITLE
Ignore blank idFile values in SpectrumSourceFiles table

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/speclib/LibSourceFile.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/speclib/LibSourceFile.java
@@ -1,6 +1,7 @@
 package org.labkey.panoramapublic.speclib;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public class LibSourceFile
 
     public boolean hasIdFile()
     {
-        return idFile != null;
+        return StringUtils.isNotBlank(idFile);
     }
 
     public @Nullable String getIdFile()


### PR DESCRIPTION
#### Rationale
`idfile` column values can be blank in a BiblioSpec library's (.blib) `SpectrumSourcefiles` table.  This causes a RuntimeValidationException during the Panorama Public data validation process. 

