### PR TITLE
Address reported security issues in the panoramapublic module

### DIFF
--- a/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/PanoramaPublicController.java
@@ -32,6 +32,7 @@ import org.labkey.api.action.ConfirmAction;
 import org.labkey.api.action.FormHandlerAction;
 import org.labkey.api.action.FormViewAction;
 import org.labkey.api.action.LabKeyError;
+import org.labkey.api.action.MutatingApiAction;
 import org.labkey.api.action.ReadOnlyApiAction;
 import org.labkey.api.action.ReturnUrlForm;
 import org.labkey.api.action.SimpleErrorView;
@@ -11233,34 +11234,47 @@ public class PanoramaPublicController extends SpringActionController
 
     // ======================== Support actions for Selenium tests ========================
 
+    // These actions swap the process-wide NCBI publication search service to a mock so that Selenium tests
+    // run without calling the live NCBI API. They must never be reachable on a production server (non-dev-mode)
+    private static void requireDevModeForMockNcbiService()
+    {
+        if (!AppProps.getInstance().isDevMode())
+        {
+            throw new NotFoundException("Mock NCBI publication search service actions are only available on a server running in dev mode.");
+        }
+    }
+
     @RequiresSiteAdmin
-    public static class SetupMockNcbiServiceAction extends ReadOnlyApiAction<Object>
+    public static class SetupMockNcbiServiceAction extends MutatingApiAction<Object>
     {
         @Override
         public Object execute(Object form, BindException errors)
         {
+            requireDevModeForMockNcbiService();
             NcbiPublicationSearchServiceImpl.setInstance(new MockNcbiPublicationSearchService());
             return new ApiSimpleResponse("mock", true);
         }
     }
 
     @RequiresSiteAdmin
-    public static class RestoreNcbiServiceAction extends ReadOnlyApiAction<Object>
+    public static class RestoreNcbiServiceAction extends MutatingApiAction<Object>
     {
         @Override
         public Object execute(Object form, BindException errors)
         {
+            requireDevModeForMockNcbiService();
             NcbiPublicationSearchServiceImpl.setInstance(new NcbiPublicationSearchServiceImpl());
             return new ApiSimpleResponse("restored", true);
         }
     }
 
     @RequiresSiteAdmin
-    public static class RegisterMockPublicationAction extends ReadOnlyApiAction<RegisterMockPublicationForm>
+    public static class RegisterMockPublicationAction extends MutatingApiAction<RegisterMockPublicationForm>
     {
         @Override
         public Object execute(RegisterMockPublicationForm form, BindException errors)
         {
+            requireDevModeForMockNcbiService();
             NcbiPublicationSearchService service = NcbiPublicationSearchServiceImpl.getInstance();
             if (!(service instanceof MockNcbiPublicationSearchService mock))
             {

--- a/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
+++ b/panoramapublic/src/org/labkey/panoramapublic/proteomexchange/ExperimentModificationGetter.java
@@ -345,8 +345,6 @@ public class ExperimentModificationGetter
 
     public static class TestCase extends Assert
     {
-        private static final boolean debug = false;
-
         @Test
         public void testBuildIsotopeModFormula()
         {
@@ -701,8 +699,6 @@ public class ExperimentModificationGetter
             {
                 PxModification pxMod = getStructuralUnimodMod(mod, uMods);
 
-                printStructuralMod(mod, pxMod);
-
                 List<UnimodModification> matches = unimodMatches.get(pxMod.getSkylineName());
                 if (matches.isEmpty())
                 {
@@ -723,32 +719,6 @@ public class ExperimentModificationGetter
                     assertFalse("Unexpected Unimod Id for modification " + pxMod.getSkylineName(), pxMod.hasUnimodId());
                     assertEquals("Expected " + matches.size() + " possible matches for modification " + pxMod.getSkylineName(), matches.size(), possibleMods.size());
                     assertEquals(matches.stream().map(m -> m.getId()).collect(Collectors.toSet()), possibleMods.stream().map(m -> m.getId()).collect(Collectors.toSet()));
-                }
-            }
-        }
-
-        private void printStructuralMod(Modification mod, PxModification pxMod)
-        {
-            if (!debug)
-            {
-                return;
-            }
-
-            if (pxMod.hasUnimodId())
-            {
-                String term = mod.getTerminus() == null ? "" : (mod.getTerminus().equals("N") ? "N-term" : "C-term");
-                String modInfo = pxMod.getSkylineName() + ", " + Formula.normalizeFormula(mod.getFormula()) + ", " + mod.getAminoAcid() + ", TERM: " + term;
-                System.out.print("Skyline: " + modInfo);
-                System.out.println(" --- " + pxMod.getUnimodId() + ", " + pxMod.getName());
-            }
-            if (pxMod.hasPossibleUnimods())
-            {
-                String term = mod.getTerminus() == null ? "" : (mod.getTerminus().equals("N") ? "N-term" : "C-term");
-                String modInfo = pxMod.getSkylineName() + ", " + Formula.normalizeFormula(mod.getFormula()) + ", " + mod.getAminoAcid() + ", TERM: " + term;
-                System.out.println("Skyline: " + modInfo);
-                for (UnimodModification umod: pxMod.getPossibleUnimodMatches())
-                {
-                    System.out.println(" --- List.of(new UnimodModification(" + umod.getId() + ", \"" + umod.getName() + "\", null))");
                 }
             }
         }
@@ -899,8 +869,6 @@ public class ExperimentModificationGetter
                 }
                 PxModification pxMod = getIsotopicUnimodMod(mod, uMods);
 
-                printIsotopicMod(mod, pxMod);
-
                 List<UnimodModification> expectedMatches = matches.get(pxMod.getSkylineName());
 
                 if (expectedMatches.isEmpty())
@@ -922,31 +890,6 @@ public class ExperimentModificationGetter
                     assertFalse("Unexpected Unimod Id for isotopic modification " + pxMod.getSkylineName(), pxMod.hasUnimodId());
                     assertEquals("Expected " + expectedMatches.size() + " possible matches for isotopic modification " + pxMod.getSkylineName(), expectedMatches.size(), possibleMods.size());
                     assertEquals(expectedMatches.stream().map(m -> m.getId()).collect(Collectors.toSet()), possibleMods.stream().map(m -> m.getId()).collect(Collectors.toSet()));
-                }
-            }
-        }
-
-        private void printIsotopicMod(IsotopeModification mod, PxModification pxMod)
-        {
-            if (!debug)
-            {
-                return;
-            }
-            if (pxMod.hasUnimodId())
-            {
-                String term = mod.getTerminus() == null ? "" : (mod.getTerminus().equals("N") ? "N-term" : "C-term");
-                String modInfo = pxMod.getSkylineName() + ", " + Formula.normalizeFormula(mod.getFormula()) + ", " + mod.getAminoAcid() + ", TERM: " + term;
-                System.out.print("Skyline: " + modInfo);
-                System.out.println(" --- " + pxMod.getUnimodId() + ", " + pxMod.getName());
-            }
-            if (pxMod.hasPossibleUnimods())
-            {
-                String term = mod.getTerminus() == null ? "" : (mod.getTerminus().equals("N") ? "N-term" : "C-term");
-                String modInfo = pxMod.getSkylineName() + ", " + Formula.normalizeFormula(mod.getFormula()) + ", " + mod.getAminoAcid() + ", TERM: " + term;
-                System.out.println("Skyline: " + modInfo);
-                for (UnimodModification umod: pxMod.getPossibleUnimodMatches())
-                {
-                    System.out.println(" --- List.of(new UnimodModification(" + umod.getId() + ", \"" + umod.getName() + "\", null))");
                 }
             }
         }

