### PR TITLE
Drop redundant indices

### DIFF
--- a/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-25.004-25.005.sql
+++ b/panoramapublic/resources/schemas/dbscripts/postgresql/panoramapublic-25.004-25.005.sql
@@ -1,0 +1,14 @@
+-- Dropping ix_datasetstatus_experimentannotations [ExperimentAnnotationsId] because it overlaps with uq_datasetstatus_experimentannotations [ExperimentAnnotationsId]
+DROP INDEX panoramapublic.ix_datasetstatus_experimentannotations;
+-- Dropping ix_experimentannotations_shorturl [ShortUrl] because it overlaps with uq_experimentannotations_shorturl [ShortUrl]
+DROP INDEX panoramapublic.ix_experimentannotations_shorturl;
+-- Dropping ix_speclibinfo_experimentannotations [experimentAnnotationsId] because it overlaps with uq_speclibinfo [experimentAnnotationsId, librarytype, name, filenamehint, skylinelibraryid, revision]
+DROP INDEX panoramapublic.ix_speclibinfo_experimentannotations;
+-- Dropping ix_catalogentry_shorturl [ShortUrl] because it overlaps with uq_catalogentry_shorturl [ShortUrl]
+DROP INDEX panoramapublic.ix_catalogentry_shorturl;
+-- Dropping ix_experimentstructuralmodinfo_experimentannotationsid [ExperimentAnnotationsId] because it overlaps with uq_experimentstructuralmodinfo [ExperimentAnnotationsId, ModId]
+DROP INDEX panoramapublic.ix_experimentstructuralmodinfo_experimentannotationsid;
+-- Dropping ix_journalexperiment_journal [JournalId] because it overlaps with uq_journalexperiment [JournalId, ExperimentAnnotationsId]
+DROP INDEX panoramapublic.ix_journalexperiment_journal;
+-- Dropping ix_experimentisotopemodinfo_experimentannotationsid [ExperimentAnnotationsId] because it overlaps with uq_experimentisotopemodinfo [ExperimentAnnotationsId, ModId]
+DROP INDEX panoramapublic.ix_experimentisotopemodinfo_experimentannotationsid;

--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicModule.java
@@ -94,7 +94,7 @@ public class PanoramaPublicModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.004;
+        return 25.005;
     }
 
     @Override

--- a/testresults/resources/schemas/dbscripts/postgresql/testresults-13.400-13.401.sql
+++ b/testresults/resources/schemas/dbscripts/postgresql/testresults-13.400-13.401.sql
@@ -1,0 +1,2 @@
+-- Dropping testrunid_unqiue [id] because it overlaps with pk_testruns [id]
+ALTER TABLE testresults.testruns DROP CONSTRAINT testrunid_unqiue;

--- a/testresults/src/org/labkey/testresults/TestResultsModule.java
+++ b/testresults/src/org/labkey/testresults/TestResultsModule.java
@@ -64,7 +64,7 @@ public class TestResultsModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 13.40;
+        return 13.401;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Redundant indices waste disk space and degrade insert/update/delete performance

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7630

Note: Once merged to develop, I'll immediately backport this change to 26.3.