### PR TITLE
Filter testresults tables to the current folder

### DIFF
--- a/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
+++ b/testresults/src/org/labkey/testresults/SendTestResultsEmail.java
@@ -106,7 +106,7 @@ public class SendTestResultsEmail implements org.quartz.Job
             TestResultsController.ensureRunDataCached(runs, false);
             TestResultsController.populatePassesLeaksFails(runs);
 
-            User[] users = TestResultsController.getUsers(container, null);
+            User[] users = TestResultsController.getUsers(from, container, null);
 
             RunDownBean data = new RunDownBean(runs, users);
             RunProblems problems = new RunProblems(data.getRunsByDate(end));

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -411,6 +411,8 @@ public class TestResultsController extends SpringActionController
     }
 
     public static User[] getUsers(org.labkey.api.security.User user, Container trainingDataContainer, String username) {
+        if (trainingDataContainer == null)
+            throw new IllegalArgumentException("getUsers requires a folder; use findUserIdByName(username) for the no-folder lookup");
         // Scope the computer list to the current folder via the filtered "user" query table.
         TableInfo userTable = new TestResultsSchema(user, trainingDataContainer)
                 .getTable(TestResultsSchema.TABLE_USER, ContainerFilter.current(trainingDataContainer, user));

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -34,6 +34,7 @@ import org.labkey.api.action.SpringActionController;
 import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.JdbcType;
@@ -44,6 +45,7 @@ import org.labkey.api.data.Sort;
 import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
+import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.files.FileContentService;
 import org.labkey.api.notification.EmailMessage;
@@ -323,7 +325,7 @@ public class TestResultsController extends SpringActionController
 
         ensureRunDataCached(allRuns, false);
 
-        User[] users = getUsers(c, null);
+        User[] users = getUsers(user, c, null);
         return new RunDownBean(allRuns, users, viewType, null, endDate);
     }
 
@@ -408,53 +410,57 @@ public class TestResultsController extends SpringActionController
         }
     }
 
