### PR TITLE
Add kaptcha verification to signup module

### DIFF
--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -642,7 +642,7 @@ public class SignUpController extends SpringActionController
     }
 
     // On success returns null and clears the session attribute so the captcha cannot be replayed.
-    // On failure return a a user-facing error message.
+    // On failure return a user-facing error message.
     // Logging matches LoginController's RegisterUserAction.
     private String verifyCaptcha(String submittedText, String emailForLogging)
     {
@@ -655,7 +655,7 @@ public class SignUpController extends SpringActionController
         }
         if (!expected.equalsIgnoreCase(StringUtils.trimToNull(submittedText)))
         {
-            _log.warn("Captcha text did not match for signup attempt for " + emailForLogging);
+            _log.warn("Captcha text did not match for signup attempt for {}", emailForLogging);
             return "Verification text does not match, please retry.";
         }
         session.removeAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
@@ -892,6 +892,7 @@ public class SignUpController extends SpringActionController
             validateSignupForm(signupForm, errors);
             if (errors.hasErrors())
             {
+                response.put("status", "ERROR");
                 response.put("error_message", errorsToMessages(errors));
                 return response;
             }
@@ -899,6 +900,7 @@ public class SignUpController extends SpringActionController
             ValidEmail email = parseAndValidateEmail(signupForm, errors);
             if (email == null)
             {
+                response.put("status", "ERROR");
                 response.put("error_message", errorsToMessages(errors));
                 return response;
             }
@@ -911,6 +913,7 @@ public class SignUpController extends SpringActionController
 
             if (!createUserAndSendEmail(signupForm, email, errors))
             {
+                response.put("status", "ERROR");
                 response.put("error_message", errorsToMessages(errors));
                 return response;
             }

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -16,6 +16,7 @@
 
 package org.labkey.signup;
 
+import jakarta.mail.MessagingException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.logging.log4j.LogManager;
@@ -528,7 +529,8 @@ public class SignUpController extends SpringActionController
         @Override
         public void validateCommand(SignupForm form, Errors errors)
         {
-            validateSignupForm(form, errors);
+            // All validation happens in handlePost so the order matches SignUpApiAction
+            // (captcha first, then blank-field checks, then email parsing, etc.).
         }
 
         @Override
@@ -560,27 +562,26 @@ public class SignUpController extends SpringActionController
         @Override
         public boolean handlePost(SignupForm signupForm, BindException errors) throws Exception
         {
-            // Validate with EmailValidator first. ValidEmail(email) will not throw an exception if the domain is
-            // missing from the email. The default domain configured for the server is appended.
-            EmailValidator validator = EmailValidator.getInstance();
-            if(!validator.isValid(signupForm.getEmail()))
+            String kaptchaError = verifyCaptcha(signupForm.getKaptchaText(), signupForm.getEmail());
+            if (kaptchaError != null)
             {
-                errors.reject(ERROR_MSG,"'" + signupForm.getEmail() + "' is not a valid email address.");
+                errors.reject(ERROR_MSG, kaptchaError);
                 return false;
             }
 
-            ValidEmail email;
-            try
+            validateSignupForm(signupForm, errors);
+            if (errors.hasErrors())
             {
-                email = new ValidEmail(signupForm.getEmail());
-            }
-            catch (ValidEmail.InvalidEmailException iee)
-            {
-                errors.reject(ERROR_MSG, iee.getMessage());
                 return false;
             }
 
-            if(UserManager.userExists(email))
+            ValidEmail email = parseAndValidateEmail(signupForm, errors);
+            if (email == null)
+            {
+                return false;
+            }
+
+            if (UserManager.userExists(email))
             {
                 // If the user already exists forward them to a page where they can click on a link to recover their password, if required
                 signupForm.setAccountExists(true);
@@ -588,26 +589,12 @@ public class SignUpController extends SpringActionController
                 return false;
             }
 
-            // If the user does not exit in LabKey's core database, check in our temporaryusers table
-            TempUser tempUser = getTempUser(signupForm, email);
-
-            // Send email to the user.
-            ActionURL confirmationUrl = getConfirmationURL(getContainer(), email, tempUser.getKey());
-            try
+            if (!createUserAndSendEmail(signupForm, email, errors))
             {
-                User mockUser = new User();
-                mockUser.setEmail(email.getEmailAddress());
-                SecurityManager.sendEmail(getContainer(), mockUser, SecurityManager.getRegistrationMessage(null, false), email.getEmailAddress(), confirmationUrl);
-            }
-            catch(Exception e)
-            {
-                String systemEmail = LookAndFeelProperties.getInstance(getContainer()).getSystemEmailAddress();
-                errors.reject(ERROR_MSG, "Could not send new user registration email.  Please contact your server administrator at " + systemEmail);
-                errors.reject(ERROR_MSG, e.getMessage());
                 return false;
             }
 
-
+            // Re-render the JSP with the CONFIRMATION_SENT message.
             signupForm.setNewSignUp(false);
             return false;
         }