--- a/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PublicationSearchTest.java
+++ b/panoramapublic/test/src/org/labkey/test/tests/panoramapublic/PublicationSearchTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
-import org.labkey.remoteapi.SimpleGetCommand;
+import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
@@ -341,7 +341,7 @@ public class PublicationSearchTest extends PanoramaPublicBaseTest
         try
         {
             Connection connection = createDefaultConnection();
-            SimpleGetCommand command = new SimpleGetCommand("panoramapublic", "setupMockNcbiService");
+            SimplePostCommand command = new SimplePostCommand("panoramapublic", "setupMockNcbiService");
             command.execute(connection, "/");
             _useMockNcbi = true;
             log("Using mock NCBI service");
@@ -417,7 +417,7 @@ public class PublicationSearchTest extends PanoramaPublicBaseTest
         try
         {
             Connection connection = createDefaultConnection();
-            SimpleGetCommand command = new SimpleGetCommand("panoramapublic", "registerMockPublication");
+            SimplePostCommand command = new SimplePostCommand("panoramapublic", "registerMockPublication");
             Map<String, Object> params = new HashMap<>();
             params.put("database", database);
             params.put("id", id);
@@ -447,7 +447,7 @@ public class PublicationSearchTest extends PanoramaPublicBaseTest
         try
         {
             Connection connection = createDefaultConnection();
-            SimpleGetCommand command = new SimpleGetCommand("panoramapublic", "restoreNcbiService");
+            SimplePostCommand command = new SimplePostCommand("panoramapublic", "restoreNcbiService");
             command.execute(connection, "/");
             log("Restored real NCBI service");
         }


### PR DESCRIPTION
#### Rationale
A security review of the panoramapublic module identified three issues. Two are addressed here. The third is noted below as out of scope by decision.

#### Changes
**Test actions globally swap the NcbiPublicationSearchService singleton with no audit event (Informational)**
* The three Selenium-test support actions (`SetupMockNcbiServiceAction`, `RestoreNcbiServiceAction`, `RegisterMockPublicationAction`) swap a process-wide singleton. They are @RequiresSiteAdmin but otherwise reachable in production, and extended ReadOnlyApiAction, which does no CSRF check and is reachable by a plain GET. 
* Added `requireDevModeForMockNcbiService()`: the actions now return 404 on a non-dev-mode server. Dev machines and TeamCity run in dev mode, so tests are unaffected.
* Changed the three actions from `ReadOnlyApiAction` to `MutatingApiAction`, since they mutate global state, which also requires a POST with a CSRF token.
* The report suggested adding an audit event or compiling these out of production builds. On review we found that gating them to dev mode is a better fix, since it removes the production attack surface entirely rather than just recording the swap.

**Uses System.out instead of Log4J2 (Informational)**
* `ExperimentModificationGetter`: removed System.out helpers printStructuralMod and printIsotopicMod and their call sites.

**Tests**
* `PublicationSearchTest`: invoke the three mock-NCBI actions with `SimplePostCommand `instead of `SimpleGetCommand`. 


#### _**Not in scope (by decision)**_
* The spectral-library source password stored unencrypted in panoramapublic.speclibinfo (the third finding) is deferred. The value is masked on display to non-site-admins, and the at-rest risk is acceptable. We intend to remove this column in future work. 
