### PR TITLE
ProcessBuilder -> LabKeyProcessBuilder

### DIFF
--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
@@ -79,7 +79,7 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
             FileLike dir = getJob().getLogFileLike().getParent();
             getJob().runSubProcess(secretsPB, dir);
 
-            ProcessBuilder executionPB = new ProcessBuilder(getArgs());
+            LabKeyProcessBuilder executionPB = new LabKeyProcessBuilder(getArgs());
             getJob().runSubProcess(executionPB, dir);
             log.info("Job Finished");
             NextFlowPipelineJob.LOG.info("Finished executing NextFlow: {}", getJob().getJsonJobInfo(true));

--- a/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
+++ b/nextflow/src/org/labkey/nextflow/pipeline/NextFlowRunTask.java
@@ -14,6 +14,7 @@ import org.labkey.api.pipeline.WorkDirectoryTask;
 import org.labkey.api.security.SecurityManager;
 import org.labkey.api.targetedms.TargetedMSService;
 import org.labkey.api.util.FileType;
+import org.labkey.api.util.LabKeyProcessBuilder;
 import org.labkey.nextflow.NextFlowConfiguration;
 import org.labkey.nextflow.NextFlowManager;
 import org.labkey.vfs.FileLike;
@@ -73,7 +74,7 @@ public class NextFlowRunTask extends WorkDirectoryTask<NextFlowRunTask.Factory>
             }
 
             // Need to pass to the main process directly in the future to allow concurrent execution for different users
-            ProcessBuilder secretsPB = new ProcessBuilder("nextflow", "secrets", "set", "PANORAMA_API_KEY", apiKey);
+            LabKeyProcessBuilder secretsPB = new LabKeyProcessBuilder("nextflow", "secrets", "set", "PANORAMA_API_KEY", apiKey);
             log.info("Setting secrets");
             FileLike dir = getJob().getLogFileLike().getParent();
             getJob().runSubProcess(secretsPB, dir);


### PR DESCRIPTION
#### Rationale
We want to consistently use our own `ProcessBuilder` variant, `LabKeyProcessBuilder` to standardize the environment variables we pass to forked processes.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7704

#### Changes
- Adopt LabKeyProcessBuilder
- Misc cleanup