@@ -642,6 +629,96 @@ public class SignUpController extends SpringActionController
         {
             errors.reject(ERROR_MSG, "Email cannot be blank.");
         }
+        if(StringUtils.isBlank(form.getEmailConfirm()))
+        {
+            errors.reject(ERROR_MSG, "Confirm email cannot be blank.");
+        }
+        else if(form.getEmail() != null && !form.getEmail().equals(form.getEmailConfirm()))
+        {
+            errors.reject(ERROR_MSG, "Email addresses do not match.");
+        }
+    }
+
+    // On success returns null and clears the session attribute so the captcha cannot be replayed.
+    // On failure return a a user-facing error message.
+    // Logging matches LoginController's RegisterUserAction.
+    private String verifyCaptcha(String submittedText, String emailForLogging)
+    {
+        var session = getViewContext().getRequest().getSession(true);
+        String expected = (String) session.getAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
+        if (expected == null)
+        {
+            _log.info("Captcha not initialized for signup attempt");
+            return "Captcha not initialized, please retry.";
+        }
+        if (!expected.equalsIgnoreCase(StringUtils.trimToNull(submittedText)))
+        {
+            _log.warn("Captcha text did not match for signup attempt for " + emailForLogging);
+            return "Verification text does not match, please retry.";
+        }
+        session.removeAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
+        return null;
+    }
+
+    // Returns a parsed ValidEmail, or null if the address is invalid (errors populated).
+    // Uses EmailValidator first because ValidEmail's constructor does not throw on bare
+    // strings like "foo" - it silently appends the server's default domain.
+    private ValidEmail parseAndValidateEmail(SignupForm form, Errors errors)
+    {
+        EmailValidator validator = EmailValidator.getInstance();
+        if (!validator.isValid(form.getEmail()))
+        {
+            errors.reject(ERROR_MSG, "'" + form.getEmail() + "' is not a valid email address.");
+            return null;
+        }
+        try
+        {
+            return new ValidEmail(form.getEmail());
+        }
+        catch (ValidEmail.InvalidEmailException iee)
+        {
+            errors.reject(ERROR_MSG, iee.getMessage());
+            return null;
+        }
+    }
+
+    // Creates (or reuses) a TempUser row and sends the confirmation email in a single
+    // transaction. On send failure the transaction is rolled back so a freshly inserted
+    // TempUser row does not persist when the user never received a confirmation link.
+    private boolean createUserAndSendEmail(SignupForm form, ValidEmail email, Errors errors) throws java.sql.SQLException
+    {
+        try (DbScope.Transaction transaction = SignUpManager.getSchema().getScope().ensureTransaction())
+        {
+            TempUser tempUser = getTempUser(form, email);
+            ActionURL confirmationUrl = getConfirmationURL(getContainer(), email, tempUser.getKey());
+            try
+            {
+                User mockUser = new User();
+                mockUser.setEmail(email.getEmailAddress());
+                SecurityManager.sendEmail(getContainer(), mockUser,
+                        SecurityManager.getRegistrationMessage(null, false),
+                        email.getEmailAddress(), confirmationUrl);
+            }
+            catch (MessagingException e)
+            {
+                String systemEmail = LookAndFeelProperties.getInstance(getContainer()).getSystemEmailAddress();
+                errors.reject(ERROR_MSG, "Could not send new user registration email. Please contact your server administrator at " + systemEmail);
+                if (e.getMessage() != null)
+                {
+                    errors.reject(ERROR_MSG, e.getMessage());
+                }
+                return false;
+            }
+            transaction.commit();
+            return true;
+        }
+    }
+
+    private static List<String> errorsToMessages(Errors errors)
+    {
+        return errors.getAllErrors().stream()
+                .map(e -> e.getDefaultMessage())
+                .toList();
     }
 
     public static ActionURL getConfirmationURL(Container c, ValidEmail email, String key)
