### PR TITLE
Fix mutating SQL assertion in Tool Store download

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -1088,7 +1088,12 @@ public class SkylineToolsStoreController extends SpringActionController
                 // Cookie expires after 1 day
                 final int expires = 24 * 60 * 60;
 
-                SkylineToolsStoreManager.get().recordToolDownload(tool);
+                // Download counter is an incidental write on a GET action — use ignoreSqlUpdates()
+                // to avoid the dev-mode mutating SQL assertion (like auditing writes)
+                try (var ignored = SpringActionController.ignoreSqlUpdates())
+                {
+                    SkylineToolsStoreManager.get().recordToolDownload(tool);
+                }
 
                 DateFormat df = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss 'GMT'", Locale.US);
                 Calendar calendar = Calendar.getInstance();


### PR DESCRIPTION
## Summary

* Wrapped `recordToolDownload()` in `SpringActionController.ignoreSqlUpdates()` to fix dev-mode assertion that blocks mutating SQL (UPDATE download counter) on GET request in `DownloadToolAction`

Replaces #607 (which was incorrectly based on develop).

## Test plan

- [x] Verified locally: Tool Store download no longer throws 500 in dev mode

Co-Authored-By: Claude <noreply@anthropic.com>