### PR TITLE
Fix mutating SQL assertion in Tool Store download

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -1088,7 +1088,12 @@ public class SkylineToolsStoreController extends SpringActionController
                 // Cookie expires after 1 day
                 final int expires = 24 * 60 * 60;
 
-                SkylineToolsStoreManager.get().recordToolDownload(tool);
+                // Download counter is an incidental write on a GET action — use ignoreSqlUpdates()
+                // to avoid the dev-mode mutating SQL assertion (like auditing writes)
+                try (var ignored = SpringActionController.ignoreSqlUpdates())
+                {
+                    SkylineToolsStoreManager.get().recordToolDownload(tool);
+                }
 
                 DateFormat df = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss 'GMT'", Locale.US);
                 Calendar calendar = Calendar.getInstance();

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -1180,7 +1180,7 @@ public class SkylineToolsStoreController extends SpringActionController
                 }
                 else
                 {
-                    PageFlowUtil.streamFile(getViewContext().getResponse(), downloadFile, true);
+                    PageFlowUtil.streamFile(getViewContext().getResponse(), downloadFile.toPath(), true);
                     return null;
                 }
             }

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -87,6 +87,7 @@ import org.labkey.lincs.psp.LincsPspPipelineJob;
 import org.labkey.lincs.psp.LincsPspUtil;
 import org.labkey.lincs.psp.PspEndpoint;
 import org.labkey.lincs.view.GctUtils;
+import org.labkey.vfs.FileLike;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -144,35 +145,32 @@ public class LincsController extends SpringActionController
         }
     }
 
-    private void copyFiles(Path gctDir, String outputFileBaseName, Path gct, File reportDir) throws IOException
+    private void copyFiles(Path gctDir, String outputFileBaseName, Path gct, FileLike reportDir) throws IOException
     {
         // reportDir is a local directory under tomcat's temp directory
-        File[] reportDirFiles = reportDir.listFiles(new FilenameFilter()
+        List<FileLike> reportDirFiles = reportDir.getChildren((f) ->
         {
-            @Override
-            public boolean accept(File dir, String name)
-            {
-                return name.toLowerCase().endsWith(".txt")
+            String name = f.getName();
+            return name.toLowerCase().endsWith(".txt")
                         || name.toLowerCase().endsWith(".gct")
                         || name.equals("script.Rout");
-            }
         });
 
         // The report should create two files: lincs.gct and lincs.processed.gct
         // Copy both to the GCT folder
-        for(File file: reportDirFiles)
+        for(FileLike file: reportDirFiles)
         {
             if(file.getName().equalsIgnoreCase("lincs.gct"))
             {
-                Files.copy(file.toPath(), gct, StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(file.toNioPathForRead(), gct, StandardCopyOption.REPLACE_EXISTING);
             }
             else if(file.getName().equalsIgnoreCase("console.txt"))
             {
-                Files.copy(file.toPath(), gctDir.resolve(outputFileBaseName + ".console.txt" ), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(file.toNioPathForRead(), gctDir.resolve(outputFileBaseName + ".console.txt" ), StandardCopyOption.REPLACE_EXISTING);
             }
             else if(file.getName().equals("script.Rout"))
             {
-                Files.copy(file.toPath(), gctDir.resolve(outputFileBaseName + ".script.Rout" ), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(file.toNioPathForRead(), gctDir.resolve(outputFileBaseName + ".script.Rout" ), StandardCopyOption.REPLACE_EXISTING);
             }
         }
     }
@@ -306,11 +304,11 @@ public class LincsController extends SpringActionController
             }
             catch(Exception e)
             {
-                copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDir(getContainer().getId()));
+                copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDirFileLike(getContainer().getId()));
                 throw new ApiUsageException("There was an error running the GCT R script.", e);
             }
 
-            copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDir(getContainer().getId()));
+            copyFiles(gctDir, outputFileBaseName, downloadFile, rreport.getReportDirFileLike(getContainer().getId()));
 
             if(!Files.exists(downloadFile))
             {

--- a/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
@@ -43,7 +43,7 @@ public class LincsPspPipelineJob extends PipelineJob implements LincsPspJobSuppo
         String baseLogFileName = FileUtil.makeFileNameWithTimestamp("LincsPSP_" + (_oldPspJob != null ? "rerun_" : "") + run.getBaseName().replace(" ", "_"));
 
         LocalDirectory localDirectory = LocalDirectory.create(root, baseLogFileName,
-                !root.isCloudRoot() ? root.getRootPath().getAbsolutePath() : FileUtil.getTempDirectory().getPath());
+                !root.isCloudRoot() ? root.getRootFileLike() : FileUtil.getTempDirectoryFileLike());
         setLocalDirectory(localDirectory);
         setLogFile(localDirectory.determineLogFile());
 