@@ -658,6 +735,7 @@ public class SignUpController extends SpringActionController
         private String _lastName;
         private String _organization;
         private String _email;
+        private String _emailConfirm;
         private boolean _accountExists;
         private boolean _newSignUp = true;
 
@@ -699,6 +777,16 @@ public class SignUpController extends SpringActionController
         public void setEmail(String email)
         {
             _email = email;
+        }
+
+        public String getEmailConfirm()
+        {
+            return _emailConfirm;
+        }
+
+        public void setEmailConfirm(String emailConfirm)
+        {
+            _emailConfirm = emailConfirm;
         }
 
         public boolean isAccountExists()
@@ -791,72 +879,40 @@ public class SignUpController extends SpringActionController
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
 
-            String expectedKaptcha = (String) getViewContext().getRequest().getSession(true)
-                    .getAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
-            if (expectedKaptcha == null)
+            String kaptchaError = verifyCaptcha(signupForm.getKaptchaText(), signupForm.getEmail());
+            if (kaptchaError != null)
             {
-                _log.info("Captcha not initialized for signup attempt");
-                response.put("error_message", List.of("Captcha not initialized, please retry."));
-                return response;
-            }
-            if (!expectedKaptcha.equalsIgnoreCase(StringUtils.trimToNull(signupForm.getKaptchaText())))
-            {
-                _log.warn("Captcha text did not match for signup attempt for " + signupForm.getEmail());
-                response.put("error_message", List.of("Verification text does not match, please retry."));
-                return response;
-            }
-            getViewContext().getRequest().getSession(true).removeAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
-
-            ValidEmail email;
-            try
-            {
-                email = new ValidEmail(signupForm.getEmail());
-            }
-            catch (ValidEmail.InvalidEmailException iee)
-            {
-                response.put("error_message", List.of(iee.getMessage()));
+                response.put("error_message", List.of(kaptchaError));
                 return response;
             }
 
-            if(UserManager.userExists(email))
+            validateSignupForm(signupForm, errors);
+            if (errors.hasErrors())
+            {
+                response.put("error_message", errorsToMessages(errors));
+                return response;
+            }
+
+            ValidEmail email = parseAndValidateEmail(signupForm, errors);
+            if (email == null)
+            {
+                response.put("error_message", errorsToMessages(errors));
+                return response;
+            }
+
+            if (UserManager.userExists(email))
             {
                 response.put("status", "USER_EXISTS");
                 return response;
             }
 
-            validateSignupForm(signupForm, errors);
-            if(errors.hasErrors())
+            if (!createUserAndSendEmail(signupForm, email, errors))
             {
-                List<String> messages = errors.getAllErrors().stream()
-                        .map(e -> e.getDefaultMessage())
-                        .toList();
-                response.put("error_message", messages);
+                response.put("error_message", errorsToMessages(errors));
                 return response;
             }
 
-            TempUser tempUser = getTempUser(signupForm, email);
-
-
-            // Send email to the user.
-            ActionURL confirmationUrl = getConfirmationURL(getContainer(), email, tempUser.getKey());
-            try
-            {
-                User mockUser = new User();
-                mockUser.setEmail(email.getEmailAddress());
-                SecurityManager.sendEmail(getContainer(), mockUser, SecurityManager.getRegistrationMessage(null, false), email.getEmailAddress(), confirmationUrl);
-            }
-            catch(Exception e)
-            {
-                String systemEmail = LookAndFeelProperties.getInstance(getContainer()).getSystemEmailAddress();
-                List<String> messages = new ArrayList<>();
-                messages.add("Could not send new user registration email.  Please contact your server administrator at " + systemEmail);
-                messages.add(e.getMessage());
-                response.put("error_message", messages);
-            }
-
-            signupForm.setNewSignUp(false); // TODO: Most likely not needed here
             response.put("status", "USER_ADDED");
