### PR TITLE
nextflow security fixes

### DIFF
--- a/nextflow/src/org/labkey/nextflow/NextFlowController.java
+++ b/nextflow/src/org/labkey/nextflow/NextFlowController.java
@@ -45,6 +45,7 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.io.File;
+import java.nio.file.InvalidPathException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -325,7 +326,17 @@ public class NextFlowController extends SpringActionController
                 return false;
             }
             File configDir = new File(config.getNextFlowConfigFilePath());
-            File configFile = FileUtil.appendPath(configDir, Path.parse(form.getConfigFile()));
+            File configFile;
+            try
+            {
+                // appendPath normalizes and enforces that the resolved path stays within configDir, rejecting traversal
+                configFile = FileUtil.appendPath(configDir, Path.parse(form.getConfigFile()));
+            }
+            catch (InvalidPathException e)
+            {
+                errors.reject(ERROR_MSG, "Invalid config file");
+                return false;
+            }
             if (!configFile.exists())
             {
                 errors.reject(ERROR_MSG, "Config file does not exist");

--- a/nextflow/src/org/labkey/nextflow/NextFlowController.java
+++ b/nextflow/src/org/labkey/nextflow/NextFlowController.java
@@ -223,6 +223,10 @@ public class NextFlowController extends SpringActionController
         @Override
         public boolean handlePost(EnabledForm form, BindException errors)
         {
+            if (!getUser().hasSiteAdminPermission())
+            {
+                throw new UnauthorizedException();
+            }
             NextFlowManager.get().saveEnabledState(getContainer(), form.getEnabled());
             return true;
         }
@@ -257,6 +261,10 @@ public class NextFlowController extends SpringActionController
             {
                 errors.reject(ERROR_MSG, "NextFlow is not enabled");
             }
+            else if (NextFlowManager.get().getConfiguration() == null)
+            {
+                errors.reject(ERROR_MSG, "NextFlow has not been configured");
+            }
         }
 
         @Override
@@ -278,7 +286,7 @@ public class NextFlowController extends SpringActionController
             }
 
             NextFlowConfiguration config = NextFlowManager.get().getConfiguration();
-            if (config.getNextFlowConfigFilePath() != null)
+            if (config != null && config.getNextFlowConfigFilePath() != null)
             {
                 File configDir = new File(config.getNextFlowConfigFilePath());
                 if (configDir.isDirectory())
@@ -311,6 +319,11 @@ public class NextFlowController extends SpringActionController
             }
 
             NextFlowConfiguration config = NextFlowManager.get().getConfiguration();
+            if (config == null || config.getNextFlowConfigFilePath() == null)
+            {
+                errors.reject(ERROR_MSG, "NextFlow has not been configured");
+                return false;
+            }
             File configDir = new File(config.getNextFlowConfigFilePath());
             File configFile = FileUtil.appendPath(configDir, Path.parse(form.getConfigFile()));
             if (!configFile.exists())

--- a/nextflow/src/org/labkey/nextflow/NextFlowController.java
+++ b/nextflow/src/org/labkey/nextflow/NextFlowController.java
@@ -325,6 +325,11 @@ public class NextFlowController extends SpringActionController
                 errors.reject(ERROR_MSG, "NextFlow has not been configured");
                 return false;
             }
+            if (StringUtils.isBlank(form.getConfigFile()))
+            {
+                errors.reject(ERROR_MSG, "No config file specified");
+                return false;
+            }
             File configDir = new File(config.getNextFlowConfigFilePath());
             File configFile;
             try


### PR DESCRIPTION
#### Rationale
Two security/robustness issues were found in NextFlowController:                                                                                                                                                                  
                                                                                                                                                                                                                                    
  1. Function-level authorization gap (BeginAction.handlePost). BeginAction is gated only by ReadPermission, and the site-admin check (hasSiteAdminPermission()) lived solely in getView() — the UI only renders the enable/disable 
  toggle for site admins. The POST handler that actually writes the per-folder enabled state had no privilege re-check, so any folder reader could POST directly to the action and toggle NextFlow integration for the folder.      
  Because isEnabled() walks up the container tree, child containers inherit that state, widening the impact. The editing capability is intended for site admins only, so the invariant needed to be re-established on the write     
  path.                                                                                                                                                                                                                             
  2. NullPointerException on the run path (NextFlowRunAction). NextFlowManager.getConfiguration() returns null when no NextFlow configuration has been saved. Both getView() and handlePost() immediately dereferenced the result   
  (config.getNextFlowConfigFilePath()), producing a 500 error for an editor working in a container where NextFlow is enabled but not yet configured. Users should get a clear message instead of a server error.                    

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* NextFlowController.BeginAction.handlePost                                                                                                                                                                                         
  - Added a hasSiteAdminPermission() check that throws UnauthorizedException before writing the enabled state, matching the gate already present in getView(). Enabling alone still does not grant run rights — NextFlowRunAction   
  continues to require InsertPermission. 
  - NextFlowRunAction.handlePost: wrapped the FileUtil.appendPath call (which already enforces directory containment / rejects .. traversal) in a try/catch so an invalid configFile yields a user-facing "Invalid config file"     
  error instead of an unhandled 500.                                                                                                                                                                                           
                                                                                                                                                                                                                                    
* NextFlowController.NextFlowRunAction                                                                                                                                                                                              
  - validateCommand: reject with "NextFlow has not been configured" when getConfiguration() is null (guards the POST path).                                                                                                         
  - getView: added a config != null guard, falling through to the existing "Couldn't find NextFlow config file(s)" message.                                                                                                         
  - handlePost: added a defensive null/empty-path check (it re-fetches the configuration independently), rejecting with a user-facing error instead of throwing.