--- a/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspPipelineJob.java
@@ -12,7 +12,6 @@ import org.labkey.api.targetedms.ITargetedMSRun;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ViewBackgroundInfo;
-import org.labkey.lincs.LincsModule;
 
 public class LincsPspPipelineJob extends PipelineJob implements LincsPspJobSupport
 {
@@ -43,7 +42,7 @@ public class LincsPspPipelineJob extends PipelineJob implements LincsPspJobSuppo
 
         String baseLogFileName = FileUtil.makeFileNameWithTimestamp("LincsPSP_" + (_oldPspJob != null ? "rerun_" : "") + run.getBaseName().replace(" ", "_"));
 
-        LocalDirectory localDirectory = LocalDirectory.create(root, LincsModule.NAME, baseLogFileName,
+        LocalDirectory localDirectory = LocalDirectory.create(root, baseLogFileName,
                 !root.isCloudRoot() ? root.getRootPath().getAbsolutePath() : FileUtil.getTempDirectory().getPath());
         setLocalDirectory(localDirectory);
         setLogFile(localDirectory.determineLogFile());

--- a/nextflow/src/org/labkey/nextflow/NextFlowController.java
+++ b/nextflow/src/org/labkey/nextflow/NextFlowController.java
@@ -39,6 +39,7 @@ import org.labkey.api.view.UnauthorizedException;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.nextflow.pipeline.NextFlowPipelineJob;
 import org.labkey.nextflow.pipeline.NextFlowProtocol;
+import org.labkey.vfs.FileLike;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -261,17 +262,17 @@ public class NextFlowController extends SpringActionController
         @Override
         public ModelAndView getView(AnalyzeForm o, boolean b, BindException errors)
         {
-            List<File> selectedFiles = o.getValidatedFiles(getContainer(), false);
+            List<FileLike> selectedFiles = o.getValidatedFiles(getContainer(), false);
             if (selectedFiles.isEmpty())
             {
                 return new HtmlView(HtmlString.of("Couldn't find input file(s)"));
             }
             // NextFlow operates on the full directory so show the list to the user, regardless of what they selected
             // from the file listing
-            File inputDir = selectedFiles.get(0).getParentFile();
+            FileLike inputDir = selectedFiles.get(0).getParent();
 
-            File[] inputFiles = inputDir.listFiles(new PipelineProvider.FileTypesEntryFilter(NextFlowProtocol.INPUT_TYPES));
-            if (inputFiles == null || inputFiles.length == 0)
+            List<FileLike> inputFiles = inputDir.getChildren().stream().filter(new PipelineProvider.FileTypesEntryFilter(NextFlowProtocol.INPUT_TYPES)).toList();
+            if (inputFiles.isEmpty())
             {
                 return new HtmlView(HtmlString.of("Couldn't find input file(s)"));
             }
@@ -290,7 +291,7 @@ public class NextFlowController extends SpringActionController
                                         INPUT(at(hidden, true, name, "launch", value, true)),
                                         Arrays.stream(o.getFile()).map(f -> INPUT(at(hidden, true, name, "file", value, f))).toList(),
                                         "Files: ",
-                                        UL(Arrays.stream(inputFiles).map(File::getName).map(DOM::LI)),
+                                        UL(inputFiles.stream().map(FileLike::getName).map(DOM::LI)),
                                         "Config: ",
                                         new SelectBuilder().name("configFile").addOptions(Arrays.stream(configFiles).filter(f -> f.isFile() && f.getName().toLowerCase().endsWith(".config")).map(File::getName).sorted(String.CASE_INSENSITIVE_ORDER).toList()).build(),
                                         DOM.BR(),
@@ -318,7 +319,7 @@ public class NextFlowController extends SpringActionController
             }
             else
             {
-                List<File> inputFiles = form.getValidatedFiles(getContainer());
+                List<FileLike> inputFiles = form.getValidatedFiles(getContainer());
                 if (inputFiles.isEmpty())
                 {
                     errors.reject(ERROR_MSG, "No input files");
@@ -327,7 +328,7 @@ public class NextFlowController extends SpringActionController
                 {
                     ViewBackgroundInfo info = getViewBackgroundInfo();
                     PipeRoot root = PipelineService.get().findPipelineRoot(info.getContainer());
-                    NextFlowPipelineJob job = NextFlowPipelineJob.create(info, root, configFile.toPath(), inputFiles.stream().map(File::toPath).toList());
+                    NextFlowPipelineJob job = NextFlowPipelineJob.create(info, root, configFile.toPath(), inputFiles);
                     PipelineService.get().queueJob(job);
                     LOG.info("NextFlow job queued: {}", job.getJsonJobInfo(false));
                 }

--- a/nextflow/src/org/labkey/nextflow/NextFlowModule.java
+++ b/nextflow/src/org/labkey/nextflow/NextFlowModule.java
@@ -47,7 +47,7 @@ public class NextFlowModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.000;
+        return 26.000;
     }
 
     @Override

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
@@ -20,7 +20,9 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.api.writer.PrintWriters;
 import org.labkey.nextflow.NextFlowManager;
+import org.labkey.vfs.FileLike;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -35,29 +37,29 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
 {
     protected static final Logger LOG = LogHelper.getLogger(NextFlowPipelineJob.class, "NextFlow jobs");
 
-    private Path config;
+    private FileLike config;
 
     @SuppressWarnings("unused") // For serialization
     protected NextFlowPipelineJob()
     {}
 
-    public static NextFlowPipelineJob create(ViewBackgroundInfo info, @NotNull PipeRoot root, Path templateConfig, List<Path> inputFiles) throws IOException
+    public static NextFlowPipelineJob create(ViewBackgroundInfo info, @NotNull PipeRoot root, Path templateConfig, List<FileLike> inputFiles) throws IOException
     {
-        Path parentDir = inputFiles.get(0).getParent();
+        FileLike parentDir = inputFiles.get(0).getParent();
 
         String jobName = FileUtil.makeFileNameWithTimestamp("NextFlow");
-        Path jobDir = parentDir.resolve(jobName);
-        Path log = jobDir.resolve(jobName + ".log");
+        FileLike jobDir = parentDir.resolveChild(jobName);
+        FileLike log = jobDir.resolveChild(jobName + ".log");
         FileUtil.createDirectory(jobDir);
 
-        Path config = createConfig(templateConfig, parentDir, jobDir, info.getContainer());
+        FileLike config = createConfig(templateConfig, parentDir, jobDir, info.getContainer());
 
         return new NextFlowPipelineJob(info, root, config, inputFiles, log);
     }
 
-    public NextFlowPipelineJob(ViewBackgroundInfo info, @NotNull PipeRoot root, Path config, List<Path> inputFiles, Path log) throws IOException
+    public NextFlowPipelineJob(ViewBackgroundInfo info, @NotNull PipeRoot root, FileLike config, List<FileLike> inputFiles, FileLike log) throws IOException
     {
-        super(new NextFlowProtocol(), NextFlowPipelineProvider.NAME, info, root, config.getFileName().toString(), config, inputFiles, false, false);
+        super(new NextFlowProtocol(), NextFlowPipelineProvider.NAME, info, root, config.getName(), config, inputFiles, false);
         this.config = config;
         setLogFile(log);
     }
@@ -69,7 +71,7 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
         result.put("container", getContainer().getPath());
         result.put("filePath", getLogFilePath().getParent().toString());
         result.put("runName", getNextFlowRunName(includeInvocationCount));
-        result.put("configFile", getConfig().getFileName().toString());
+        result.put("configFile", getConfig().getName());
         return result;
     }
 
@@ -88,7 +90,7 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     }
 
     /** Take the template config file and substitute in the values for this job */
-    private static Path createConfig(Path configTemplate, Path parentDir, Path jobDir, Container container) throws IOException
+    private static FileLike createConfig(Path configTemplate, FileLike parentDir, FileLike jobDir, Container container) throws IOException
     {
         String template;
         try (InputStream in = Files.newInputStream(configTemplate))
@@ -104,8 +106,8 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
         uploadUrl = StringUtils.stripEnd(uploadUrl, "/");
         substitutedContent = substitutedContent.replace("${panorama.upload_url}", "panorama.upload_url = '" + uploadUrl + "'");
 
-        Path substitutedFile = jobDir.resolve(configTemplate.getFileName());
-        try (BufferedWriter writer = Files.newBufferedWriter(substitutedFile))
+        FileLike substitutedFile = jobDir.resolveChild(configTemplate.getFileName().toString());
+        try (BufferedWriter writer = new BufferedWriter(PrintWriters.getPrintWriter(substitutedFile.openOutputStream())))
         {
             writer.write(substitutedContent);
         }
@@ -115,7 +117,7 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     @Override
     public String getDescription()
     {
-        return "NextFlow analysis of " + StringUtilsLabKey.pluralize(getInputFilePaths().size(), "file") + " using config: " + config.getFileName();
+        return "NextFlow analysis of " + StringUtilsLabKey.pluralize(getInputFilePaths().size(), "file") + " using config: " + config.getName();
     }
 
     @Override
@@ -131,7 +133,7 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     }
 
     @Override
-    public AbstractFileAnalysisJob createSingleFileJob(File file)
+    public AbstractFileAnalysisJob createSingleFileJob(FileLike file)
     {
         throw new UnsupportedOperationException();
     }

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowPipelineJob.java
@@ -25,7 +25,6 @@ import org.labkey.nextflow.NextFlowManager;
 import org.labkey.vfs.FileLike;
 
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -117,7 +116,7 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     @Override
     public String getDescription()
     {
-        return "NextFlow analysis of " + StringUtilsLabKey.pluralize(getInputFilePaths().size(), "file") + " using config: " + config.getName();
+        return "NextFlow analysis of " + StringUtilsLabKey.pluralize(getInputFiles().size(), "file") + " using config: " + config.getName();
     }
 
     @Override
@@ -139,13 +138,13 @@ public class NextFlowPipelineJob extends AbstractFileAnalysisJob
     }
 
     @Override
-    public File findInputFile(String name)
+    public FileLike findInputFile(String name)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public File findOutputFile(String name)
+    public FileLike findOutputFile(String name)
     {
         return null;
     }

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowProtocol.java
@@ -7,8 +7,8 @@ import org.labkey.api.pipeline.file.AbstractFileAnalysisProtocol;
 import org.labkey.api.pipeline.file.AbstractFileAnalysisProtocolFactory;
 import org.labkey.api.util.FileType;
 import org.labkey.api.view.ViewBackgroundInfo;
+import org.labkey.vfs.FileLike;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public class NextFlowProtocol extends AbstractFileAnalysisProtocol<NextFlowPipel
             }
 
             @Override