-
             return response;
         }
     }

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -62,6 +62,7 @@ import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.HtmlView;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.JspView;
+import org.labkey.api.view.LabKeyKaptchaServlet;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.WebPartView;
 import org.springframework.validation.BindException;
@@ -719,6 +720,18 @@ public class SignUpController extends SpringActionController
         {
             _newSignUp = newSignUp;
         }
+
+        private String _kaptchaText;
+
+        public String getKaptchaText()
+        {
+            return _kaptchaText;
+        }
+
+        public void setKaptchaText(String kaptchaText)
+        {
+            _kaptchaText = kaptchaText;
+        }
     }
 
     @RequiresLogin
@@ -778,6 +791,22 @@ public class SignUpController extends SpringActionController
         {
             ApiSimpleResponse response = new ApiSimpleResponse();
 
+            String expectedKaptcha = (String) getViewContext().getRequest().getSession(true)
+                    .getAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
+            if (expectedKaptcha == null)
+            {
+                _log.info("Captcha not initialized for signup attempt");
+                response.put("error_message", List.of("Captcha not initialized, please retry."));
+                return response;
+            }
+            if (!expectedKaptcha.equalsIgnoreCase(StringUtils.trimToNull(signupForm.getKaptchaText())))
+            {
+                _log.warn("Captcha text did not match for signup attempt for " + signupForm.getEmail());
+                response.put("error_message", List.of("Verification text does not match, please retry."));
+                return response;
+            }
+            getViewContext().getRequest().getSession(true).removeAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
+
             ValidEmail email;
             try
             {
@@ -785,7 +814,7 @@ public class SignUpController extends SpringActionController
             }
             catch (ValidEmail.InvalidEmailException iee)
             {
-                errors.reject(ERROR_MSG, iee.getMessage());
+                response.put("error_message", List.of(iee.getMessage()));
                 return response;
             }
 
@@ -798,6 +827,10 @@ public class SignUpController extends SpringActionController
             validateSignupForm(signupForm, errors);
             if(errors.hasErrors())
             {
+                List<String> messages = errors.getAllErrors().stream()
+                        .map(e -> e.getDefaultMessage())
+                        .toList();
+                response.put("error_message", messages);
                 return response;
             }
 

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -55,6 +55,7 @@ import org.labkey.api.security.ValidEmail;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.ButtonBuilder;
+import org.labkey.api.util.ConfigurationException;
 import org.labkey.api.util.DOM;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.URLHelper;
@@ -68,6 +69,7 @@ import org.labkey.api.view.NavTree;
 import org.labkey.api.view.WebPartView;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.ArrayList;
@@ -699,7 +701,7 @@ public class SignUpController extends SpringActionController
                         SecurityManager.getRegistrationMessage(null, false),
                         email.getEmailAddress(), confirmationUrl);
             }
-            catch (MessagingException e)
+            catch (MessagingException | ConfigurationException e)
             {
                 String systemEmail = LookAndFeelProperties.getInstance(getContainer()).getSystemEmailAddress();
                 errors.reject(ERROR_MSG, "Could not send new user registration email. Please contact your server administrator at " + systemEmail);
@@ -717,7 +719,7 @@ public class SignUpController extends SpringActionController
     private static List<String> errorsToMessages(Errors errors)
     {
         return errors.getAllErrors().stream()
-                .map(e -> e.getDefaultMessage())
+                .map(ObjectError::getDefaultMessage)
                 .toList();
     }
 
@@ -882,6 +884,7 @@ public class SignUpController extends SpringActionController
             String kaptchaError = verifyCaptcha(signupForm.getKaptchaText(), signupForm.getEmail());
             if (kaptchaError != null)
             {
+                response.put("status", "ERROR");
                 response.put("error_message", List.of(kaptchaError));
                 return response;
             }

--- a/signup/src/org/labkey/signup/SignUpController.java
+++ b/signup/src/org/labkey/signup/SignUpController.java
@@ -591,10 +591,21 @@ public class SignUpController extends SpringActionController
                 return false;
             }
 
-            if (!createUserAndSendEmail(signupForm, email, errors))
+            try
             {
+                createUserAndSendEmail(signupForm, email);
+            }
+            catch (MessagingException | ConfigurationException e)
+            {
+                errors.reject(ERROR_MSG, sendEmailErrorMessage(getContainer()));
+                if (e.getMessage() != null)
+                {
+                    errors.reject(ERROR_MSG, e.getMessage());
+                }
                 return false;
             }
