### PR TITLE
Address reported security issues in the LINCS module

### DIFF
--- a/lincs/src/org/labkey/lincs/DocImportListener.java
+++ b/lincs/src/org/labkey/lincs/DocImportListener.java
@@ -41,11 +41,11 @@ public class DocImportListener implements ExperimentListener, SkylineDocumentImp
             return;
         }
 
-        ITargetedMSRun tRun = TargetedMSService.get().getRunByFileName(run.getName(), run.getContainer());
+        ITargetedMSRun tRun = TargetedMSService.get().getRunByFileName(run.getName(), c);
         if(tRun != null)
         {
             // Delete saved entries in lincs.lincspspjob table for this runId
-            LincsManager.get().deleteLincsPspJobsForRun(tRun.getId());
+            LincsManager.get().deleteLincsPspJobsForRun(tRun.getId(), c);
         }
 
         // Get the file root for the container

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -733,8 +733,7 @@ public class LincsController extends SpringActionController
 
             Path gctDir = getGCTDir(getContainer()).normalize();
             Path downloadFile = gctDir.resolve(form.getFileName()).normalize();
-            // Defense in depth: ensure the resolved path is still inside the GCT directory before
-            // reading or deleting it, so a traversal sequence cannot escape the container's folder.
+            // Ensure the resolved path is still inside the GCT directory
             if(!downloadFile.startsWith(gctDir))
             {
                 errors.reject(ERROR_MSG, "Invalid fileName '" + form.getFileName() + "'.");
@@ -1031,8 +1030,8 @@ public class LincsController extends SpringActionController
         @Override
         public void validateCommand(ClueCredentialsForm form, Errors errors)
         {
-            // The API key is sent to this server as a request header. Require https so the key is
-            // never transmitted in clear text (CWE-319).
+            // The API key entered on this form will later be sent to this server URI as a request header,
+            // so reject a non-https URI at save time to keep the key out of clear text (CWE-319).
             String uri = form.getServerUri();
             if (StringUtils.isNotBlank(uri) && !uri.trim().toLowerCase(Locale.ROOT).startsWith("https://"))
             {
@@ -1138,7 +1137,7 @@ public class LincsController extends SpringActionController
             }
             config.save(getContainer());
 
-            // Record an audit event noting who changed the Cromwell configuration.
+            // Record an audit event noting the container and the user who changed the Cromwell configuration.
             AuditLogService.get().addEvent(getUser(),
                     new ClientApiAuditProvider.ClientApiAuditEvent(getContainer(), "LINCS Cromwell configuration updated."));
             return true;

--- a/lincs/src/org/labkey/lincs/LincsController.java
+++ b/lincs/src/org/labkey/lincs/LincsController.java
@@ -30,6 +30,8 @@ import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.SimpleErrorView;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.audit.AuditLogService;
+import org.labkey.api.audit.ClientApiAuditProvider;
 import org.labkey.api.data.ActionButton;
 import org.labkey.api.data.ButtonBar;
 import org.labkey.api.data.Container;
@@ -108,6 +110,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -720,8 +723,23 @@ public class LincsController extends SpringActionController
                 return new SimpleErrorView(errors, false);
             }
 
-            Path gctDir = getGCTDir(getContainer());
-            Path downloadFile = gctDir.resolve(form.getFileName());
+            // isAllowedFileName returns null when the name is acceptable, an error message otherwise.
+            String fileNameError = FileUtil.isAllowedFileName(form.getFileName(), false);
+            if(fileNameError != null)
+            {
+                errors.reject(ERROR_MSG, "Invalid fileName '" + form.getFileName() + "': " + fileNameError);
+                return new SimpleErrorView(errors, false);
+            }
+
+            Path gctDir = getGCTDir(getContainer()).normalize();
+            Path downloadFile = gctDir.resolve(form.getFileName()).normalize();
+            // Defense in depth: ensure the resolved path is still inside the GCT directory before
+            // reading or deleting it, so a traversal sequence cannot escape the container's folder.
+            if(!downloadFile.startsWith(gctDir))
+            {
+                errors.reject(ERROR_MSG, "Invalid fileName '" + form.getFileName() + "'.");
+                return new SimpleErrorView(errors, false);
+            }
             if(!Files.exists(downloadFile))
             {
                 errors.reject(ERROR_MSG, "File does not exist '" + form.getFileName() + "'.");
@@ -1011,15 +1029,28 @@ public class LincsController extends SpringActionController
     public static class ManageLincsClueCredentials extends FormViewAction<ClueCredentialsForm>
     {
         @Override
-        public void validateCommand(ClueCredentialsForm target, Errors errors) {}
+        public void validateCommand(ClueCredentialsForm form, Errors errors)
+        {
+            // The API key is sent to this server as a request header. Require https so the key is
+            // never transmitted in clear text (CWE-319).
+            String uri = form.getServerUri();
+            if (StringUtils.isNotBlank(uri) && !uri.trim().toLowerCase(Locale.ROOT).startsWith("https://"))
+            {
+                errors.reject(ERROR_MSG, "Clue/PSP Server URI must use https so the API key is not transmitted in clear text.");
+            }
+        }
 
         @Override
         public boolean handlePost(ClueCredentialsForm form, BindException errors)
         {
             WritablePropertyMap map = PropertyManager.getEncryptedStore().getWritableProperties(getContainer(), LINCS_CLUE_CREDENTIALS, true);
-            map.put(CLUE_SERVER_URI, form.getServerUri());
+            map.put(CLUE_SERVER_URI, StringUtils.trim(form.getServerUri()));
             map.put(CLUE_API_KEY, form.getApiKey());
             map.save();
+
+            // Record an audit event noting the container and the user who changed the credentials.
+            AuditLogService.get().addEvent(getUser(),
+                    new ClientApiAuditProvider.ClientApiAuditEvent(getContainer(), "LINCS Clue/PSP server credentials updated."));
             return true;
         }
 
@@ -1106,6 +1137,10 @@ public class LincsController extends SpringActionController
                 return false;
             }
             config.save(getContainer());
+
+            // Record an audit event noting who changed the Cromwell configuration.
+            AuditLogService.get().addEvent(getUser(),
+                    new ClientApiAuditProvider.ClientApiAuditEvent(getContainer(), "LINCS Cromwell configuration updated."));
             return true;
         }
 
@@ -1188,7 +1223,7 @@ public class LincsController extends SpringActionController
         {
             int runId = form.getRunId();
 
-            LincsPspJob pspJob = LincsManager.get().getLincsPspJobForRun(runId);
+            LincsPspJob pspJob = LincsManager.get().getLincsPspJobForRun(runId, getContainer());
             if(pspJob == null)
             {
                 errors.addError(new LabKeyError("Could not find a PSP job for runId: " + runId));
@@ -1333,7 +1368,7 @@ public class LincsController extends SpringActionController
         {
             int jobId = form.getJobId();
 
-            LincsPspJob pspJob = LincsManager.get().getLincsPspJob(jobId);
+            LincsPspJob pspJob = LincsManager.get().getLincsPspJob(jobId, getContainer());
             if(pspJob == null)
             {
                 errors.addError(new LabKeyError("Could not find a PSP job for id: " + jobId));
@@ -1411,7 +1446,7 @@ public class LincsController extends SpringActionController
             int jobId = form.getJobId();
             _runId = form.getRunId();
 
-            LincsPspJob pspJob = LincsManager.get().getLincsPspJob(jobId);
+            LincsPspJob pspJob = LincsManager.get().getLincsPspJob(jobId, getContainer());
             if(pspJob == null)
             {
                 errors.reject(ERROR_MSG, "Could not find a PSP job for id: " + jobId);
@@ -1537,7 +1572,7 @@ public class LincsController extends SpringActionController
 
             LincsManager lincsManager = LincsManager.get();
 
-            LincsPspJob oldPspJob = lincsManager.getLincsPspJobForRun(runId);
+            LincsPspJob oldPspJob = lincsManager.getLincsPspJobForRun(runId, container);
             LincsPspJob newPspJob = lincsManager.saveNewLincsPspJob(skylineRun, getUser());
 
             ViewBackgroundInfo info = new ViewBackgroundInfo(container, getUser(), null);

--- a/lincs/src/org/labkey/lincs/LincsDataTable.java
+++ b/lincs/src/org/labkey/lincs/LincsDataTable.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.analytics.AnalyticsService;
 import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.data.TableInfo;
@@ -154,7 +155,7 @@ public class LincsDataTable extends FilteredTable
                     out.write("NO_RUN_ID");
                     return;
                 }
-                LincsPspJob pspJob = LincsManager.get().getLincsPspJobForRun(runId);
+                LincsPspJob pspJob = LincsManager.get().getLincsPspJobForRun(runId, getContainer());
                 if(pspJob == null)
                 {
                     out.write("PSP job not found for runId: " + runId);
@@ -374,7 +375,7 @@ public class LincsDataTable extends FilteredTable
             String downloadFileName = getBaseName(fileName);
             String extension = LincsModule.getExt(getLevel());
             downloadFileName = downloadFileName + extension;
-            if(!fileAvailable(runId, downloadFileName))
+            if(!fileAvailable(runId, downloadFileName, ctx.getContainer()))
             {
                 out.write("NOT AVAILABLE");
                 return;
@@ -403,9 +404,9 @@ public class LincsDataTable extends FilteredTable
             ).appendTo(out);
         }
 
-        private boolean fileAvailable(Integer runId, String downloadFileName)
+        private boolean fileAvailable(Integer runId, String downloadFileName, Container container)
         {
-            LincsPspJob job = LincsManager.get().getLincsPspJobForRun(runId);
+            LincsPspJob job = LincsManager.get().getLincsPspJobForRun(runId, container);
             if(job != null)
             {
                 if(getLevel() == LincsModule.LincsLevel.Two && job.isLevel2Done())

--- a/lincs/src/org/labkey/lincs/LincsManager.java
+++ b/lincs/src/org/labkey/lincs/LincsManager.java
@@ -183,9 +183,11 @@ public class LincsManager
         return new TableSelector(getTableInfoLincsPspJob(), filter, null).getObject(LincsPspJob.class);
     }
 
-    public void deleteLincsPspJobsForRun(long runId)
+    public void deleteLincsPspJobsForRun(long runId, Container container)
     {
-        Table.delete(getTableInfoLincsPspJob(), new SimpleFilter(FieldKey.fromParts("runId"), runId));
+        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
+        filter.addCondition(FieldKey.fromParts("runId"), runId);
+        Table.delete(getTableInfoLincsPspJob(), filter);
     }
 
     public void deleteLincsPspJob(LincsPspJob job)

--- a/lincs/src/org/labkey/lincs/LincsManager.java
+++ b/lincs/src/org/labkey/lincs/LincsManager.java
@@ -164,19 +164,23 @@ public class LincsManager
                 job.getPipelineJobId(), job.getId());
     }
 
-    public LincsPspJob getLincsPspJobForRun(int runId)
+    public LincsPspJob getLincsPspJobForRun(int runId, Container container)
     {
         // Get the most recent PSP job details
         Sort sort = new Sort();
         sort.appendSortColumn(FieldKey.fromParts("Modified"), Sort.SortDirection.DESC, true);
-        TableSelector ts = new TableSelector(getTableInfoLincsPspJob(), new SimpleFilter(FieldKey.fromParts("RunId"), runId), sort);
+        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
+        filter.addCondition(FieldKey.fromParts("RunId"), runId);
+        TableSelector ts = new TableSelector(getTableInfoLincsPspJob(), filter, sort);
         ts.setMaxRows(1);
         return ts.getObject(LincsPspJob.class);
     }
 
-    public LincsPspJob getLincsPspJob(int id)
+    public LincsPspJob getLincsPspJob(int id, Container container)
     {
-        return new TableSelector(getTableInfoLincsPspJob(), new SimpleFilter(FieldKey.fromParts("Id"), id), null).getObject(LincsPspJob.class);
+        SimpleFilter filter = SimpleFilter.createContainerFilter(container);
+        filter.addCondition(FieldKey.fromParts("Id"), id);
+        return new TableSelector(getTableInfoLincsPspJob(), filter, null).getObject(LincsPspJob.class);
     }
 
     public void deleteLincsPspJobsForRun(long runId)

--- a/lincs/src/org/labkey/lincs/psp/LincsPspUtil.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspUtil.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 public class LincsPspUtil
 {
@@ -54,6 +55,13 @@ public class LincsPspUtil
         if(StringUtils.isBlank(pspApiKey))
         {
             throw new LincsPspException("Could not find PSP API Key in the saved properties.");
+        }
+        // The API key is sent to this URL as a request header. Refuse to use a non-https endpoint so the
+        // key is never transmitted in clear text (CWE-319). This also guards configurations that were saved
+        // with an http:// URL before save-time validation was added.
+        if(!pspUrl.trim().toLowerCase(Locale.ROOT).startsWith("https://"))
+        {
+            throw new LincsPspException("PSP endpoint URL must use https so the API key is not transmitted in clear text.");
         }
         return new PspEndpoint(pspUrl, pspApiKey);
     }

--- a/lincs/src/org/labkey/lincs/psp/LincsPspUtil.java
+++ b/lincs/src/org/labkey/lincs/psp/LincsPspUtil.java
@@ -56,9 +56,8 @@ public class LincsPspUtil
         {
             throw new LincsPspException("Could not find PSP API Key in the saved properties.");
         }
-        // The API key is sent to this URL as a request header. Refuse to use a non-https endpoint so the
-        // key is never transmitted in clear text (CWE-319). This also guards configurations that were saved
-        // with an http:// URL before save-time validation was added.
+        // The API key retrieved here is later sent to the endpoint URL as a request header by the callers.
+        // Refuse to return a non-https endpoint so the key is never transmitted in clear text (CWE-319).
         if(!pspUrl.trim().toLowerCase(Locale.ROOT).startsWith("https://"))
         {
             throw new LincsPspException("PSP endpoint URL must use https so the API key is not transmitted in clear text.");

--- a/lincs/src/org/labkey/lincs/view/manageClueCredentials.jsp
+++ b/lincs/src/org/labkey/lincs/view/manageClueCredentials.jsp
@@ -11,6 +11,7 @@
     LincsController.ClueCredentialsForm form = ((JspView<LincsController.ClueCredentialsForm>) HttpView.currentView()).getModelBean();
  %>
 
+<labkey:errors/>
 <labkey:form method="post">
     <table>
         <tr>


### PR DESCRIPTION
#### Rationale
A security review of the LINCS module identified six issues, addressed here:
* High - path traversal (arbitrary file read + delete) in DownloadCustomGCTReportAction
* Medium / Low - PSP job lookups not container-scoped (cross-folder data access)
* Low (CWE-319) - Clue/PSP API key transmittable over http
* Low - credential / config changes not audited


#### Changes
**Path traversal (High) - DownloadCustomGCTReportAction**
* Validate the requested `fileName` with `FileUtil.isAllowedFileName` and confirm the resolved path stays inside the container's GCT directory.

**Cross-container access (Medium / Low) - PSP job lookups**
* `LincsManager.getLincsPspJob` / `getLincsPspJobForRun` now require a `Container` and filter on it. 
   The PSP-job detail/status/update actions can no longer reach jobs in other  folders. 
   All callers updated (3 controller actions, SubmitPspJobAction, and 2 LincsDataTable display columns).

**Cleartext credential transmission (Low, CWE-319) - Clue/PSP server URI**
* Require `https` for the Clue/PSP server URI: rejected at save time in `ManageLincsClueCredentials.validateCommand`, 
   and as defense in depth in `LincsPspUtil.getPspEndpoint` before the API key is sent as a request header.
  The point-of-use check also blocks endpoints saved as `http://` before this fix.
* Added `<labkey:errors/>` to `manageClueCredentials.jsp` so the save-time rejection is actually shown.

**Missing audit trail (Low) - credential / config changes**
* `ManageLincsClueCredentials.handlePost` and `CromwellConfigAction.handlePost`  now write an audit event (container and acting user, no secret values) when the PSP/Clue credentials or Cromwell config change.


Co-Authored-By: Claude <noreply@anthropic.com>


