### PR TITLE
Added documentation support to Skyline Tool Store

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -178,7 +178,8 @@ public class SkylineToolsStoreController extends SpringActionController
             while ((zipEntry = zipStream.getNextEntry()) != null &&
                     (tool == null || tool.getIcon() == null))
             {
-                if (zipEntry.getName().toLowerCase().startsWith("tool-inf/"))
+                String entryLower = zipEntry.getName().toLowerCase();
+                if (entryLower.startsWith("tool-inf/") && !entryLower.startsWith("tool-inf/docs/"))
                 {
                     String lowerBaseName = new File(zipEntry.getName()).getName().toLowerCase();
 
@@ -227,6 +228,39 @@ public class SkylineToolsStoreController extends SpringActionController
         {
             return null;
         }
+    }
+
+    protected static boolean extractDocsFromZip(File zipFile, File containerDir) throws IOException
+    {
+        File docsDir = new File(containerDir, "docs");
+        boolean extracted = false;
+        try (ZipFile zf = new ZipFile(zipFile))
+        {
+            Enumeration<? extends ZipEntry> entries = zf.entries();
+            while (entries.hasMoreElements())
+            {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (!name.toLowerCase().startsWith("tool-inf/docs/") || entry.isDirectory())
+                    continue;
+                // Strip "tool-inf/docs/" prefix to get relative path within docs dir
+                String relativePath = name.substring("tool-inf/docs/".length());
+                if (relativePath.isEmpty())
+                    continue;
+                File destFile = new File(docsDir, relativePath);
+                // Zip-slip protection
+                if (!destFile.getCanonicalPath().startsWith(docsDir.getCanonicalPath() + File.separator))
+                    throw new IOException("Zip entry outside target directory: " + name);
+                Files.createDirectories(destFile.getParentFile().toPath());
+                try (InputStream in = zf.getInputStream(entry);
+                     FileOutputStream out = new FileOutputStream(destFile))
+                {
+                    in.transferTo(out);
+                }
+                extracted = true;
+            }
+        }
+        return extracted;
     }
 
     public static File makeFile(Container c, String filename)
@@ -408,7 +442,7 @@ public class SkylineToolsStoreController extends SpringActionController
         for (String suppFile : localToolDir.list())
         {
             final String basename = new File(suppFile).getName();
-            if (!basename.startsWith(".") && !basename.equals(tool.getZipName()) && !basename.equals("icon.png"))
+            if (!basename.startsWith(".") && !basename.equals(tool.getZipName()) && !basename.equals("icon.png") && !basename.equals("docs"))
                 suppFiles.add(suppFile);
         }
         return suppFiles;
@@ -583,8 +617,18 @@ public class SkylineToolsStoreController extends SpringActionController
                     {
                         Container c = makeContainer(getContainer(), folderName, toolOwnersUsers, RoleManager.getRole(EditorRole.class));
                         copyContainerPermissions(existingVersionContainer, c);
-                        zip.transferTo(makeFile(c, zip.getOriginalFilename()));
+                        File storedZip = makeFile(c, zip.getOriginalFilename());
+                        zip.transferTo(storedZip);
                         tool.writeIconToFile(makeFile(c, "icon.png"), "png");
+
+                        // Extract docs from tool-inf/docs/ in the ZIP; carry forward from previous version if absent
+                        boolean hasDocs = extractDocsFromZip(storedZip, getLocalPath(c));
+                        if (!hasDocs && existingVersionContainer != null)
+                        {
+                            File oldDocs = new File(getLocalPath(existingVersionContainer), "docs");
+                            if (oldDocs.isDirectory())
+                                FileUtils.copyDirectory(oldDocs, new File(getLocalPath(c), "docs"));
+                        }
 
                         if (copyFiles != null && existingVersionContainer != null)
                             for (String copyFile : copyFiles)

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -100,6 +100,7 @@ import java.io.StringReader;
 import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -230,11 +231,11 @@ public class SkylineToolsStoreController extends SpringActionController
         }
     }
 