-    public static User[] getUsers(Container trainingDataContainer, String username) {
-        SQLFragment sqlFragment = new SQLFragment();
-        sqlFragment.append("SELECT id, username FROM testresults.user WHERE 1=1");
-        if (trainingDataContainer != null)
-        {
-            sqlFragment.append(" AND id IN (SELECT userid FROM testresults.testruns WHERE container = ?)");
-            sqlFragment.add(trainingDataContainer.getEntityId());
-        }
+    public static User[] getUsers(org.labkey.api.security.User user, Container trainingDataContainer, String username) {
+        // Scope the computer list to the current folder via the filtered "user" query table.
+        TableInfo userTable = new TestResultsSchema(user, trainingDataContainer)
+                .getTable(TestResultsSchema.TABLE_USER, ContainerFilter.current(trainingDataContainer, user));
+        SimpleFilter filter = new SimpleFilter();
         if (username != null && !username.isEmpty())
-        {
-            sqlFragment.append(" AND username = ?");
-            sqlFragment.add(username);
-        }
-        sqlFragment.append(" ORDER BY id");
+            filter.addCondition(FieldKey.fromParts("username"), username);
         List<User> users = new ArrayList<>();
-        new SqlSelector(TestResultsSchema.getSchema(), sqlFragment).forEach(rs -> {
+        new TableSelector(userTable, filter, new Sort("id")).forEach(rs -> {
             User u = new User();
             u.setId(rs.getInt("id"));
             u.setUsername(rs.getString("username"));
             users.add(u);
         });
 
-        if (trainingDataContainer != null)
-        {
-            sqlFragment = new SQLFragment();
-            sqlFragment.append(
-                "SELECT userid, meantestsrun, meanmemory, stddevtestsrun, stddevmemory, active " +
-                "FROM testresults.userdata " +
-                "WHERE container = ?");
-            sqlFragment.add(trainingDataContainer.getEntityId());
-            new SqlSelector(TestResultsSchema.getSchema(), sqlFragment).forEach(rs -> {
-                for (User u : users)
+        // Attach the training stats (userdata is keyed by container).
+        SQLFragment sqlFragment = new SQLFragment();
+        sqlFragment.append(
+            "SELECT userid, meantestsrun, meanmemory, stddevtestsrun, stddevmemory, active " +
+            "FROM testresults.userdata " +
+            "WHERE container = ?");
+        sqlFragment.add(trainingDataContainer.getEntityId());
+        new SqlSelector(TestResultsSchema.getSchema(), sqlFragment).forEach(rs -> {
+            for (User u : users)
+            {
+                if (u.getId() == rs.getInt("userid"))
                 {
-                    if (u.getId() == rs.getInt("userid"))
-                    {
-                        u.setMeantestsrun(rs.getDouble("meantestsrun"));
-                        u.setMeanmemory(rs.getDouble("meanmemory"));
-                        u.setStddevtestsrun(rs.getDouble("stddevtestsrun"));
-                        u.setStddevmemory(rs.getDouble("stddevmemory"));
-                        u.setContainer(trainingDataContainer);
-                        u.setActive(rs.getBoolean("active"));
-                        break;
-                    }
+                    u.setMeantestsrun(rs.getDouble("meantestsrun"));
+                    u.setMeanmemory(rs.getDouble("meanmemory"));
+                    u.setStddevtestsrun(rs.getDouble("stddevtestsrun"));
+                    u.setStddevmemory(rs.getDouble("stddevmemory"));
+                    u.setContainer(trainingDataContainer);
+                    u.setActive(rs.getBoolean("active"));
+                    break;
                 }
-            });
-        }
+            }
+        });
         return users.toArray(new User[0]);
+    }
+
+    /**
+     * Looks up a computer's id by exact name across all folders, or -1 if none exists. The "user"
+     * row is global (no container column), and run ingestion (ParseAndStoreXML) runs anonymously
+     * and may be the computer's first post to a given folder, so this lookup must not be container-scoped.
+     */
+    private static int findUserIdByName(String username)
+    {
+        SQLFragment sql = new SQLFragment("SELECT id FROM testresults.user WHERE username = ? ORDER BY id", username);
+        List<Integer> ids = new ArrayList<>();
+        new SqlSelector(TestResultsSchema.getSchema(), sql).forEach(rs -> ids.add(rs.getInt("id")));
+        return ids.isEmpty() ? -1 : ids.get(0);
     }
 
     /**
@@ -479,7 +485,7 @@ public class TestResultsController extends SpringActionController
 
             ensureRunDataCached(runs, false);
 
-            User[] users = getUsers(getContainer(), null);
+            User[] users = getUsers(getUser(), getContainer(), null);
             TestsDataBean bean = new TestsDataBean(runs, users);
             JspView<TestsDataBean> view = new JspView<>("/org/labkey/testresults/view/trainingdata.jsp", bean);
             view.setFrame(WebPartView.FrameType.PORTAL);
@@ -627,7 +633,7 @@ public class TestResultsController extends SpringActionController
             User user = null;
             if (StringUtils.isNotBlank(userName))
             {
-                User[] users = getUsers(getContainer(), userName);
+                User[] users = getUsers(getUser(), getContainer(), userName);
                 if (users.length == 1)
                     user = users[0];
             }
@@ -1826,19 +1832,16 @@ public class TestResultsController extends SpringActionController
 
                 Element docElement = doc.getDocumentElement();
                 // USER ID
-                int userid;
                 String username = docElement.getAttribute("id");
-                User[] details = getUsers(null, username);
-                if (details.length == 0) {
-                    User newUser =  new User();
+                int userid = findUserIdByName(username);
+                if (userid == -1) {
+                    User newUser = new User();
                     newUser.setUsername(username);
                     User u = Table.insert(null, TestResultsSchema.getTableInfoUser(), newUser);
                     if (u == null) {
                         throw new Exception();
                     }
                     userid = u.getId();
-                } else {
-                    userid = details[0].getId();
                 }
                 if (userid == -1)
                     throw new Exception("Issue with user/userid, may not be set");

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -25,6 +25,7 @@ import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.labkey.api.action.ApiSimpleResponse;
 import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ReadOnlyApiAction;
@@ -410,7 +411,7 @@ public class TestResultsController extends SpringActionController
         }
     }
 
-    public static User[] getUsers(org.labkey.api.security.User user, Container trainingDataContainer, String username) {
+    public static User[] getUsers(@NotNull org.labkey.api.security.User user, @NotNull Container trainingDataContainer, @Nullable String username) {
         if (trainingDataContainer == null)
             throw new IllegalArgumentException("getUsers requires a folder; use findUserIdByName(username) for the no-folder lookup");
         // Scope the computer list to the current folder via the filtered "user" query table.
@@ -457,7 +458,7 @@ public class TestResultsController extends SpringActionController
      * row is global (no container column), and run ingestion (ParseAndStoreXML) runs anonymously
      * and may be the computer's first post to a given folder, so this lookup must not be container-scoped.
      */
-    private static int findUserIdByName(String username)
+    private static int findUserIdByName(@NotNull String username)
     {
         SQLFragment sql = new SQLFragment("SELECT id FROM testresults.user WHERE username = ? ORDER BY id", username);
         List<Integer> ids = new ArrayList<>();
@@ -1835,6 +1836,8 @@ public class TestResultsController extends SpringActionController
                 Element docElement = doc.getDocumentElement();
                 // USER ID
                 String username = docElement.getAttribute("id");
+                if (StringUtils.isBlank(username))
+                    throw new IllegalArgumentException("Posted run XML is missing the required computer name (id attribute)");
                 int userid = findUserIdByName(username);
                 if (userid == -1) {
                     User newUser = new User();

--- a/testresults/src/org/labkey/testresults/TestResultsController.java
+++ b/testresults/src/org/labkey/testresults/TestResultsController.java
@@ -410,10 +410,15 @@ public class TestResultsController extends SpringActionController
 
     public static User[] getUsers(Container trainingDataContainer, String username) {
         SQLFragment sqlFragment = new SQLFragment();
-        sqlFragment.append("SELECT id, username FROM testresults.user");
+        sqlFragment.append("SELECT id, username FROM testresults.user WHERE 1=1");
+        if (trainingDataContainer != null)
+        {
+            sqlFragment.append(" AND id IN (SELECT userid FROM testresults.testruns WHERE container = ?)");
+            sqlFragment.add(trainingDataContainer.getEntityId());
+        }
         if (username != null && !username.isEmpty())
         {
-            sqlFragment.append(" WHERE username = ?");
+            sqlFragment.append(" AND username = ?");
             sqlFragment.add(username);
         }
         sqlFragment.append(" ORDER BY id");

--- a/testresults/src/org/labkey/testresults/TestResultsSchema.java
+++ b/testresults/src/org/labkey/testresults/TestResultsSchema.java
@@ -153,6 +153,9 @@ public class TestResultsSchema extends UserSchema
     /**
      * The user table has no container column and no FK to testruns. Filter it to users
      * referenced by at least one testrun in an allowed container.
+     *
+     * No getContainerFieldKey() override: a machine can post to several containers, so it
+     * has no single "home" container. applyContainerFilter() alone does the scoping.
      */
     private FilteredTable<TestResultsSchema> createUserTable(TableInfo dbTable, ContainerFilter cf)
     {

--- a/testresults/src/org/labkey/testresults/TestResultsSchema.java
+++ b/testresults/src/org/labkey/testresults/TestResultsSchema.java
@@ -24,10 +24,12 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
 import org.labkey.api.data.ForeignKey;
+import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.DefaultSchema;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QuerySchema;
@@ -86,7 +88,8 @@ public class TestResultsSchema extends UserSchema
     @Override
     public @Nullable TableInfo createTable(@NotNull String name, @NotNull ContainerFilter cf)
     {
-        TableInfo dbTable = switch (name.toLowerCase())
+        String lower = name.toLowerCase();
+        TableInfo dbTable = switch (lower)
         {
             case TABLE_TEST_RUNS       -> getTableInfoTestRuns();
             case TABLE_USER            -> getTableInfoUser();
@@ -102,10 +105,72 @@ public class TestResultsSchema extends UserSchema
         };
         if (dbTable == null)
             return null;
-        FilteredTable<TestResultsSchema> table = new FilteredTable<>(dbTable, this, cf);
+        FilteredTable<TestResultsSchema> table = switch (lower)
+        {
+            case TABLE_HANGS, TABLE_MEMORY_LEAKS, TABLE_HANDLE_LEAKS, TABLE_TEST_PASSES, TABLE_TEST_FAILS ->
+                    createRunChildTable(dbTable, cf, "testrunid");
+            case TABLE_TRAIN_RUNS ->
+                    createRunChildTable(dbTable, cf, "runid");
+            case TABLE_USER ->
+                    createUserTable(dbTable, cf);
+            default ->
+                    new FilteredTable<>(dbTable, this, cf);
+        };
         table.wrapAllColumns(true);
         resolveSchemaForeignKeys(table, cf);
         return table;
+    }
+
+    /**
+     * Filters a table that has no container column of its own by joining to testruns
+     * via fkColumn and applying the container filter to testruns.container.
+     */
+    private FilteredTable<TestResultsSchema> createRunChildTable(TableInfo dbTable, ContainerFilter cf, String fkColumn)
+    {
+        return new FilteredTable<>(dbTable, this, cf)
+        {
+            @Override
+            public FieldKey getContainerFieldKey()
+            {
+                return FieldKey.fromParts(fkColumn, "container");
+            }
+
+            @Override
+            protected void applyContainerFilter(ContainerFilter filter)
+            {
+                FieldKey containerFieldKey = FieldKey.fromParts("container");
+                clearConditions(containerFieldKey);
+                SQLFragment sql = new SQLFragment().appendIdentifier(fkColumn).append(" IN (SELECT tr.id FROM ");
+                sql.append(getTableInfoTestRuns(), "tr");
+                sql.append(" WHERE ");
+                sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("tr.container")));
+                sql.append(")");
+                addCondition(sql, containerFieldKey);
+            }
+        };
+    }
+
+    /**
+     * The user table has no container column and no FK to testruns. Filter it to users
+     * referenced by at least one testrun in an allowed container.
+     */
+    private FilteredTable<TestResultsSchema> createUserTable(TableInfo dbTable, ContainerFilter cf)
+    {
+        return new FilteredTable<>(dbTable, this, cf)
+        {
+            @Override
+            protected void applyContainerFilter(ContainerFilter filter)
+            {
+                FieldKey containerFieldKey = FieldKey.fromParts("container");
+                clearConditions(containerFieldKey);
+                SQLFragment sql = new SQLFragment("id IN (SELECT tr.userid FROM ");
+                sql.append(getTableInfoTestRuns(), "tr");
+                sql.append(" WHERE ");
+                sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("tr.container")));
+                sql.append(")");
+                addCondition(sql, containerFieldKey);
+            }
+        };
     }
 
     /**

--- a/testresults/src/org/labkey/testresults/view/user.jsp
+++ b/testresults/src/org/labkey/testresults/view/user.jsp
@@ -86,7 +86,7 @@
 <%--        <input type="file" name="xml_file"><input type="submit" value="submit">This form is meant to parse and store xml files into the database--%>
 <%--    </form>--%>
     <%
-        User[] users = TestResultsController.getUsers(null, null);
+        User[] users = TestResultsController.getUsers(getViewContext().getContainer(), null);
         Arrays.sort(users, Comparator.comparing(User::getUsername)); %>
     <div style="margin: 12px 0;">
         <select id="users">

--- a/testresults/src/org/labkey/testresults/view/user.jsp
+++ b/testresults/src/org/labkey/testresults/view/user.jsp
@@ -86,7 +86,7 @@
 <%--        <input type="file" name="xml_file"><input type="submit" value="submit">This form is meant to parse and store xml files into the database--%>
 <%--    </form>--%>
     <%
-        User[] users = TestResultsController.getUsers(getViewContext().getContainer(), null);
+        User[] users = TestResultsController.getUsers(getViewContext().getUser(), getViewContext().getContainer(), null);
         Arrays.sort(users, Comparator.comparing(User::getUsername)); %>
     <div style="margin: 12px 0;">
         <select id="users">

--- a/testresults/test/src/org/labkey/test/tests/testresults/TestResultsTest.java
+++ b/testresults/test/src/org/labkey/test/tests/testresults/TestResultsTest.java
@@ -722,6 +722,27 @@ public class TestResultsTest extends BaseWebDriverTest implements PostgresOnlyTe
                 .map(r -> (String) r.get("username")).toList();
         assertTrue("Parent should see TEST-PC-1", parentUsernames.contains(COMPUTER_NAME_1));
         assertTrue("Parent should see TEST-PC-2", parentUsernames.contains(COMPUTER_NAME_2));
+
+        // The SelectRows checks above hit the "user" query table (the FilteredTable from
+        // TestResultsSchema.createUserTable) via the query API. The User-page dropdown is a
+        // separate code path - built by TestResultsController.getUsers() - so verify it is
+        // folder-scoped too: the subfolder lists only TEST-PC-1, the parent lists both.
+        assertUserDropdownContains(subFolderPath, List.of(COMPUTER_NAME_1), List.of(COMPUTER_NAME_2));
+        assertUserDropdownContains("/" + PROJECT_NAME, List.of(COMPUTER_NAME_1, COMPUTER_NAME_2), List.of());
+    }
+
+    /**
+     * Navigates to the User page (ShowUserAction) in the given folder and asserts the computer
+     * dropdown - populated by TestResultsController.getUsers() - lists the expected computers.
+     * This exercises the server-rendered getUsers() path, separate from the query "user" table.
+     */
+    private void assertUserDropdownContains(String containerPath, List<String> present, List<String> absent)
+    {
+        beginAt(WebTestHelper.buildRelativeUrl("testresults", containerPath, "showUser"));
+        for (String name : present)
+            assertElementPresent(Locator.xpath("//select[@id='users']/option[@value='" + name + "']"));
+        for (String name : absent)
+            assertElementNotPresent(Locator.xpath("//select[@id='users']/option[@value='" + name + "']"));
     }
 
     /**

--- a/testresults/test/src/org/labkey/test/tests/testresults/TestResultsTest.java
+++ b/testresults/test/src/org/labkey/test/tests/testresults/TestResultsTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
@@ -44,6 +45,7 @@ import org.labkey.test.util.PostgresOnlyTest;
 import org.labkey.test.util.TextSearcher;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -51,6 +53,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category({External.class, MacCossLabModules.class})
@@ -115,12 +118,20 @@ public class TestResultsTest extends BaseWebDriverTest implements PostgresOnlyTe
     }
 
     /**
-     * Posts a sample XML file to PostAction.
+     * Posts a sample XML file to PostAction in the main project container.
      */
     private void postSampleXml(String sampleDataRelativePath)
     {
+        postSampleXml(sampleDataRelativePath, PROJECT_NAME);
+    }
+
+    /**
+     * Posts a sample XML file to PostAction in the given container.
+     */
+    private void postSampleXml(String sampleDataRelativePath, String containerPath)
+    {
         File xmlFile = TestFileUtils.getSampleData(sampleDataRelativePath);
-        String postUrl = WebTestHelper.buildURL("testresults", PROJECT_NAME, "post");
+        String postUrl = WebTestHelper.buildURL("testresults", containerPath, "post");
 
         try (CloseableHttpClient httpClient = WebTestHelper.getHttpClient())
         {
@@ -655,6 +666,90 @@ public class TestResultsTest extends BaseWebDriverTest implements PostgresOnlyTe
         assertTextNotPresent("TestDisposableOne");
     }
 
+    /**
+     * Verifies that child tables in the testresults schema are container-filtered
+     * via a join to testruns. Creates a subfolder, posts a single run into it,
+     * then checks that testpasses, testfails, trainruns, and user queries from
+     * each container only return rows for runs in that container.
+     *
+     * Not separately tested: hangs, memoryleaks, handleleaks. These go through the
+     * same {@code createRunChildTable} helper as testpasses/testfails, so verifying
+     * those covers them by construction.
+     */
+    @Test
+    public void testContainerFiltering() throws IOException, CommandException
+    {
+        final String subFolder = "ContainerFilterTest";
+        final String subFolderPath = "/" + PROJECT_NAME + "/" + subFolder;
+        _containerHelper.createSubfolder(PROJECT_NAME, subFolder);
+        _containerHelper.enableModule(subFolderPath, "TestResults");
+        // pc1-run-0116-failures.xml: 150 tests (testsrun=150), 2 failures (TestFailOne, TestFailTwo).
+        postSampleXml("testresults/pc1-run-0116-failures.xml", subFolderPath);
+
+        Connection conn = WebTestHelper.getRemoteApiConnection();
+
+        // The subfolder has exactly one run (the one we just posted). Fetch its ID.
+        SelectRowsCommand runsCmd = new SelectRowsCommand("testresults", "testruns");
+        runsCmd.setColumns(List.of("id", "userid/username"));
+        SelectRowsResponse subRuns = runsCmd.execute(conn, subFolderPath);
+        assertEquals("Subfolder should have exactly 1 run", 1, subRuns.getRows().size());
+        int subRunId = ((Number) subRuns.getRows().getFirst().get("id")).intValue();
+
+        // testpasses: 150 rows, all referencing subRunId. None visible from parent.
+        assertTableContainerFiltered(conn, "testpasses", "testrunid", subFolderPath, subRunId, 150);
+
+        // testfails: 2 failures in the posted XML.
+        assertTableContainerFiltered(conn, "testfails", "testrunid", subFolderPath, subRunId, 2);
+
+        // Add the subfolder's run to the training set, then verify trainruns filtering.
+        JSONObject trainResp = postApi("trainRun",
+                Map.of("runId", String.valueOf(subRunId), "train", "true"),
+                subFolderPath);
+        assertTrue("Adding run to training set failed: " + trainResp, trainResp.optBoolean("Success", false));
+
+        assertTableContainerFiltered(conn, "trainruns", "runid", subFolderPath, subRunId, 1);
+
+        // user: the subfolder's only run is for TEST-PC-1, so only that user should
+        // be visible there. The parent has both TEST-PC-1 and TEST-PC-2.
+        SelectRowsCommand userCmd = new SelectRowsCommand("testresults", "user");
+        userCmd.setColumns(List.of("username"));
+        SelectRowsResponse subUsers = userCmd.execute(conn, subFolderPath);
+        assertEquals("Subfolder should see only TEST-PC-1", 1, subUsers.getRows().size());
+        assertEquals(COMPUTER_NAME_1, subUsers.getRows().getFirst().get("username"));
+
+        SelectRowsResponse parentUsers = userCmd.execute(conn, PROJECT_NAME);
+        List<String> parentUsernames = parentUsers.getRows().stream()
+                .map(r -> (String) r.get("username")).toList();
+        assertTrue("Parent should see TEST-PC-1", parentUsernames.contains(COMPUTER_NAME_1));
+        assertTrue("Parent should see TEST-PC-2", parentUsernames.contains(COMPUTER_NAME_2));
+    }
+
+    /**
+     * Asserts that {@code tableName} is container-filtered: the subfolder query
+     * returns exactly {@code expectedSubfolderRows} rows, all referencing
+     * {@code subRunId}; the parent query returns no rows referencing
+     * {@code subRunId}.
+     */
+    private void assertTableContainerFiltered(Connection conn, String tableName, String fkColumn,
+                                              String subFolderPath, int subRunId, int expectedSubfolderRows)
+            throws IOException, CommandException
+    {
+        SelectRowsCommand cmd = new SelectRowsCommand("testresults", tableName);
+        cmd.setColumns(List.of(fkColumn));
+
+        SelectRowsResponse subfolderRows = cmd.execute(conn, subFolderPath);
+        assertEquals(tableName + " row count in subfolder",
+                expectedSubfolderRows, subfolderRows.getRows().size());
+        for (Map<String, Object> row : subfolderRows.getRows())
+            assertEquals("All " + tableName + " rows in subfolder must reference subRunId",
+                    subRunId, ((Number) row.get(fkColumn)).intValue());
+
+        SelectRowsResponse parentRows = cmd.execute(conn, PROJECT_NAME);
+        for (Map<String, Object> row : parentRows.getRows())
+            assertNotEquals("Parent " + tableName + " must not reference subfolder's run " + subRunId,
+                    subRunId, ((Number) row.get(fkColumn)).intValue());
+    }
+
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
@@ -860,7 +955,12 @@ public class TestResultsTest extends BaseWebDriverTest implements PostgresOnlyTe
      */
     private JSONObject postApi(String action, Map<String, String> params)
     {
-        StringBuilder url = new StringBuilder(WebTestHelper.buildURL("testresults", PROJECT_NAME, action));
+        return postApi(action, params, PROJECT_NAME);
+    }
+
+    private JSONObject postApi(String action, Map<String, String> params, String containerPath)
+    {
+        StringBuilder url = new StringBuilder(WebTestHelper.buildURL("testresults", containerPath, action));
         boolean first = true;
         for (Map.Entry<String, String> e : params.entrySet())
         {


### PR DESCRIPTION
#### Rationale
Several `testresults` tables have no folder column, so the query browser showed rows from every folder. 
Scope each table to the folder being viewed. Query-layer only, no schema change.

#### Related Pull Requests
- https://github.com/LabKey/MacCossLabModules/pull/622

#### Changes
- Child tables (`testpasses`, `testfails`, `handleleaks`, `memoryleaks`, `hangs`, `trainruns`) filter to the current folder by joining back to `testruns`.
- `user` table shows only computers with a run in the folder. Also fixes the User dropdown and Training Data tab.
- `getUsers()` reads the filtered `user` query table. 
- Run ingestion (`ParseAndStoreXML`) resolves a computer by name with a deliberately **unscoped** `findUserIdByName()`. The `user` row is global (no container column), `PostAction` is `@RequiresNoPermission`, and a computer's first post to a folder has no run there yet, so any container filter would miss it and create a duplicate. The method returns only an id (no row data).
- `testContainerFiltering` covers the child tables, the `user` query table, and the User-page dropdown.
