### PR TITLE
Mark SignUpGroupChangeSecurityTest as postgres-only

### DIFF
--- a/signup/test/src/org/labkey/test/tests/signup/SignUpGroupChangeSecurityTest.java
+++ b/signup/test/src/org/labkey/test/tests/signup/SignUpGroupChangeSecurityTest.java
@@ -44,6 +44,7 @@ import org.labkey.test.util.APITestHelper;
 import org.labkey.test.util.ApiPermissionsHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PermissionsHelper.PrincipalType;
+import org.labkey.test.util.PostgresOnlyTest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -88,7 +89,7 @@ import static org.labkey.test.util.PermissionsHelper.FOLDER_ADMIN_ROLE;
  */
 @Category({External.class, MacCossLabModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 2)
-public class SignUpGroupChangeSecurityTest extends BaseWebDriverTest
+public class SignUpGroupChangeSecurityTest extends BaseWebDriverTest implements PostgresOnlyTest
 {
     private static final String PROJECT_1 = "SignUpSecurityTest P1";
     private static final String PROJECT_2 = "SignUpSecurityTest P2";


### PR DESCRIPTION
## Rationale
Need to prevent this new test from running on SQL Server on TeamCity.

## Related Pull Requests
- #667 

## Changes
- Mark SignUpGroupChangeSecurityTest as postgres-only