-    protected static boolean extractDocsFromZip(File zipFile, File containerDir) throws IOException
+    protected static boolean extractDocsFromZip(Path zipFile, Path containerDir) throws IOException
     {
-        File docsDir = new File(containerDir, "docs");
+        Path docsDir = containerDir.resolve("docs");
         boolean extracted = false;
-        try (ZipFile zf = new ZipFile(zipFile))
+        try (ZipFile zf = new ZipFile(zipFile.toFile()))
         {
             Enumeration<? extends ZipEntry> entries = zf.entries();
             while (entries.hasMoreElements())
@@ -247,15 +248,14 @@ public class SkylineToolsStoreController extends SpringActionController
                 String relativePath = name.substring("tool-inf/docs/".length());
                 if (relativePath.isEmpty())
                     continue;
-                File destFile = new File(docsDir, relativePath);
+                Path destPath = docsDir.resolve(relativePath).normalize();
                 // Zip-slip protection
-                if (!destFile.getCanonicalPath().startsWith(docsDir.getCanonicalPath() + File.separator))
+                if (!destPath.startsWith(docsDir.normalize()))
                     throw new IOException("Zip entry outside target directory: " + name);
-                Files.createDirectories(destFile.getParentFile().toPath());
-                try (InputStream in = zf.getInputStream(entry);
-                     FileOutputStream out = new FileOutputStream(destFile))
+                Files.createDirectories(destPath.getParent());
+                try (InputStream in = zf.getInputStream(entry))
                 {
-                    in.transferTo(out);
+                    Files.copy(in, destPath, StandardCopyOption.REPLACE_EXISTING);
                 }
                 extracted = true;
             }
@@ -265,12 +265,12 @@ public class SkylineToolsStoreController extends SpringActionController
 
     public static File makeFile(Container c, String filename)
     {
-        return new File(getLocalPath(c), FileUtil.makeLegalName(filename));
+        return getLocalPath(c).resolve(FileUtil.makeLegalName(filename)).toFile();
     }
 
-    public static File getLocalPath(Container c)
+    public static Path getLocalPath(Container c)
     {
-        return FileContentService.get().getFileRootPath(c, FileContentService.ContentType.files).toFile();
+        return FileContentService.get().getFileRootPath(c, FileContentService.ContentType.files);
     }
 
     protected Container makeContainer(Container parent, String folderName, List<User> users, Role role) throws IOException
@@ -417,7 +417,7 @@ public class SkylineToolsStoreController extends SpringActionController
         return new ArrayList<>(users);
     }
 
-    public static HashMap<String, String> getSupplementaryFiles(SkylineTool tool)
+    public static HashMap<String, String> getSupplementaryFiles(SkylineTool tool) throws IOException
     {
         // Store supporting files in map <url, icon url>
         final String[] knownExtensions = {"pdf", "zip"};
@@ -435,15 +435,15 @@ public class SkylineToolsStoreController extends SpringActionController
         return suppFiles;
     }
 
-    public static HashSet<String> getSupplementaryFileBasenames(SkylineTool tool)
+    public static HashSet<String> getSupplementaryFileBasenames(SkylineTool tool) throws IOException
     {
         HashSet<String> suppFiles = new HashSet<>();
-        File localToolDir = getLocalPath(tool.lookupContainer());
-        for (String suppFile : localToolDir.list())
+        Path localToolDir = getLocalPath(tool.lookupContainer());
+        try (var stream = Files.list(localToolDir))
         {
-            final String basename = new File(suppFile).getName();
-            if (!basename.startsWith(".") && !basename.equals(tool.getZipName()) && !basename.equals("icon.png") && !basename.equals("docs"))
-                suppFiles.add(suppFile);
+            stream.map(p -> p.getFileName().toString())
+                  .filter(name -> !name.startsWith(".") && !name.equals(tool.getZipName()) && !name.equals("icon.png") && !name.equals("docs"))
+                  .forEach(suppFiles::add);
         }
         return suppFiles;
     }
@@ -622,12 +622,12 @@ public class SkylineToolsStoreController extends SpringActionController
                         tool.writeIconToFile(makeFile(c, "icon.png"), "png");
 
                         // Extract docs from tool-inf/docs/ in the ZIP; carry forward from previous version if absent
-                        boolean hasDocs = extractDocsFromZip(storedZip, getLocalPath(c));
+                        boolean hasDocs = extractDocsFromZip(storedZip.toPath(), getLocalPath(c));
                         if (!hasDocs && existingVersionContainer != null)
                         {
-                            File oldDocs = new File(getLocalPath(existingVersionContainer), "docs");
-                            if (oldDocs.isDirectory())
-                                FileUtils.copyDirectory(oldDocs, new File(getLocalPath(c), "docs"));
+                            Path oldDocs = getLocalPath(existingVersionContainer).resolve("docs");
+                            if (Files.isDirectory(oldDocs))
+                                FileUtil.copyDirectory(oldDocs, getLocalPath(c).resolve("docs"));
                         }
 
                         if (copyFiles != null && existingVersionContainer != null)

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/SkylineToolsStoreController.java
@@ -176,7 +176,7 @@ public class SkylineToolsStoreController extends SpringActionController
         {
             ZipEntry zipEntry;
             while ((zipEntry = zipStream.getNextEntry()) != null &&
-                    (tool == null || tool.getIcon() == null))
+                    (tool == null || toolIcon == null))
             {
                 String entryLower = zipEntry.getName().toLowerCase();
                 if (entryLower.startsWith("tool-inf/") && !entryLower.startsWith("tool-inf/docs/"))

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/SkylineTool.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/SkylineTool.java
@@ -293,6 +293,16 @@ public class SkylineTool extends Entity
         return AppProps.getInstance().getContextPath() + "/files" + lookupContainer().getPath() + "/";
     }
 