+
+            clearCaptcha();
 
             // Re-render the JSP with the CONFIRMATION_SENT message.
             signupForm.setNewSignUp(false);
@@ -635,14 +646,15 @@ public class SignUpController extends SpringActionController
         {
             errors.reject(ERROR_MSG, "Confirm email cannot be blank.");
         }
-        else if(form.getEmail() != null && !form.getEmail().equals(form.getEmailConfirm()))
+        else if(!StringUtils.isBlank(form.getEmail()) && !form.getEmail().equalsIgnoreCase(form.getEmailConfirm()))
         {
             errors.reject(ERROR_MSG, "Email addresses do not match.");
         }
     }
 
-    // On success returns null and clears the session attribute so the captcha cannot be replayed.
-    // On failure return a user-facing error message.
+    // On success returns null. On failure returns a user-facing error message.
+    // Does not clear the session attribute — callers clear it after the full operation
+    // succeeds so the user can retry with the same captcha if a later step fails.
     // Logging matches LoginController's RegisterUserAction.
     private String verifyCaptcha(String submittedText, String emailForLogging)
     {
@@ -658,8 +670,12 @@ public class SignUpController extends SpringActionController
             _log.warn("Captcha text did not match for signup attempt for {}", emailForLogging);
             return "Verification text does not match, please retry.";
         }
-        session.removeAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
         return null;
+    }
+
+    private void clearCaptcha()
+    {
+        getViewContext().getRequest().getSession(true).removeAttribute(LabKeyKaptchaServlet.SESSION_KEY_VALUE);
     }
 
     // Returns a parsed ValidEmail, or null if the address is invalid (errors populated).
@@ -685,34 +701,21 @@ public class SignUpController extends SpringActionController
     }
 
     // Creates (or reuses) a TempUser row and sends the confirmation email in a single
-    // transaction. On send failure the transaction is rolled back so a freshly inserted
-    // TempUser row does not persist when the user never received a confirmation link.
-    private boolean createUserAndSendEmail(SignupForm form, ValidEmail email, Errors errors) throws java.sql.SQLException
+    // transaction. On send failure the exception propagates and the transaction rolls back
+    // automatically so a freshly inserted TempUser row does not persist.
+    private void createUserAndSendEmail(SignupForm form, ValidEmail email)
+            throws MessagingException, ConfigurationException, java.sql.SQLException
     {
         try (DbScope.Transaction transaction = SignUpManager.getSchema().getScope().ensureTransaction())
         {
             TempUser tempUser = getTempUser(form, email);
             ActionURL confirmationUrl = getConfirmationURL(getContainer(), email, tempUser.getKey());
-            try
-            {
-                User mockUser = new User();
-                mockUser.setEmail(email.getEmailAddress());
-                SecurityManager.sendEmail(getContainer(), mockUser,
-                        SecurityManager.getRegistrationMessage(null, false),
-                        email.getEmailAddress(), confirmationUrl);
-            }
-            catch (MessagingException | ConfigurationException e)
-            {
-                String systemEmail = LookAndFeelProperties.getInstance(getContainer()).getSystemEmailAddress();
-                errors.reject(ERROR_MSG, "Could not send new user registration email. Please contact your server administrator at " + systemEmail);
-                if (e.getMessage() != null)
-                {
-                    errors.reject(ERROR_MSG, e.getMessage());
-                }
-                return false;
-            }
+            User mockUser = new User();
+            mockUser.setEmail(email.getEmailAddress());
+            SecurityManager.sendEmail(getContainer(), mockUser,
+                    SecurityManager.getRegistrationMessage(null, false),
+                    email.getEmailAddress(), confirmationUrl);
             transaction.commit();
-            return true;
         }
     }
 
@@ -721,6 +724,12 @@ public class SignUpController extends SpringActionController
         return errors.getAllErrors().stream()
                 .map(ObjectError::getDefaultMessage)
                 .toList();
