### PR TITLE
Added accessibility and docs support to tool listing page

### DIFF
--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
@@ -74,6 +74,8 @@
         cursor:pointer;
     }
     .styled-button:hover{background-color:#1e90ff; color:#f5f5dc;}
+    a.styled-button{text-decoration:none; color:#fff;}
+    a.styled-button:visited{color:#fff;}
     .toolOwners {width: 80%; min-width: 300px;}
     .ui-menu {width:240px;}
     .dropMenu {position: absolute;}
@@ -204,20 +206,19 @@
 
                 <div class="toolButtons">
 
-                    <button type="button" id="download-tool-btn-<%=tool.getRowId()%>" class="styled-button">Download <span class="visually-hidden"><%=h(tool.getName())%></span></button>
-                    <% addHandler("download-tool-btn-" + tool.getRowId(), "click", "window.location.href = " + q(urlFor(SkylineToolsStoreController.DownloadToolAction.class).addParameter("id", tool.getRowId()))); %>
+                    <%=link(unsafe("Download<span class=\"visually-hidden\">&nbsp;" + h(tool.getName()) + "</span>")).href(urlFor(SkylineToolsStoreController.DownloadToolAction.class).addParameter("id", tool.getRowId()).toString()).clearClasses().addClass("styled-button")%>
 <%
     if (docCount == 1 && hasDocs) {
 %>
-                        <%=link(unsafe("Documentation <span class=\"visually-hidden\">" + h(tool.getName()) + "</span>")).href(tool.getDocsUrl()).clearClasses().addClass("styled-button").target("_blank").rel("noopener noreferrer")%>
+                        <%=link(unsafe("Documentation<span class=\"visually-hidden\">&nbsp;" + h(tool.getName()) + "</span>")).href(tool.getDocsUrl()).clearClasses().addClass("styled-button").target("_blank").rel("noopener noreferrer")%>
 <%
     } else if (docCount == 1) {
         Map.Entry suppPair = (Map.Entry)suppIter.next();
 %>
-                        <%=link(unsafe("Documentation <span class=\"visually-hidden\">" + h(tool.getName()) + "</span>")).href(suppPair.getKey().toString()).clearClasses().addClass("styled-button")%>
+                        <%=link(unsafe("Documentation<span class=\"visually-hidden\">&nbsp;" + h(tool.getName()) + "</span>")).href(suppPair.getKey().toString()).clearClasses().addClass("styled-button")%>
 <% } else if (docCount > 1) { %>
                         <div class="menuMouseArea">
-                            <button type="button" class="styled-button">Documentation <span class="visually-hidden"><%=h(tool.getName())%></span></button>
+                            <button type="button" class="styled-button">Documentation<span class="visually-hidden"><%=h(tool.getName())%></span></button>
                             <ul class="dropMenu">
 <% if (hasDocs) { %>
                                 <li><a href="<%=h(tool.getDocsUrl())%>" target="_blank" rel="noopener noreferrer"><img class="menuIconImg" src="<%= h(imgDir) %>link.png" alt="Documentation">Online Documentation</a></li>

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
@@ -153,6 +153,8 @@
         // Get supporting files in map <url, icon url>
         HashMap<String, String> suppFiles = SkylineToolsStoreController.getSupplementaryFiles(tool);
         Iterator suppIter = suppFiles.entrySet().iterator();
+        boolean hasDocs = tool.hasDocumentation();
+        int docCount = suppFiles.size() + (hasDocs ? 1 : 0);
 
         final String curToolOwners = StringUtils.join(SkylineToolsStoreController.getToolOwners(tool), ", ");
         toolOwners.put(tool.getRowId(), curToolOwners);
@@ -203,14 +205,21 @@
                     <button type="button" id="download-tool-btn-<%=tool.getRowId()%>" class="styled-button">Download <span class="visually-hidden"><%=h(tool.getName())%></span></button>
                     <% addHandler("download-tool-btn-" + tool.getRowId(), "click", "window.location.href = " + q(urlFor(SkylineToolsStoreController.DownloadToolAction.class).addParameter("id", tool.getRowId()))); %>
 <%
-    if (suppFiles.size() == 1) {
+    if (docCount == 1 && hasDocs) {
+%>
+                        <a href="<%=h(tool.getDocsUrl())%>" target="_blank" rel="noopener noreferrer"><button type="button" class="styled-button">Documentation <span class="visually-hidden"><%=h(tool.getName())%></span></button></a>
+<%
+    } else if (docCount == 1) {
         Map.Entry suppPair = (Map.Entry)suppIter.next();
 %>
-                        <a href="<%=h(suppPair.getKey())%>"><button type="button" class="styled-button">Documentation</button></a>
-<% } else if (suppFiles.size() > 1) { %>
+                        <a href="<%=h(suppPair.getKey())%>"><button type="button" class="styled-button">Documentation <span class="visually-hidden"><%=h(tool.getName())%></span></button></a>
+<% } else if (docCount > 1) { %>
                         <div class="menuMouseArea">
-                            <button type="button" class="styled-button">Documentation</button>
+                            <button type="button" class="styled-button">Documentation <span class="visually-hidden"><%=h(tool.getName())%></span></button>
                             <ul class="dropMenu">
+<% if (hasDocs) { %>
+                                <li><a href="<%=h(tool.getDocsUrl())%>" target="_blank" rel="noopener noreferrer"><img class="menuIconImg" src="<%= h(imgDir) %>link.png" alt="Documentation">Online Documentation</a></li>
+<% } %>
 <%
         while (suppIter.hasNext()) {
             Map.Entry suppPair = (Map.Entry)suppIter.next();

--- a/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
+++ b/SkylineToolsStore/src/org/labkey/skylinetoolsstore/view/SkylineToolsStoreWebPart.jsp
@@ -58,6 +58,8 @@
     .content {margin: 8px 12px 0 0; padding:0; text-align:justify;}
     .toolButtons {margin-top: 12px;}
     .styled-button{
+        display:inline-flex;
+        align-items:center;
         box-shadow:rgba(0,0,0,0.0.1) 0 1px 0 0;
         background-color:#5B74A8;
         border:1px solid #29447E;
@@ -207,12 +209,12 @@
 <%
     if (docCount == 1 && hasDocs) {
 %>
-                        <a href="<%=h(tool.getDocsUrl())%>" target="_blank" rel="noopener noreferrer"><button type="button" class="styled-button">Documentation <span class="visually-hidden"><%=h(tool.getName())%></span></button></a>
+                        <%=link(unsafe("Documentation <span class=\"visually-hidden\">" + h(tool.getName()) + "</span>")).href(tool.getDocsUrl()).clearClasses().addClass("styled-button").target("_blank").rel("noopener noreferrer")%>
 <%
     } else if (docCount == 1) {
         Map.Entry suppPair = (Map.Entry)suppIter.next();
 %>
-                        <a href="<%=h(suppPair.getKey())%>"><button type="button" class="styled-button">Documentation <span class="visually-hidden"><%=h(tool.getName())%></span></button></a>
+                        <%=link(unsafe("Documentation <span class=\"visually-hidden\">" + h(tool.getName()) + "</span>")).href(suppPair.getKey().toString()).clearClasses().addClass("styled-button")%>
 <% } else if (docCount > 1) { %>
                         <div class="menuMouseArea">
                             <button type="button" class="styled-button">Documentation <span class="visually-hidden"><%=h(tool.getName())%></span></button>


### PR DESCRIPTION
## Summary

* Added visually-hidden tool name to Download and Documentation buttons on the tool store listing page for screen reader accessibility (per WCAG 2.1 C7 technique)
* Show Documentation button on the listing page when a tool has HTML docs extracted from its ZIP (`tool.hasDocumentation()`), consistent with the docs link added to the tool details page in #610

## Test plan

- [x] Download buttons include visually-hidden tool name (inspect DOM)
- [x] Documentation buttons include visually-hidden tool name
- [x] AI Connector shows Documentation button on listing page when docs are present
- [x] Tools with supplementary files still show correct Documentation button/dropdown

Co-Authored-By: Claude <noreply@anthropic.com>