+    public boolean hasDocumentation()
+    {
+        return new File(SkylineToolsStoreController.getLocalPath(lookupContainer()), "docs/index.html").exists();
+    }
+
+    public String getDocsUrl()
+    {
+        return AppProps.getInstance().getContextPath() + "/_webdav" + lookupContainer().getPath() + "/@files/docs/index.html";
+    }
+
     public String getIconUrl()
     {
         return (SkylineToolsStoreController.makeFile(lookupContainer(), "icon.png").exists()) ?

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/SkylineTool.java
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/model/SkylineTool.java
@@ -3,9 +3,14 @@ package org.labkey.skylinetoolsstore.model;
 import org.apache.commons.lang3.StringUtils;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.Entity;
+import org.labkey.api.files.FileContentService;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.util.Pair;
+import org.labkey.api.webdav.WebdavService;
 import org.labkey.skylinetoolsstore.SkylineToolsStoreController;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.imageio.ImageIO;
 import java.io.BufferedReader;
@@ -295,12 +300,17 @@ public class SkylineTool extends Entity
 
     public boolean hasDocumentation()
     {
-        return new File(SkylineToolsStoreController.getLocalPath(lookupContainer()), "docs/index.html").exists();
+        Path localPath = SkylineToolsStoreController.getLocalPath(lookupContainer());
+        return localPath != null && Files.exists(localPath.resolve("docs/index.html"));
     }
 
     public String getDocsUrl()
     {
-        return AppProps.getInstance().getContextPath() + "/_webdav" + lookupContainer().getPath() + "/@files/docs/index.html";
+        org.labkey.api.util.Path path = WebdavService.getPath()
+                .append(lookupContainer().getParsedPath())
+                .append(FileContentService.FILES_LINK)
+                .append(new org.labkey.api.util.Path("docs", "index.html"));
+        return AppProps.getInstance().getContextPath() + path.encode();
     }
 
     public String getIconUrl()

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
@@ -347,10 +347,13 @@ a { text-decoration: none; }
     </div>
 </div>
 
-<% if (tool.hasDocumentation() || suppIter.hasNext()) { %>
+<%
+    boolean hasDocumentation = tool.hasDocumentation();
+%>
+<% if (hasDocumentation || suppIter.hasNext()) { %>
 <div id="documentationbox" class="itemsbox">
     <legend>Documentation</legend>
-<% if (tool.hasDocumentation()) { %>
+<% if (hasDocumentation) { %>
     <div class="barItem">
         <a href="<%=h(tool.getDocsUrl())%>" target="_blank" rel="noopener noreferrer">
         <img src="<%= h(imgDir) %>link.png" alt="Documentation" />

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
@@ -1,4 +1,6 @@
 <%@ page import="org.apache.commons.lang3.StringUtils" %>
+<%@ page import="org.labkey.api.data.Container" %>
+<%@ page import="org.labkey.api.data.ContainerManager" %>
 <%@ page import="org.labkey.api.portal.ProjectUrls" %>
 <%@ page import="org.labkey.api.security.permissions.DeletePermission" %>
 <%@ page import="org.labkey.api.security.permissions.InsertPermission" %>
@@ -299,7 +301,17 @@ a { text-decoration: none; }
         </div>
 
         <button id="tool-support-board-btn" class="banner-button-small">Support Board</button>
-        <% addHandler("tool-support-board-btn", "click", "window.open(" + q(urlProvider(ProjectUrls.class).getBeginURL(getContainer().getChild("Support").getChild(tool.getName()))) + ", '_blank', 'noopener,noreferrer')"); %>
+        <%
+            Container supportContainer = getContainer().getChild("Support");
+            Container toolSupportBoard = supportContainer != null ? supportContainer.getChild(tool.getName()) : null;
+            Container supportTarget;
+            if (toolSupportBoard != null)
+                supportTarget = toolSupportBoard;
+            else
+                supportTarget = ContainerManager.getForPath("/home/support");
+            if (supportTarget != null)
+                addHandler("tool-support-board-btn", "click", "window.open(" + q(urlProvider(ProjectUrls.class).getBeginURL(supportTarget)) + ", '_blank', 'noopener,noreferrer')");
+        %>
     </div>
 <% if (toolEditor) { %>
     <div class="menuMouseArea sprocket">
@@ -332,9 +344,17 @@ a { text-decoration: none; }
     </div>
 </div>
 
-<% if (suppIter.hasNext()) { %>
+<% if (tool.hasDocumentation() || suppIter.hasNext()) { %>
 <div id="documentationbox" class="itemsbox">
     <legend>Documentation</legend>
+<% if (tool.hasDocumentation()) { %>
+    <div class="barItem">
+        <a href="<%=h(tool.getDocsUrl())%>" target="_blank" rel="noopener noreferrer">
+        <img src="<%= h(imgDir) %>link.png" alt="Documentation" />
+        <span>Online Documentation</span>
+        </a>
+    </div>
+<% } %>
 <%
     while (suppIter.hasNext()) {
         Map.Entry suppPair = (Map.Entry)suppIter.next();

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
@@ -303,17 +303,12 @@ a { text-decoration: none; }
         <%
             Container supportContainer = getContainer().getChild("Support");
             Container toolSupportBoard = supportContainer != null ? supportContainer.getChild(tool.getName()) : null;
-            Container supportTarget;
-            if (toolSupportBoard != null)
-                supportTarget = toolSupportBoard;
-            else
-                supportTarget = ContainerManager.getForPath("/home/support");
+            if (toolSupportBoard == null)
+                toolSupportBoard = ContainerManager.getForPath("/home/support");
         %>
-        <% if (supportTarget != null) { %>
+        <% if (toolSupportBoard != null) { %>
         <button id="tool-support-board-btn" class="banner-button-small">Support Board</button>
-        <%
-                addHandler("tool-support-board-btn", "click", "window.open(" + q(urlProvider(ProjectUrls.class).getBeginURL(supportTarget)) + ", '_blank', 'noopener,noreferrer')");
-        %>
+        <% addHandler("tool-support-board-btn", "click", "window.open(" + q(urlProvider(ProjectUrls.class).getBeginURL(toolSupportBoard)) + ", '_blank', 'noopener,noreferrer')"); %>
         <% } %>
     </div>
 <% if (toolEditor) { %>

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolDetails.jsp
@@ -300,7 +300,6 @@ a { text-decoration: none; }
 <% } %>
         </div>
 
-        <button id="tool-support-board-btn" class="banner-button-small">Support Board</button>
         <%
             Container supportContainer = getContainer().getChild("Support");
             Container toolSupportBoard = supportContainer != null ? supportContainer.getChild(tool.getName()) : null;
@@ -309,9 +308,13 @@ a { text-decoration: none; }
                 supportTarget = toolSupportBoard;
             else
                 supportTarget = ContainerManager.getForPath("/home/support");
-            if (supportTarget != null)
+        %>
+        <% if (supportTarget != null) { %>
+        <button id="tool-support-board-btn" class="banner-button-small">Support Board</button>
+        <%
                 addHandler("tool-support-board-btn", "click", "window.open(" + q(urlProvider(ProjectUrls.class).getBeginURL(supportTarget)) + ", '_blank', 'noopener,noreferrer')");
         %>
+        <% } %>
     </div>
 <% if (toolEditor) { %>
     <div class="menuMouseArea sprocket">

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
@@ -200,7 +200,7 @@
 
                 <div class="toolButtons">
 
-                    <button type="button" id="download-tool-btn-<%=tool.getRowId()%>" class="styled-button">Download</button>
+                    <button type="button" id="download-tool-btn-<%=tool.getRowId()%>" class="styled-button">Download <span class="visually-hidden"><%=h(tool.getName())%></span></button>
                     <% addHandler("download-tool-btn-" + tool.getRowId(), "click", "window.location.href = " + q(urlFor(SkylineToolsStoreController.DownloadToolAction.class).addParameter("id", tool.getRowId()))); %>
 <%
     if (suppFiles.size() == 1) {


### PR DESCRIPTION
## Summary

* Extract `tool-inf/docs/` from uploaded tool ZIPs and serve HTML documentation via WebDAV (`/_webdav/.../@files/docs/`)
* Show "Online Documentation" link in the Documentation box on tool details page when `docs/index.html` exists
* Carry forward docs from previous version when new ZIP omits them (same pattern as supplementary files)
* Fix icon extraction to skip images under `tool-inf/docs/` so screenshot PNGs don't replace the tool icon
* Exclude `docs` directory from supplementary file listings
* Fall back to `/home/support` when no tool-specific support board exists, so new tools default to the Skyline support board

## Test plan

- [x] Uploaded SkylineMcpConnector ZIP with `tool-inf/docs/` — docs extracted, "Online Documentation" link appears, renders correctly in new tab
- [x] Tool icon displays correctly (not replaced by docs screenshot)
- [x] Support Board button navigates to `/home/support` for tools without a dedicated support board
- [x] Support Board button still navigates to tool-specific board (e.g., AvantGardeDIA) when one exists
- [x] Supplementary files section does not show `docs` directory

Co-Authored-By: Claude <noreply@anthropic.com>