+    }
+
+    private static String sendEmailErrorMessage(Container container)
+    {
+        return "Could not send new user registration email. Please contact your server administrator at "
+                + LookAndFeelProperties.getInstance(container).getSystemEmailAddress();
     }
 
     public static ActionURL getConfirmationURL(Container c, ValidEmail email, String key)
@@ -911,12 +920,24 @@ public class SignUpController extends SpringActionController
                 return response;
             }
 
-            if (!createUserAndSendEmail(signupForm, email, errors))
+            try
+            {
+                createUserAndSendEmail(signupForm, email);
+            }
+            catch (MessagingException | ConfigurationException e)
             {
                 response.put("status", "ERROR");
-                response.put("error_message", errorsToMessages(errors));
+                List<String> messages = new ArrayList<>();
+                messages.add(sendEmailErrorMessage(getContainer()));
+                if (e.getMessage() != null)
+                {
+                    messages.add(e.getMessage());
+                }
+                response.put("error_message", messages);
                 return response;
             }
+
+            clearCaptcha();
 
             response.put("status", "USER_ADDED");
             return response;

--- a/signup/src/org/labkey/signup/signupPage.jsp
+++ b/signup/src/org/labkey/signup/signupPage.jsp
@@ -1,38 +1,37 @@
-<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
-<%@ page import="org.labkey.signup.SignUpController.BeginAction" %>
 <%@ page import="org.labkey.signup.SignUpController.SignupForm" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
     SignupForm form = (SignupForm)HttpView.currentModel();
-    ActionURL url = urlFor(BeginAction.class);
+    String contextPath = request.getContextPath();
 %>
 
-<!-- Display errors here -->
 <labkey:errors/>
 
-<form action="<%=h(url)%>" method=post>
-    <labkey:csrf/>
-    <table>
-        <tr>
-            <td class="labkey-form-label"><label for="firstName">First Name</label> *</td>
-            <td nowrap><input size="20" type="text" id="firstName" name="firstName" value="<%=h(form.getFirstName())%>"/></td>
-        </tr>
-        <tr>
-            <td class="labkey-form-label"><label for="lastName">Last Name</label> *</td>
-            <td nowrap><input size="20" type="text" id="lastName" name="lastName" value="<%=h(form.getLastName())%>"/></td>
-        </tr>
-        <tr>
-            <td class="labkey-form-label"><label for="organization">Organization</label> *</td>
-            <td nowrap><input size="20" type="text" id="organization" name="organization" value="<%=h(form.getOrganization())%>"/></td>
-        </tr>
-        <tr>
-            <td class="labkey-form-label"><label for="email">Email</label> *</td>
-            <td nowrap><input size="20" type="text" id="email" name="email" value="<%=h(form.getEmail())%>"/></td>
-        </tr>
-        <tr>
-            <td colspan="2"><labkey:button text="Submit" /></td>
-        </tr>
-    </table>
-</form>
+<labkey:form method="post" layout="horizontal" autoComplete="off" style="max-width:600px;">
+    <labkey:input name="firstName" id="firstName" label="First Name" isRequired="true" size="50" value="<%=form.getFirstName()%>"/>
+    <labkey:input name="lastName" id="lastName" label="Last Name" isRequired="true" size="50" value="<%=form.getLastName()%>"/>
+    <labkey:input name="organization" id="organization" label="Organization" isRequired="true" size="50" value="<%=form.getOrganization()%>"/>
+    <labkey:input name="email" id="email" label="Email" isRequired="true" size="50" value="<%=form.getEmail()%>"/>
+    <labkey:input name="emailConfirm" id="emailConfirm" label="Confirm Email" isRequired="true" size="50" value="<%=form.getEmailConfirm()%>"/>
+
+    <%-- Verification: standalone full-width block --%>
+    <div style="margin-top:20px;"><strong>Verification</strong></div>
+    <p style="margin:8px 0 4px 0;">Please enter the six characters shown below (case-insensitive).</p>
+    <p style="margin:0 0 8px 0;"><a id="kaptchaReload" href="#">Get a new image.</a></p>
+    <img id="kaptchaImg" src="<%=h(contextPath)%>/kaptcha.jpg" alt="Captcha" width="200" height="50" style="border: 1px solid #ccc; display:block; margin-bottom:6px;"/>
+    <input type="text" id="kaptchaText" name="kaptchaText" style="width:200px;"/>
+
+    <div style="margin-top:20px; clear:both;">
+        <button type="submit" class="btn btn-default labkey-button">Register</button>
+    </div>
+</labkey:form>
+
+<script type="text/javascript" nonce="<%=getScriptNonce()%>">
+    document.getElementById("kaptchaReload").addEventListener("click", function(e) {
+        e.preventDefault();
+        var img = document.getElementById("kaptchaImg");
+        img.src = img.src.split("?")[0] + "?ts=" + new Date().getTime();
+    });
+</script>