-            public Path getDefaultParametersFile(PipeRoot root)
+            public FileLike getDefaultParametersFile(PipeRoot root)
             {
                 return null;
             }
@@ -61,7 +61,7 @@ public class NextFlowProtocol extends AbstractFileAnalysisProtocol<NextFlowPipel
     }
 
     @Override
-    public NextFlowPipelineJob createPipelineJob(ViewBackgroundInfo info, PipeRoot root, List<Path> filesInput, Path fileParameters, @Nullable Map<String, String> variableMap)
+    public NextFlowPipelineJob createPipelineJob(ViewBackgroundInfo info, PipeRoot root, List<FileLike> filesInput, FileLike fileParameters, @Nullable Map<String, String> variableMap)
     {
         throw new UnsupportedOperationException();
     }

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
@@ -16,6 +16,7 @@ import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.FileType;
 import org.labkey.nextflow.NextFlowConfiguration;
 import org.labkey.nextflow.NextFlowManager;
+import org.labkey.vfs.FileLike;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -143,9 +144,9 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
         }
     }
 
-    private boolean hasAwsSection(Path configFile) throws PipelineJobException
+    private boolean hasAwsSection(FileLike configFile) throws PipelineJobException
     {
-        try (InputStream in = Files.newInputStream(configFile);
+        try (InputStream in = configFile.openInputStream();
              InputStreamReader isReader = new InputStreamReader(in, StandardCharsets.UTF_8);
              BufferedReader reader = new BufferedReader(isReader))
         {
@@ -174,7 +175,7 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
     private @NotNull List<String> getArgs() throws PipelineJobException
     {
         NextFlowConfiguration config = NextFlowManager.get().getConfiguration();
-        Path configFile = getJob().getConfig();
+        FileLike configFile = getJob().getConfig();
 
         boolean aws = hasAwsSection(configFile);
 
@@ -194,7 +195,7 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
             args.add(s3Path);
         }
         args.add("-c");
-        args.add(configFile.toAbsolutePath().toString());
+        args.add(configFile.toNioPathForRead().toAbsolutePath().toString());
         args.add("-name");
         args.add(getJob().getNextFlowRunName(true));
         return args;

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
@@ -19,7 +19,6 @@ import org.labkey.nextflow.NextFlowManager;
 import org.labkey.vfs.FileLike;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -76,7 +75,7 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
             // Need to pass to the main process directly in the future to allow concurrent execution for different users
             ProcessBuilder secretsPB = new ProcessBuilder("nextflow", "secrets", "set", "PANORAMA_API_KEY", apiKey);
             log.info("Setting secrets");
-            File dir = getJob().getLogFile().getParentFile();
+            FileLike dir = getJob().getLogFileLike().getParent();
             getJob().runSubProcess(secretsPB, dir);
 
             ProcessBuilder executionPB = new ProcessBuilder(getArgs());
@@ -85,9 +84,9 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
             NextFlowPipelineJob.LOG.info("Finished executing NextFlow: {}", getJob().getJsonJobInfo(true));
 
             RecordedAction action = new RecordedAction(ACTION_NAME);
-            for (Path inputFile : getJob().getInputFilePaths())
+            for (FileLike inputFile : getJob().getInputFiles())
             {
-                action.addInput(inputFile.toFile(), SPECTRA_INPUT_ROLE);
+                action.addInput(inputFile, SPECTRA_INPUT_ROLE);
             }
             addOutputs(action, getJob().getLogFilePath().getParent().resolve("reports"), log);
             addOutputs(action, getJob().getLogFilePath().getParent().resolve("results"), log);

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -139,6 +139,7 @@ import org.labkey.api.view.*;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.api.wiki.WikiRendererType;
 import org.labkey.api.wiki.WikiRenderingService;
+import org.labkey.api.writer.PrintWriters;
 import org.labkey.panoramapublic.bluesky.BlueskyApiClient;
 import org.labkey.panoramapublic.bluesky.BlueskyException;
 import org.labkey.panoramapublic.bluesky.BlueskySettingsManager;
@@ -4617,11 +4618,11 @@ public class PanoramaPublicController extends SpringActionController
             }
         }
 
-        private File writePxXmlFile(String xmlString) throws PxException
+        private FileLike writePxXmlFile(String xmlString) throws PxException
         {
-            File xml = getLocalFile(getContainer(), "px.xml"); // TODO: Add date time stamp
+            FileLike xml = getLocalFile(getContainer(), "px.xml"); // TODO: Add date time stamp
 
-            try (PrintWriter out = new PrintWriter(new FileWriter(xml, StandardCharsets.UTF_8)))
+            try (PrintWriter out = PrintWriters.getPrintWriter(xml.openOutputStream()))
             {
                 out.write(xmlString);
             }
@@ -4656,7 +4657,7 @@ public class PanoramaPublicController extends SpringActionController
 
         private void validatePxXml(boolean useTestDb, String pxChangeLog, String pxUser, String pxPassword, BindException errors) throws PxException, ProteomeXchangeServiceException
         {
-            File xmlFile = writePxXmlFile(createPxXml(_expAnnot, _journalExperiment, _submission, _validationStatus, pxChangeLog, true).getXml());
+            FileLike xmlFile = writePxXmlFile(createPxXml(_expAnnot, _journalExperiment, _submission, _validationStatus, pxChangeLog, true).getXml());
             _pxResponse = ProteomeXchangeService.validatePxXml(xmlFile, useTestDb, pxUser, pxPassword);
             if(ProteomeXchangeService.responseHasErrors(_pxResponse))
             {
@@ -4677,7 +4678,7 @@ public class PanoramaPublicController extends SpringActionController
                 return;
             }
             PxXml pxXml = createPxXml(_expAnnot, _journalExperiment, _submission, _validationStatus, pxChangeLog, true);
-            File xmlFile = writePxXmlFile(pxXml.getXml());
+            FileLike xmlFile = writePxXmlFile(pxXml.getXml());
             _pxResponse = ProteomeXchangeService.submitPxXml(xmlFile, useTestDb, pxUser, pxPassword);
             if(ProteomeXchangeService.responseHasErrors(_pxResponse))
             {
@@ -4699,7 +4700,7 @@ public class PanoramaPublicController extends SpringActionController
             submitPxXml(useTestDb, testMode, pxChangeLog, pxUser, pxPassword, errors);
         }
 
-        private static File getLocalFile(Container container, String fileName) throws PxException
+        private static FileLike getLocalFile(Container container, String fileName) throws PxException
         {
             // File.createTempFile()
             java.nio.file.Path fileRoot = FileContentService.get().getFileRootPath(container, FileContentService.ContentType.files);
@@ -4713,7 +4714,7 @@ public class PanoramaPublicController extends SpringActionController
                 if (root != null)
                 {
                     LocalDirectory localDirectory = LocalDirectory.create(root);
-                    return new File(localDirectory.getLocalDirectoryFile(), fileName);
+                    return localDirectory.getLocalDirectoryFile().resolveChild(fileName);
                 }
                 else
                 {
@@ -4722,7 +4723,7 @@ public class PanoramaPublicController extends SpringActionController
             }
             else
             {
-                return fileRoot.resolve(fileName).toFile();
+                return FileSystemLike.wrapFile(fileRoot).resolveChild(fileName);
             }
         }
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -215,6 +215,8 @@ import org.labkey.panoramapublic.view.expannotations.ExperimentAnnotationsFormDa
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentWebPart;
 import org.labkey.panoramapublic.view.expannotations.TargetedMSExperimentsWebPart;
 import org.labkey.panoramapublic.view.publish.CatalogEntryWebPart;
+import org.labkey.vfs.FileLike;
+import org.labkey.vfs.FileSystemLike;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
@@ -1748,7 +1750,7 @@ public class PanoramaPublicController extends SpringActionController
             return true;
         }
 
-        private Path getExportFilesDir(Container c)
+        private FileLike getExportFilesDir(Container c)
         {
             FileContentService fcs = FileContentService.get();
             if(fcs != null)
@@ -1756,7 +1758,7 @@ public class PanoramaPublicController extends SpringActionController
                 Path fileRoot = fcs.getFileRootPath(c, FileContentService.ContentType.files);
                 if (fileRoot != null)
                 {
-                    return fileRoot.resolve(PipelineService.EXPORT_DIR);
+                    return FileSystemLike.wrapFile(fileRoot.resolve(PipelineService.EXPORT_DIR));
                 }
             }
             return null;
@@ -4710,7 +4712,7 @@ public class PanoramaPublicController extends SpringActionController
                 PipeRoot root = PipelineService.get().getPipelineRootSetting(container);
                 if (root != null)
                 {
-                    LocalDirectory localDirectory = LocalDirectory.create(root, PanoramaPublicModule.NAME);
+                    LocalDirectory localDirectory = LocalDirectory.create(root);
                     return new File(localDirectory.getLocalDirectoryFile(), fileName);
                 }
                 else

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -106,8 +106,8 @@ public class PanoramaPublicModule extends SpringModule
     {
         addController(PanoramaPublicController.NAME, PanoramaPublicController.class);
         PanoramaPublicSchema.register(this);
-        AttachmentService.get().registerAttachmentType(CatalogImageAttachmentType.get());
-        AttachmentService.get().registerAttachmentType(PanoramaPublicLogoResourceType.get());
+        AttachmentService.get().registerAttachmentParentType(CatalogImageAttachmentType.get());
+        AttachmentService.get().registerAttachmentParentType(PanoramaPublicLogoResourceType.get());
     }
 
     @Override

--- a/panoramapublic/src/org/labkey/panoramapublic/bluesky/PanoramaPublicLogoAttachmentParent.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/bluesky/PanoramaPublicLogoAttachmentParent.java
@@ -2,7 +2,7 @@ package org.labkey.panoramapublic.bluesky;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.attachments.AttachmentType;
+import org.labkey.api.attachments.AttachmentParentType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.panoramapublic.model.Journal;
@@ -29,7 +29,7 @@ public class PanoramaPublicLogoAttachmentParent extends ContainerManager.Contain
     }
 
     @Override
-    public @NotNull AttachmentType getAttachmentType()
+    public @NotNull AttachmentParentType getAttachmentParentType()
     {
         return PanoramaPublicLogoResourceType.get();
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/bluesky/PanoramaPublicLogoResourceType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/bluesky/PanoramaPublicLogoResourceType.java
@@ -1,11 +1,11 @@
 package org.labkey.panoramapublic.bluesky;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.attachments.AttachmentType;
+import org.labkey.api.attachments.AttachmentParentType;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.SQLFragment;
 
-public class PanoramaPublicLogoResourceType implements AttachmentType
+public class PanoramaPublicLogoResourceType implements AttachmentParentType
 {
     private static final PanoramaPublicLogoResourceType INSTANCE = new PanoramaPublicLogoResourceType();
 
@@ -21,17 +21,17 @@ public class PanoramaPublicLogoResourceType implements AttachmentType
     @Override
     public @NotNull String getUniqueName()
     {
-        return getClass().getName();
+        return "PanoramaPublicLogoResource";
     }
 
     @Override
     public void addWhereSql(SQLFragment sql, String parentColumn, String documentNameColumn)
     {
         sql.append(parentColumn).append(" IN (SELECT EntityId FROM ")
-                .append(CoreSchema.getInstance().getTableInfoContainers(), "c").append(")")
-                .append(" AND (")
-                .append(documentNameColumn).append(" LIKE ")
-                .appendStringLiteral(PanoramaPublicLogoManager.LOGO_FILE_PREFIX + "%", CoreSchema.getInstance().getSqlDialect())
-                .append(") ");
+            .append(CoreSchema.getInstance().getTableInfoContainers(), "c").append(")")
+            .append(" AND (")
+            .append(documentNameColumn).append(" LIKE ")
+            .appendStringLiteral(PanoramaPublicLogoManager.LOGO_FILE_PREFIX + "%", CoreSchema.getInstance().getSqlDialect())
+            .append(") ");
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/bluesky/PanoramaPublicLogoResourceType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/bluesky/PanoramaPublicLogoResourceType.java
@@ -34,4 +34,10 @@ public class PanoramaPublicLogoResourceType implements AttachmentParentType
             .appendStringLiteral(PanoramaPublicLogoManager.LOGO_FILE_PREFIX + "%", CoreSchema.getInstance().getSqlDialect())
             .append(") ");
     }
+
+    @Override
+    public @NotNull SQLFragment getSelectEntityIdAndDescriptionSql()
+    {
+        return PARENT_CONTAINER_SQL;
+    }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/catalog/CatalogImageAttachmentParent.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/catalog/CatalogImageAttachmentParent.java
@@ -2,7 +2,7 @@ package org.labkey.panoramapublic.catalog;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.attachments.AttachmentParent;
-import org.labkey.api.attachments.AttachmentType;
+import org.labkey.api.attachments.AttachmentParentType;
 import org.labkey.api.data.Container;
 import org.labkey.api.view.ShortURLRecord;
 
@@ -29,7 +29,7 @@ public class CatalogImageAttachmentParent implements AttachmentParent
     }
 
     @Override
-    public @NotNull AttachmentType getAttachmentType()
+    public @NotNull AttachmentParentType getAttachmentParentType()
     {
         return CatalogImageAttachmentType.get();
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/catalog/CatalogImageAttachmentType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/catalog/CatalogImageAttachmentType.java
@@ -1,11 +1,11 @@
 package org.labkey.panoramapublic.catalog;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.attachments.AttachmentType;
+import org.labkey.api.attachments.AttachmentParentType;
 import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.SQLFragment;
 
-public class CatalogImageAttachmentType implements AttachmentType
+public class CatalogImageAttachmentType implements AttachmentParentType
 {
     private static final CatalogImageAttachmentType INSTANCE = new CatalogImageAttachmentType();
 
@@ -21,7 +21,7 @@ public class CatalogImageAttachmentType implements AttachmentType
     @Override
     public @NotNull String getUniqueName()
     {
-        return getClass().getName();
+        return "CatalogImage";
     }
 
     @Override

--- a/panoramapublic/src/org/labkey/panoramapublic/catalog/CatalogImageAttachmentType.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/catalog/CatalogImageAttachmentType.java
@@ -25,8 +25,8 @@ public class CatalogImageAttachmentType implements AttachmentParentType
     }
 
     @Override
-    public void addWhereSql(SQLFragment sql, String parentColumn, String documentNameColumn)
+    public @NotNull SQLFragment getSelectEntityIdAndDescriptionSql()
     {
-        sql.append(parentColumn).append(" IN (SELECT EntityId FROM ").append(CoreSchema.getInstance().getTableInfoShortURL(), "shorUrls").append(")");
+        return new SQLFragment("SELECT EntityId, ShortUrl AS Description FROM ").append(CoreSchema.getInstance().getTableInfoShortURL());
     }
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentFinalTask.java
@@ -79,6 +79,7 @@ import org.labkey.panoramapublic.query.ExperimentAnnotationsManager;
 import org.labkey.panoramapublic.query.JournalManager;
 import org.labkey.panoramapublic.query.SubmissionManager;
 import org.labkey.panoramapublic.security.PanoramaPublicSubmitterRole;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -254,9 +255,9 @@ public class CopyExperimentFinalTask extends PipelineJob.Task<CopyExperimentFina
         }
     }
 
-    private void cleanupExportDirectory(User user, File directory)
+    private void cleanupExportDirectory(User user, FileLike directory)
     {
-        List<? extends ExpData> datas = ExperimentService.get().getExpDatasUnderPath(directory.toPath(), null, true);
+        List<? extends ExpData> datas = ExperimentService.get().getExpDatasUnderPath(directory.toNioPathForRead(), null, true);
         for (ExpData data : datas)
         {
             data.delete(user);

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentJobSupport.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentJobSupport.java
@@ -17,9 +17,7 @@ package org.labkey.panoramapublic.pipeline;
 
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
-
-import java.io.File;
-import java.nio.file.Path;
+import org.labkey.vfs.FileLike;
 
 /**
  * User: vsharma
@@ -32,7 +30,7 @@ public interface CopyExperimentJobSupport
 
     Journal getJournal();
 
-    File getExportDir();
+    FileLike getExportDir();
 
     String getReviewerEmailPrefix();
 
@@ -48,5 +46,5 @@ public interface CopyExperimentJobSupport
 
     String getPreviousVersionName();
 
-    void setExportTargetPath(Path exportTargetPath);
+    void setExportTargetPath(FileLike exportTargetPath);
 }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -30,13 +30,12 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.ViewBackgroundInfo;
-import org.labkey.panoramapublic.PanoramaPublicModule;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * User: vsharma
@@ -63,7 +62,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
 
     private String _previousVersionName;
 
-    private Path _exportTargetPath;
+    private FileLike _exportTargetPath;
 
     private Container _exportSourceContainer;
 
@@ -93,7 +92,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
 
         // CONSIDER: Add a static factory method to LocalDirectory instead of using the constructor.
         //           create(@NotNull PipeRoot root, @NotNull String moduleName, @NotNull String baseLogFileName, @NotNull String localDirPath, boolean temporary)
-        LocalDirectory localDirectory = new LocalDirectory(targetRoot.getContainer(), PanoramaPublicModule.NAME, root, baseLogFileName);
+        LocalDirectory localDirectory = new LocalDirectory(targetRoot.getContainer(), root, baseLogFileName);
 
         setLocalDirectory(localDirectory);
         setLogFile(localDirectory.determineLogFile());
@@ -160,9 +159,9 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     }
 
     @Override
-    public File getExportDir()
+    public FileLike getExportDir()
     {
-        return _exportTargetPath.toFile();
+        return _exportTargetPath;
     }
 
     @Override
@@ -254,7 +253,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     }
 
     @Override
-    public void setExportTargetPath(Path exportTargetPath)
+    public void setExportTargetPath(FileLike exportTargetPath)
     {
         _exportTargetPath = exportTargetPath;
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/CopyExperimentPipelineJob.java
@@ -34,9 +34,6 @@ import org.labkey.panoramapublic.model.ExperimentAnnotations;
 import org.labkey.panoramapublic.model.Journal;
 import org.labkey.vfs.FileLike;
 
-import java.io.File;
-import java.io.IOException;
-
 /**
  * User: vsharma
  * Date: 8/21/2014
@@ -118,7 +115,7 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
     }
 
     @Override
-    public TaskPipeline getTaskPipeline()
+    public TaskPipeline<?> getTaskPipeline()
     {
         return PipelineJobService.get().getTaskPipeline(new TaskId(CopyExperimentPipelineJob.class));
     }
@@ -132,19 +129,6 @@ public class CopyExperimentPipelineJob extends PipelineJob implements CopyExperi
            super.finallyCleanUpLocalDirectory();
        }
    }
-
-    public static File getLogFileFor(PipeRoot root, ExperimentAnnotations experimentAnnotations) throws IOException
-    {
-        File rootDir = root.getLogDirectory();
-        if (!rootDir.exists())
-        {
-            throw new IOException("Pipeline root directory " + rootDir.getAbsolutePath() + " does not exist.");
-        }
-
-        String logFileName = "Experiment_" + experimentAnnotations.getExperimentId() + ".log";
-
-        return new File(rootDir, logFileName);
-    }
 
     @Override
     public ExperimentAnnotations getExpAnnotations()

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentExportTask.java
@@ -16,7 +16,6 @@
 package org.labkey.panoramapublic.pipeline;
 
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.admin.FolderArchiveDataTypes;
 import org.labkey.api.admin.FolderExportContext;
@@ -36,8 +35,8 @@ import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.writer.FileSystemFile;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
+import org.labkey.vfs.FileLike;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -49,8 +48,6 @@ import java.util.Set;
  */
 public class ExperimentExportTask extends PipelineJob.Task<ExperimentExportTask.Factory>
 {
-    private static final Logger _log = LogManager.getLogger(ExperimentExportTask.class);
-
     private ExperimentExportTask(Factory factory, PipelineJob job)
     {
         super(factory, job);
@@ -117,15 +114,15 @@ public class ExperimentExportTask extends PipelineJob.Task<ExperimentExportTask.
                 false, false, new StaticLoggerGetter(LogManager.getLogger(FolderWriterImpl.class)));
 
 
-        File exportDir = support.getExportDir();
+        FileLike exportDir = support.getExportDir();
         FileUtil.deleteDir(exportDir);
         if(exportDir.exists())
         {
-            throw new Exception("Could not delete already existing export directory " + exportDir.getAbsolutePath());
+            throw new Exception("Could not delete already existing export directory " + exportDir);
         }
-        if(!exportDir.mkdir())
+        if(!FileUtil.mkdir(exportDir))
         {
-            throw new Exception("Could not create directory " + exportDir.getAbsolutePath());
+            throw new Exception("Could not create directory " + exportDir);
         }
 
         FileSystemFile vf = new FileSystemFile(exportDir);
@@ -143,7 +140,7 @@ public class ExperimentExportTask extends PipelineJob.Task<ExperimentExportTask.
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public ExperimentExportTask createTask(PipelineJob job)
         {
             return new ExperimentExportTask(this, job);
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentImportTask.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/ExperimentImportTask.java
@@ -29,6 +29,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.util.FileType;
 import org.labkey.api.writer.FileSystemFile;
 import org.labkey.api.writer.VirtualFile;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.util.Collections;
@@ -74,23 +75,23 @@ public class ExperimentImportTask extends PipelineJob.Task<ExperimentImportTask.
 
     public static void doImport(PipelineJob job, CopyExperimentJobSupport jobSupport) throws Exception
     {
-        File importDir = jobSupport.getExportDir();
+        FileLike importDir = jobSupport.getExportDir();
 
         if (!importDir.exists())
         {
             throw new Exception("TargetedMS experiment import failed: Could not find directory \"" + importDir.getName() + "\"");
         }
 
-        File folderXml = new File(importDir, "folder.xml");
+        FileLike folderXml = importDir.resolveChild("folder.xml");
         if(!folderXml.exists())
         {
-            throw new Exception("This directory doesn't contain an appropriate xml: " + importDir.getAbsolutePath());
+            throw new Exception("This directory doesn't contain an appropriate xml: " + importDir);
         }
 
         User user = job.getUser();
         Container container = job.getContainer();
-        VirtualFile importJobRoot = new FileSystemFile(folderXml.getParentFile());
-        FolderImportContext importCtx = new FolderImportContext(user, container, folderXml.toPath(),
+        VirtualFile importJobRoot = new FileSystemFile(folderXml.getParent());
+        FolderImportContext importCtx = new FolderImportContext(user, container, folderXml,
                 null, new PipelineJobLoggerGetter(job),
                 importJobRoot);
         importCtx.setSkipQueryValidation(true);
@@ -110,7 +111,7 @@ public class ExperimentImportTask extends PipelineJob.Task<ExperimentImportTask.
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public ExperimentImportTask createTask(PipelineJob job)
         {
             return new ExperimentImportTask(this, job);
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataImporter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataImporter.java
@@ -9,6 +9,7 @@ import org.labkey.api.files.FileContentService;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.writer.VirtualFile;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -17,7 +18,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,7 +72,7 @@ public class FilesMetadataImporter
                 return;
             }
 
-            Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new InputSource(is));
+            Document document = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder().parse(new InputSource(is));
             NodeList nodes = document.getElementsByTagName(FilesMetadataWriter.FILE);
             for(int i = 0; i < nodes.getLength(); i++)
             {

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataWriter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/FilesMetadataWriter.java
@@ -11,12 +11,12 @@ import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.security.User;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.writer.FileSystemFile;
 import org.labkey.api.writer.VirtualFile;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -76,7 +76,7 @@ public class FilesMetadataWriter
     private void writeFilesXml(Container container, ExperimentService expSvc, FileContentService fcs, PrintWriter writer, Logger log)
             throws ParserConfigurationException, TransformerException
     {
-        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Document doc = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder().newDocument();
 
         List<? extends ExpData> expDatasWithComments = getExpDatasWithComments(container, expSvc);
 

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/PostPanoramaPublicMessageJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/PostPanoramaPublicMessageJob.java
@@ -41,7 +41,7 @@ public class PostPanoramaPublicMessageJob extends PipelineJob
                                         String titlePrefix, boolean test)
     {
         super("Panorama Public", info, root);
-        setLogFile(root.getRootNioPath().resolve(FileUtil.makeFileNameWithTimestamp("PanoramaPublic-post-to-message-thread", "log")));
+        setLogFile(root.resolvePathToFileLike(FileUtil.makeFileNameWithTimestamp("PanoramaPublic-post-to-message-thread", "log")));
         _experimentAnnotationsIds = experimentAnnotationsIds;
         _message = message;
         _titlePrefix = titlePrefix;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/PrivateDataReminderJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/PrivateDataReminderJob.java
@@ -58,7 +58,7 @@ public class PrivateDataReminderJob extends PipelineJob
     public PrivateDataReminderJob(ViewBackgroundInfo info, @NotNull PipeRoot root, Journal panoramaPublic, List<Integer> experimentAnnotationsIds, boolean test)
     {
         super("Panorama Public", info, root);
-        setLogFile(root.getRootFileLike().toNioPathForWrite().resolve(FileUtil.makeFileNameWithTimestamp("PanoramaPublic-private-data-reminder", "log")));
+        setLogFile(root.getRootFileLike().resolveChild(FileUtil.makeFileNameWithTimestamp("PanoramaPublic-private-data-reminder", "log")));
         _panoramaPublic = panoramaPublic;
 
         _experimentAnnotationsIds = experimentAnnotationsIds;

--- a/panoramapublic/src/org/labkey/panoramapublic/pipeline/PxDataValidationPipelineJob.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/pipeline/PxDataValidationPipelineJob.java
@@ -14,8 +14,6 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
 import org.labkey.panoramapublic.model.ExperimentAnnotations;
 
-import java.io.File;
-
 public class PxDataValidationPipelineJob extends PipelineJob implements PxDataValidationJobSupport
 {
     private final ExperimentAnnotations _experimentAnnotations;
@@ -41,7 +39,7 @@ public class PxDataValidationPipelineJob extends PipelineJob implements PxDataVa
         _description = String.format("Validating data for experiment Id: %d, validation Id: %d", experiment.getId(), validationId);
 
         String baseLogFileName = FileUtil.makeFileNameWithTimestamp("Experiment_Validation_" + experiment.getExperimentId(), "log");
-        setLogFile(new File(root.getLogDirectory(), baseLogFileName));
+        setLogFile(root.getLogDirectory(true).resolveChild(baseLogFileName));
 
         header("Validating data for a ProteomeXchange submission.");
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/NcbiUtils.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/NcbiUtils.java
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.AjaxCompletion;
 import org.w3c.dom.CharacterData;
@@ -33,7 +34,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -43,7 +43,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -134,8 +133,7 @@ public class NcbiUtils
 
             if (status == HttpURLConnection.HTTP_OK)
             {
-                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-                DocumentBuilder builder = factory.newDocumentBuilder();
+                DocumentBuilder builder = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
                 Document doc = builder.parse(conn.getInputStream());
 
                 NodeList nodes = doc.getElementsByTagName("DocSum");

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ProteomeXchangeService.java
@@ -17,10 +17,12 @@ package org.labkey.panoramapublic.proteomexchange;
 
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.entity.mime.FileBody;
+import org.apache.hc.client5.http.entity.mime.InputStreamBody;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
@@ -28,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.logging.LogHelper;
+import org.labkey.vfs.FileLike;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,17 +52,17 @@ public class ProteomeXchangeService
 
     private static final Logger LOG = LogHelper.getLogger(ProteomeXchangeService.class, "Handles requests to the ProteomeXchange server");
 
-    public static String validatePxXml(File pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
+    public static String validatePxXml(FileLike pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
     {
         return postPxXml(pxxmlFile, testDatabase, user, pass, METHOD.validateXML);
     }
 
-    public static String submitPxXml(File pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
+    public static String submitPxXml(FileLike pxxmlFile, boolean testDatabase, String user, String pass) throws ProteomeXchangeServiceException
     {
         return postPxXml(pxxmlFile, testDatabase, user, pass, METHOD.submitDataset);
     }
 
-    private static String postPxXml(File pxxmlFile, boolean testDatabase, String user, String pass, METHOD method) throws ProteomeXchangeServiceException
+    private static String postPxXml(FileLike pxxmlFile, boolean testDatabase, String user, String pass, METHOD method) throws ProteomeXchangeServiceException
     {
         String responseMessage;
         try {
@@ -118,12 +121,12 @@ public class ProteomeXchangeService
     }
 
     @NotNull
-    private static MultipartEntityBuilder getMultipartEntityBuilder(File pxxmlFile, boolean testDatabase, METHOD method, String user, String pass)
+    private static MultipartEntityBuilder getMultipartEntityBuilder(FileLike pxxmlFile, boolean testDatabase, METHOD method, String user, String pass) throws IOException
     {
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
         if(pxxmlFile != null)
         {
-            builder.addPart("ProteomeXchangeXML", new FileBody(pxxmlFile));
+            builder.addPart("ProteomeXchangeXML", new InputStreamBody(pxxmlFile.openInputStream(), ContentType.TEXT_XML, pxxmlFile.getName()));
         }
         builder.addTextBody("PXPartner", user);
         builder.addTextBody("authentication", pass);
@@ -140,7 +143,7 @@ public class ProteomeXchangeService
         return builder;
     }
 
-    private static MultipartEntityBuilder getMultipartEntityBuilder(boolean testDatabase, METHOD method, String user, String pass)
+    private static MultipartEntityBuilder getMultipartEntityBuilder(boolean testDatabase, METHOD method, String user, String pass) throws IOException
     {
         return getMultipartEntityBuilder(null, testDatabase, method, user, pass);
     }

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PsiInstrumentParser.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/PsiInstrumentParser.java
@@ -22,6 +22,7 @@ import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.resource.FileResource;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.util.logging.LogHelper;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -30,7 +31,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
@@ -94,12 +94,11 @@ public class PsiInstrumentParser
         {
             throw new PxException("File not found: psi-ms-PARSED.xml.");
         }
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         DocumentBuilder db;
         Document document;
         try
         {
-            db = dbf.newDocumentBuilder();
+            db = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
             document = db.parse(file);
         }
         catch (ParserConfigurationException | SAXException | IOException e)

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodParser.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/UnimodParser.java
@@ -20,6 +20,7 @@ import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.resource.FileResource;
 import org.labkey.api.util.Path;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.panoramapublic.PanoramaPublicModule;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -28,7 +29,6 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
@@ -77,13 +77,11 @@ public class UnimodParser
         {
             throw new PxException("UNIMOD xml file does not exist: " + unimodXml);
         }
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setNamespaceAware(true);
         DocumentBuilder db;
         Document document;
         try
         {
-            db = dbf.newDocumentBuilder();
+            db = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
             document = db.parse(unimodXml);
         }
         catch (ParserConfigurationException | SAXException | IOException e)
@@ -122,7 +120,7 @@ public class UnimodParser
     private void parseAminoAcid(Element aaEl, UnimodModifications uMods) throws PxException
     {
         String title = aaEl.getAttribute("title");
-        if(title == null || title.length() > 1 || !Character.isUpperCase(title.charAt(0)))
+        if(title.length() > 1 || !Character.isUpperCase(title.charAt(0)))
         {
             return;
         }

--- a/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/ExperimentAnnotationsTableInfo.java
@@ -529,7 +529,7 @@ public class ExperimentAnnotationsTableInfo extends FilteredTable<PanoramaPublic
         }
 
         @Override
-        public NamedObjectList getSelectList(RenderContext ctx)
+        public @NotNull NamedObjectList getSelectList(RenderContext ctx)
         {
             NamedObjectList objectList = new NamedObjectList();
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/JournalManager.java
@@ -210,7 +210,7 @@ public class JournalManager
     private static void addPermission(Container folder, UserPrincipal journalGroup)
     {
         SecurityPolicy oldPolicy = folder.getPolicy();
-        if (oldPolicy.getOwnPermissions(journalGroup).contains(FolderExportPermission.class))
+        if (oldPolicy.getOwnPermissions(journalGroup).anyMatch(permClass -> permClass == FolderExportPermission.class))
             return;
         MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(folder, oldPolicy);
 
@@ -249,19 +249,16 @@ public class JournalManager
     private static void removePermission(Container folder, UserPrincipal journalGroup)
     {
         SecurityPolicy oldPolicy = folder.getPolicy();
-        if (!oldPolicy.getOwnPermissions(journalGroup).contains(FolderExportPermission.class))
+        if (oldPolicy.getOwnPermissions(journalGroup).noneMatch(permClass -> permClass == FolderExportPermission.class))
             return;
-        List<Role> roles = oldPolicy.getAssignedRoles(journalGroup);
 
         MutableSecurityPolicy newPolicy = new MutableSecurityPolicy(folder, oldPolicy);
         newPolicy.clearAssignedRoles(journalGroup);
-        for(Role role: roles)
-        {
-            if(!(role instanceof CopyTargetedMSExperimentRole))
-            {
-                newPolicy.addRoleAssignment(journalGroup, role);
-            }
-        }
+
+        oldPolicy.getAssignedRoles(journalGroup)
+            .filter(role -> !(role instanceof CopyTargetedMSExperimentRole))
+            .forEach(role -> newPolicy.addRoleAssignment(journalGroup, role));
+
         SecurityPolicyManager.savePolicy(newPolicy, User.getAdminServiceUser());
     }
 

--- a/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/query/SubmissionManager.java
@@ -279,7 +279,7 @@ public class SubmissionManager
         //           A folder admin updating the submission request made by another submitter may want to change the shortUrl. They
         //           will need permission to delete the old shortUrl.
         MutableSecurityPolicy policy = new MutableSecurityPolicy(SecurityPolicyManager.getPolicy(shortUrl));
-        boolean isEditor = policy.getAssignedRoles(user).stream().anyMatch(r -> r instanceof EditorRole);
+        boolean isEditor = policy.getAssignedRoles(user).anyMatch(r -> r instanceof EditorRole);
         if (!isEditor)
         {
             policy.addRoleAssignment(user, EditorRole.class);

--- a/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/expannotations/experimentDetails.jsp
@@ -36,18 +36,17 @@
 <%@ page import="org.labkey.panoramapublic.model.JournalSubmission" %>
 <%@ page import="org.labkey.panoramapublic.model.Submission" %>
 <%@ page import="org.labkey.panoramapublic.model.validation.DataValidation" %>
-<%@ page import="static org.labkey.api.util.DOM.SPAN" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.style" %>
 <%@ page import="org.labkey.panoramapublic.model.validation.PxStatus" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.title" %>
-<%@ page import="static org.labkey.api.util.DOM.Attribute.href" %>
 <%@ page import="org.labkey.panoramapublic.proteomexchange.ProteomeXchangeService" %>
 <%@ page import="org.labkey.panoramapublic.query.CatalogEntryManager" %>
 <%@ page import="org.labkey.panoramapublic.query.DataValidationManager" %>
 <%@ page import="org.labkey.panoramapublic.query.JournalManager" %>
 <%@ page import="org.labkey.panoramapublic.view.publish.CatalogEntryWebPart" %>
 <%@ page import="java.text.SimpleDateFormat" %>
-<%@ page import="org.labkey.api.util.LinkBuilder" %>
+<%@ page import="static org.labkey.api.util.DOM.SPAN" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.style" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.title" %>
+<%@ page import="static org.labkey.api.util.DOM.Attribute.href" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 
 <%!
@@ -109,7 +108,7 @@
             StringBuilder status = new StringBuilder();
             if (DataValidationManager.isValidationOutdated(validation, annot, getUser()))
             {
-                DOM.A(DOM.at(href, viewExptDetailsUrl.toContainerRelativeURL()),
+                DOM.A(DOM.at(href, viewExptDetailsUrl.toRelativeURL()),
                         DOM.SPAN(DOM.cl("labkey-error"), SPAN(DOM.at(style, "background-color: #FFF6D8;margin:2px;font-weight:bold;"), "PX validation is outdated")))
                         .appendTo(status);
             }
@@ -121,7 +120,7 @@
                         PxStatus.IncompleteMetadata == pxStatus ? "pxv-circle-incomplete" : "pxv-circle-invalid");
                 String pxStatusStr = PxStatus.NotValid == pxStatus ? pxStatus.getLabel() :
                         ("ProteomeXchange status: " + pxStatus.getLabel());
-                DOM.A(DOM.at(href, viewExptDetailsUrl.toContainerRelativeURL()),
+                DOM.A(DOM.at(href, viewExptDetailsUrl.toRelativeURL()),
                         DOM.SPAN(DOM.at(title, pxStatusStr), DOM.SPAN(DOM.cl(pxCls), "PX")))
                         .appendTo(status);
             }

--- a/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
+++ b/panoramapublic/src/org/labkey/panoramapublic/view/search/panoramaWebSearch.jsp
@@ -361,21 +361,26 @@
                 let instrument = document.getElementById(instrumentItemId).value;
 
                 let expSearchParams = "";
+                let separator = "";
                 if (author) {
                     expAnnotationFilters.push(createFilter(authorsItemId, author));
-                    expSearchParams += "Targeted MS Experiment List." + "authors~containsoneof" + "=" + encodeURIComponent(author) + "&";
+                    expSearchParams += separator + "Targeted MS Experiment List." + "authors~containsoneof=" + encodeURIComponent(author);
+                    separator = "&";
                 }
                 if (title) {
                     expAnnotationFilters.push(createFilter(titleItemId, title));
-                    expSearchParams += "Targeted MS Experiment List." + "title~containsoneof" + "=" + encodeURIComponent(title) + "&";
+                    expSearchParams += separator + "Targeted MS Experiment List." + "title~containsoneof=" + encodeURIComponent(title);
+                    separator = "&";
                 }
                 if (organism) {
                     expAnnotationFilters.push(createFilter(organismItemId, organism));
-                    expSearchParams += "Targeted MS Experiment List." + "organism~containsoneof" + "=" + encodeURIComponent(organism.replaceAll(",", ";")) + "&";
+                    expSearchParams += separator + "Targeted MS Experiment List." + "organism~containsoneof=" + encodeURIComponent(organism.replaceAll(",", ";"));
+                    separator = "&";
                 }
                 if (instrument) {
                     expAnnotationFilters.push(createFilter(instrumentItemId, instrument));
-                    expSearchParams += "Targeted MS Experiment List." + "instrument~containsoneof" + "=" + encodeURIComponent(instrument.replaceAll(",", ";"));
+                    expSearchParams += separator + "Targeted MS Experiment List." + "instrument~containsoneof" + "=" + encodeURIComponent(instrument.replaceAll(",", ";"));
+                    separator = "&";
                 }
                 if (expSearchParams !== "") {
                     location.replace(window.location.href + "?" + expSearchParams);

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicBaseTest.java
@@ -14,6 +14,7 @@ import org.labkey.remoteapi.SimpleGetCommand;
 import org.labkey.test.Locator;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
+import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.BodyWebPart;
 import org.labkey.test.components.SubfoldersWebPart;
 import org.labkey.test.components.panoramapublic.TargetedMsExperimentInsertPage;
@@ -113,10 +114,6 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
     @After
     public void afterTest() throws IOException, CommandException
     {
-        if (isImpersonating())
-        {
-            stopImpersonating();
-        }
         verifySymlinks();
     }
 
@@ -149,7 +146,7 @@ public class PanoramaPublicBaseTest extends TargetedMSTest implements PostgresOn
 
     boolean verifySymlinks() throws IOException, CommandException
     {
-        Connection connection = createDefaultConnection();
+        Connection connection = WebTestHelper.getRemoteApiConnection(false);
         SimpleGetCommand command = new SimpleGetCommand("PanoramaPublic", "verifySymlinks");
         CommandResponse verifyResponse = command.execute(connection, "/");
 

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PanoramaPublicMyDataViewTest.java
@@ -191,7 +191,7 @@ public class PanoramaPublicMyDataViewTest extends PanoramaPublicBaseTest
     @NotNull
     private DataRegionTable myDataView()
     {
-        var table = new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();
+        var table = new DataRegionTable("Targeted MS Experiment List", getDriver());
         assertTrue(table.hasHeaderMenu("My Data"));
         table.clickHeaderButtonAndWait("My Data");
         return new DataRegionTable.DataRegionFinder(getDriver()).refindWhenNeeded();

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -56,6 +56,7 @@ import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.util.FileUtil;
 import org.labkey.api.util.MimeMap;
 import org.labkey.api.util.Pair;
+import org.labkey.api.util.XmlBeansUtil;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
@@ -93,7 +94,6 @@ import org.xml.sax.InputSource;
 
 import javax.management.modelmbean.XMLParseException;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -1381,8 +1381,7 @@ public class TestResultsController extends SpringActionController
                 "\\[(\\d\\d):(\\d\\d)]\\s+(\\d+)\\.\\d+\\s+([A-Za-z]\\w*)\\s+\\(([A-Za-z]+)\\)");
 
             try (DbScope.Transaction transaction = TestResultsSchema.getSchema().getScope().ensureTransaction()) {
-                DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-                DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+                DocumentBuilder dBuilder = XmlBeansUtil.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
                 InputSource is = new InputSource();
                 is.setCharacterStream(new StringReader(xml));
                 Document doc = dBuilder.parse(is);


### PR DESCRIPTION
## Summary
- Wrapped `recordToolDownload()` in `SpringActionController.ignoreSqlUpdates()` in `DownloadToolAction`
- The download counter increment is an incidental write on a GET action (like audit logging)
- Fixes `IllegalStateException: MUTATING SQL executed as part of handling action: GET` in dev mode

## Context
This has always been technically incorrect (mutating SQL on GET), but only throws in dev mode with assertions enabled. LabKey platform's `StatementWrapper` checks `isDevMode() && isMutatingSql()` and throws. Production skyline.ms is unaffected since it runs in production mode. The `ignoreSqlUpdates()` pattern is the same one LabKey uses for audit logging on read-only actions.

## Test plan
- [x] Verified download works on local dev server (previously returned 500)
- [x] Verified download counter still increments

Co-Authored-By: Claude <noreply@anthropic.com>