--- a/signup/src/org/labkey/signup/signupPage.jsp
+++ b/signup/src/org/labkey/signup/signupPage.jsp
@@ -18,10 +18,10 @@
 
     <%-- Verification: standalone full-width block --%>
     <div style="margin-top:20px;"><strong>Verification</strong></div>
-    <p style="margin:8px 0 4px 0;">Please enter the six characters shown below (case-insensitive).</p>
+    <p style="margin:8px 0 4px 0;">Please enter the characters shown below (case-insensitive).</p>
     <p style="margin:0 0 8px 0;"><a id="kaptchaReload" href="#">Get a new image.</a></p>
     <img id="kaptchaImg" src="<%=h(contextPath)%>/kaptcha.jpg" alt="Captcha" width="200" height="50" style="border: 1px solid #ccc; display:block; margin-bottom:6px;"/>
-    <input type="text" id="kaptchaText" name="kaptchaText" style="width:200px;"/>
+    <input type="text" id="kaptchaText" name="kaptchaText" aria-label="Verification code" style="width:200px;"/>
 
     <div style="margin-top:20px; clear:both;">
         <button type="submit" class="btn btn-default labkey-button">Register</button>

--- a/signup/src/org/labkey/signup/signupPage.jsp
+++ b/signup/src/org/labkey/signup/signupPage.jsp
@@ -1,4 +1,5 @@
 <%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.signup.SignUpController.BeginAction" %>
 <%@ page import="org.labkey.signup.SignUpController.SignupForm" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
@@ -9,7 +10,7 @@
 
 <labkey:errors/>
 
-<labkey:form method="post" layout="horizontal" autoComplete="off" style="max-width:600px;">
+<labkey:form method="post" action="<%=urlFor(BeginAction.class)%>" layout="horizontal" autoComplete="off" style="max-width:600px;">
     <labkey:input name="firstName" id="firstName" label="First Name" isRequired="true" size="50" value="<%=form.getFirstName()%>"/>
     <labkey:input name="lastName" id="lastName" label="Last Name" isRequired="true" size="50" value="<%=form.getLastName()%>"/>
     <labkey:input name="organization" id="organization" label="Organization" isRequired="true" size="50" value="<%=form.getOrganization()%>"/>


### PR DESCRIPTION
#### Rationale
We need to add bot protection to the self-sign-up form. 

#### Changes
 * Added server-side kaptcha verification to `SignUpApiAction` and `BeginAction`
  * Extracted shared helpers so both action paths follow the same verification sequence in the same order
  * Added `emailConfirm` field requiring users to enter their email address twice
  * Fixed two API path bugs: `EmailValidator.isValid` was not called, and a  `sendEmail` failure was falling through to `status=USER_ADDED`
  * Wrapped TempUser insert + confirmation email in a transaction so the row  is rolled back if email delivery fails
  * Rewrote `signupPage.jsp` to use `<labkey:form>` and `<labkey:input>` taglibs

 ## Manual test plan

  - [x] Valid kaptcha + valid form: confirmation email sent, TempUser row inserted
  - [x] Invalid kaptcha: error returned, no row inserted
  - [x] Session expired / kaptcha not initialized: load the page, delete the JSESSIONID cookie in DevTools → Application → Cookies, submit the form → expect "Captcha not initialized, please retry."
  - [x] Invalid email format (e.g. "notanemail"): rejected with error message
  - [x] Email / Confirm Email mismatch: rejected with error message
  - [x] Email already registered: API returns `status=USER_EXISTS`
  - [x] Tested as unauthenticated guest
 
 See ai/todos/active/TODO-LK-20260517_add-kaptcha-to-signup.md

Co-Authored-By: Claude <noreply@anthropic.com>